### PR TITLE
Enforce network access-control on remote document fetches (OpenAPI $ref, gateway XSD/DTD, service-catalog)

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.api/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/pom.xml
@@ -59,6 +59,10 @@
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents.wso2</groupId>
+            <artifactId>httpclient</artifactId>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/model/OASParserOptions.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/model/OASParserOptions.java
@@ -28,8 +28,42 @@ public class OASParserOptions {
 
     private boolean explicitStyleAndExplode = true;
     private Integer yamlCodePointLimit = null;
+    private String refValidationTenantDomain = null;
+    private transient RefValidator refValidator = null;
+    private transient HttpClientProvider httpClientProvider = null;
+    private long refFetchMaxBytes = 0L;
+
+    /**
+     * Layer-1 SSRF hook. Set by the impl layer to {@code APIUtil::validateRemoteURL} so the parser layer can run
+     * the platform/tenant network-security policy on each direct external $ref without a compile-time impl dependency.
+     */
+    public interface RefValidator {
+        void validate(String url, String tenantDomain) throws org.wso2.carbon.apimgt.api.APIManagementException;
+    }
+
+    /**
+     * Supplies an HTTP client for crawling remote $refs, decoupling spec.parser from impl. The impl layer provides
+     * {@code org.apache.http.client.HttpClient} instances (built from the platform truststore/TLS/proxy config); this
+     * interface keeps the api module from forcing an Apache HttpComponents compile-time requirement onto callers that
+     * never crawl. The crawl uses it to fetch allowed remote $refs and discover nested refs.
+     */
+    public interface HttpClientProvider {
+        org.apache.http.client.HttpClient getClient(String protocol, int port)
+                throws org.wso2.carbon.apimgt.api.APIManagementException;
+    }
 
     public OASParserOptions() {
+    }
+
+    public OASParserOptions(OASParserOptions other) {
+        if (other != null) {
+            this.explicitStyleAndExplode = other.explicitStyleAndExplode;
+            this.yamlCodePointLimit = other.yamlCodePointLimit;
+            this.refValidationTenantDomain = other.refValidationTenantDomain;
+            this.refValidator = other.refValidator;
+            this.httpClientProvider = other.httpClientProvider;
+            this.refFetchMaxBytes = other.refFetchMaxBytes;
+        }
     }
 
     public boolean isExplicitStyleAndExplode() {
@@ -82,6 +116,46 @@ public class OASParserOptions {
         // Consider 4 bytes per character
         double limit = fileSizeInMB * 1024 * 1024 * 4;
         this.yamlCodePointLimit = limit > Integer.MAX_VALUE ? Integer.MAX_VALUE : (int) limit;
+    }
+
+    public String getRefValidationTenantDomain() { return refValidationTenantDomain; }
+    public void setRefValidationTenantDomain(String v) { this.refValidationTenantDomain = v; }
+    public RefValidator getRefValidator() { return refValidator; }
+    public void setRefValidator(RefValidator v) { this.refValidator = v; }
+    public HttpClientProvider getHttpClientProvider() { return httpClientProvider; }
+    public void setHttpClientProvider(HttpClientProvider v) { this.httpClientProvider = v; }
+
+    public long getRefFetchMaxBytes() {
+        return refFetchMaxBytes;
+    }
+
+    /**
+     * Set the per-document size cap for the remote $ref crawl from the configured OAS import file-size limit (the same
+     * limit the top-level by-URL fetch uses). Parsing mirrors {@link #setYamlCodePointLimit(String)}: a
+     * null/blank/non-numeric/non-positive value leaves the cap unset (0), in which case the crawl applies its own
+     * fallback. The value is interpreted in megabytes.
+     *
+     * @param maxFileSizeMB maximum fetched-document size in megabytes as a String (e.g. "10")
+     */
+    public void setRefFetchMaxFileSize(String maxFileSizeMB) {
+        if (maxFileSizeMB == null || (maxFileSizeMB = maxFileSizeMB.trim()).isEmpty()) {
+            this.refFetchMaxBytes = 0L;
+            return;
+        }
+        double fileSizeInMB;
+        try {
+            fileSizeInMB = Double.parseDouble(maxFileSizeMB);
+        } catch (NumberFormatException e) {
+            log.error("Invalid remote $ref fetch size limit value: " + maxFileSizeMB + ". Using crawl default.");
+            this.refFetchMaxBytes = 0L;
+            return;
+        }
+        if (fileSizeInMB <= 0) {
+            this.refFetchMaxBytes = 0L;
+            return;
+        }
+        double bytes = fileSizeInMB * 1024 * 1024;
+        this.refFetchMaxBytes = bytes > Long.MAX_VALUE ? Long.MAX_VALUE : (long) bytes;
     }
 
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/test/java/org/wso2/carbon/apimgt/api/model/OASParserOptionsTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/test/java/org/wso2/carbon/apimgt/api/model/OASParserOptionsTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.carbon.apimgt.api.model;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.wso2.carbon.apimgt.api.APIManagementException;
+import org.wso2.carbon.apimgt.api.ExceptionCodes;
+import java.util.concurrent.atomic.AtomicReference;
+
+public class OASParserOptionsTest {
+
+    @Test
+    public void testDefaults() {
+        OASParserOptions o = new OASParserOptions();
+        Assert.assertTrue(o.isExplicitStyleAndExplode());
+        Assert.assertNull(o.getYamlCodePointLimit());
+        Assert.assertNull(o.getRefValidationTenantDomain());
+        Assert.assertNull(o.getRefValidator());
+    }
+
+    @Test
+    public void testCopyConstructorCopiesAllFields() {
+        OASParserOptions base = new OASParserOptions();
+        base.setExplicitStyleAndExplode("false");
+        base.setYamlCodePointLimit("5");
+        base.setRefValidationTenantDomain("carbon.super");
+        base.setRefValidator((url, t) -> { });
+
+        OASParserOptions copy = new OASParserOptions(base);
+        Assert.assertFalse(copy.isExplicitStyleAndExplode());
+        Assert.assertEquals(base.getYamlCodePointLimit(), copy.getYamlCodePointLimit());
+        Assert.assertEquals("carbon.super", copy.getRefValidationTenantDomain());
+        Assert.assertNotNull(copy.getRefValidator());
+        Assert.assertSame(base.getRefValidator(), copy.getRefValidator());
+    }
+
+    @Test
+    public void testCopyConstructorNullSafe() {
+        OASParserOptions copy = new OASParserOptions(null);
+        Assert.assertTrue(copy.isExplicitStyleAndExplode());
+        Assert.assertNull(copy.getYamlCodePointLimit());
+        Assert.assertNull(copy.getRefValidationTenantDomain());
+        Assert.assertNull(copy.getRefValidator());
+    }
+
+    @Test
+    public void httpClientProviderIsCarriedAndCopied() {
+        OASParserOptions opts = new OASParserOptions();
+        OASParserOptions.HttpClientProvider provider = (protocol, port) -> null;
+        opts.setHttpClientProvider(provider);
+        Assert.assertSame(provider, opts.getHttpClientProvider());
+
+        OASParserOptions copy = new OASParserOptions(opts);
+        Assert.assertSame(provider, copy.getHttpClientProvider());
+    }
+
+    @Test
+    public void testRefValidatorPropagatesCheckedException() {
+        OASParserOptions o = new OASParserOptions();
+        o.setRefValidator((url, t) -> {
+            throw new APIManagementException("blocked " + url, ExceptionCodes.UNTRUSTED_URL);
+        });
+        AtomicReference<APIManagementException> caught = new AtomicReference<>();
+        try {
+            o.getRefValidator().validate("http://127.0.0.1/x", "carbon.super");
+        } catch (APIManagementException e) {
+            caught.set(e);
+        }
+        Assert.assertNotNull(caught.get());
+        Assert.assertEquals(ExceptionCodes.UNTRUSTED_URL.getErrorCode(), caught.get().getErrorHandler().getErrorCode());
+    }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.common.gateway/src/main/java/org/wso2/carbon/apimgt/common/gateway/util/CommonAPIUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.common.gateway/src/main/java/org/wso2/carbon/apimgt/common/gateway/util/CommonAPIUtil.java
@@ -86,6 +86,22 @@ public class CommonAPIUtil {
      */
     public static HttpClient getHttpClient(String protocol, HttpClientConfigurationDTO clientConfiguration,
                                           SSLContext sslContext) {
+        return getHttpClient(protocol, clientConfiguration, sslContext, false);
+    }
+
+    /**
+     * Return a http client instance, optionally with HTTP redirect handling disabled.
+     *
+     * @param protocol - service endpoint protocol http/https
+     * @param clientConfiguration HTTP client configuration for connection pooling, proxy, timeouts
+     * @param sslContext SSL context to be used for HTTPS connections
+     * @param disableRedirects when {@code true}, the client does not follow 3xx redirects (the caller must handle
+     *                         the {@code Location} header itself); used by the SSRF $ref crawl so each redirect hop
+     *                         is re-validated before being followed
+     * @return {@link HttpClient} with all proxy, TLS, ConnectionPooling related configurations
+     */
+    public static HttpClient getHttpClient(String protocol, HttpClientConfigurationDTO clientConfiguration,
+                                          SSLContext sslContext, boolean disableRedirects) {
 
         if (log.isDebugEnabled()) {
             log.debug("Creating HTTP client with protocol: " + protocol);
@@ -126,6 +142,10 @@ public class CommonAPIUtil {
 
         HttpClientBuilder clientBuilder = HttpClients.custom().setConnectionManager(pool)
                 .setDefaultRequestConfig(params);
+
+        if (disableRedirects) {
+            clientBuilder.disableRedirectHandling();
+        }
 
         if (proxyEnabled) {
             HttpHost host = new HttpHost(proxyHost, proxyPort, protocol);

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/mediators/AccessControlledXmlResolver.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/mediators/AccessControlledXmlResolver.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.apimgt.gateway.mediators;
+
+import org.w3c.dom.ls.LSInput;
+import org.w3c.dom.ls.LSResourceResolver;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Reader;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Locale;
+
+/**
+ * An {@link LSResourceResolver} that enforces the network access-control policy on
+ * every external reference resolved while an XSD is compiled — nested
+ * xsd:import/include/redefine and external DTDs. Only http/https are permitted; each
+ * reference is checked via the injected {@link RemoteUrlValidator}. On any violation it
+ * throws {@link XsdRefBlockedException} to abort compilation (fail closed). On success it
+ * fetches the reference itself through {@link RedirectSafeXsdFetcher} (every redirect
+ * re-validated) and returns a {@link BytesLSInput} over the already-retrieved bytes, so
+ * Xerces never opens its own (redirect-following) connection for the reference.
+ */
+public class AccessControlledXmlResolver implements LSResourceResolver {
+
+    private final RemoteUrlValidator validator;
+
+    public AccessControlledXmlResolver(RemoteUrlValidator validator) {
+        this.validator = validator;
+    }
+
+    @Override
+    public LSInput resolveResource(String type, String namespaceURI, String publicId,
+                                   String systemId, String baseURI) {
+        String absoluteUrl = toAbsoluteUrl(systemId, baseURI);
+        if (absoluteUrl == null) {
+            throw new XsdRefBlockedException(
+                    "Blocked XSD reference with an unresolvable system id: " + systemId);
+        }
+        RedirectSafeXsdFetcher.Result result;
+        try {
+            result = RedirectSafeXsdFetcher.fetch(absoluteUrl, validator);
+        } catch (IOException e) {
+            throw new XsdRefFetchException(
+                    "Error fetching XSD reference " + absoluteUrl + ": " + e.getMessage(), e);
+        }
+        // systemId = the final post-redirect URL so further relative refs resolve correctly
+        return new BytesLSInput(result.body, result.finalUrl, publicId, baseURI);
+    }
+
+    /**
+     * Resolves a possibly-relative systemId against its baseURI into an absolute URL
+     * string, or returns {@code null} if it cannot be resolved to an absolute URL.
+     */
+    static String toAbsoluteUrl(String systemId, String baseURI) {
+        if (systemId == null) {
+            return null;
+        }
+        try {
+            URI ref = new URI(systemId.trim());
+            if (ref.isAbsolute()) {
+                return ref.toString();
+            }
+            if (baseURI != null) {
+                URI resolved = new URI(baseURI.trim()).resolve(ref);
+                return resolved.isAbsolute() ? resolved.toString() : null;
+            }
+            return null;
+        } catch (URISyntaxException e) {
+            return null;
+        }
+    }
+
+    /**
+     * @return {@code true} only if the URL parses and has an http or https scheme.
+     */
+    static boolean isHttpOrHttps(String url) {
+        try {
+            String scheme = new URI(url).getScheme();
+            if (scheme == null) {
+                return false;
+            }
+            scheme = scheme.toLowerCase(Locale.ROOT);
+            return "http".equals(scheme) || "https".equals(scheme);
+        } catch (URISyntaxException e) {
+            return false;
+        }
+    }
+
+    /**
+     * Minimal {@link LSInput} that hands the parser the already-retrieved bytes of a nested reference,
+     * so Xerces never opens its own (redirect-following) connection for it.
+     */
+    static final class BytesLSInput implements LSInput {
+        private final byte[] bytes;
+        private String systemId;
+        private String publicId;
+        private String baseURI;
+
+        BytesLSInput(byte[] bytes, String systemId, String publicId, String baseURI) {
+            this.bytes = bytes;
+            this.systemId = systemId;
+            this.publicId = publicId;
+            this.baseURI = baseURI;
+        }
+
+        @Override
+        public InputStream getByteStream() {
+            return new ByteArrayInputStream(bytes);
+        }
+
+        @Override
+        public void setByteStream(InputStream byteStream) {
+        }
+
+        @Override
+        public Reader getCharacterStream() {
+            return null;
+        }
+
+        @Override
+        public void setCharacterStream(Reader characterStream) {
+        }
+
+        @Override
+        public String getStringData() {
+            return null;
+        }
+
+        @Override
+        public void setStringData(String stringData) {
+        }
+
+        @Override
+        public String getSystemId() {
+            return systemId;
+        }
+
+        @Override
+        public void setSystemId(String systemId) {
+            this.systemId = systemId;
+        }
+
+        @Override
+        public String getPublicId() {
+            return publicId;
+        }
+
+        @Override
+        public void setPublicId(String publicId) {
+            this.publicId = publicId;
+        }
+
+        @Override
+        public String getBaseURI() {
+            return baseURI;
+        }
+
+        @Override
+        public void setBaseURI(String baseURI) {
+            this.baseURI = baseURI;
+        }
+
+        @Override
+        public String getEncoding() {
+            return null;
+        }
+
+        @Override
+        public void setEncoding(String encoding) {
+        }
+
+        @Override
+        public boolean getCertifiedText() {
+            return false;
+        }
+
+        @Override
+        public void setCertifiedText(boolean certifiedText) {
+        }
+    }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/mediators/RedirectSafeXsdFetcher.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/mediators/RedirectSafeXsdFetcher.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.apimgt.gateway.mediators;
+
+import org.wso2.carbon.apimgt.api.APIManagementException;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+
+/**
+ * Fetches an XSD document (the top-level {@code xsdURL}, a nested xsd:import/include/redefine, or an
+ * external DTD) with HTTP redirect following <b>disabled</b>, re-validating <b>every</b> redirect
+ * {@code Location} through the network access-control policy before following it.
+ *
+ * <p>This closes a redirect-to-private SSRF bypass: if the document is fetched by the JDK Xerces loader
+ * (via {@code newSchema(new URL(..))} or by returning {@code null} from an
+ * {@link org.w3c.dom.ls.LSResourceResolver}), {@code HttpURLConnection} follows {@code 30x} redirects by
+ * default, so an allow-listed host that redirects to {@code 127.0.0.1}/{@code 169.254.169.254} would be
+ * fetched without re-validation. Routing every fetch through this class makes the validated URL and the
+ * fetched URL the same at every hop. Mirrors the redirect-disabled, re-validating client the OpenAPI
+ * {@code $ref} crawl uses ({@code APIUtil.getCrawlHttpClient}), kept self-contained in the gateway module.
+ */
+final class RedirectSafeXsdFetcher {
+
+    /** Maximum number of redirects to follow; each one is re-validated. */
+    static final int MAX_REDIRECTS = 5;
+    /** Defensive cap on the fetched document size (XSDs/DTDs are small). */
+    static final int MAX_BYTES = 10 * 1024 * 1024;
+    private static final int CONNECT_TIMEOUT_MS = 10000;
+    private static final int READ_TIMEOUT_MS = 10000;
+
+    private RedirectSafeXsdFetcher() {
+    }
+
+    /** The retrieved document bytes and the final URL they were actually retrieved from. */
+    static final class Result {
+        final byte[] body;
+        final String finalUrl;
+
+        Result(byte[] body, String finalUrl) {
+            this.body = body;
+            this.finalUrl = finalUrl;
+        }
+    }
+
+    /**
+     * Validates and fetches {@code url}, re-validating every redirect {@code Location} before following
+     * it. Only http/https are permitted.
+     *
+     * @throws XsdRefBlockedException (unchecked) if {@code url} or any redirect target is rejected by the
+     *                                policy or uses a non-http(s) scheme — the caller must fail closed.
+     * @throws IOException            on a network/protocol error (no Location, bad status, too many hops,
+     *                                oversized body).
+     */
+    static Result fetch(String url, RemoteUrlValidator policy) throws IOException {
+        String current = url;
+        for (int hop = 0; hop <= MAX_REDIRECTS; hop++) {
+            assertAllowed(current, policy);                 // re-validate before every hop
+            HttpURLConnection conn = (HttpURLConnection) new URL(current).openConnection();
+            conn.setInstanceFollowRedirects(false);         // never auto-follow a redirect
+            conn.setConnectTimeout(CONNECT_TIMEOUT_MS);
+            conn.setReadTimeout(READ_TIMEOUT_MS);
+            conn.setRequestMethod("GET");
+            try {
+                int code = conn.getResponseCode();
+                if (code >= 300 && code < 400) {
+                    String location = conn.getHeaderField("Location");
+                    if (location == null) {
+                        throw new IOException("Redirect (" + code + ") with no Location header from " + current);
+                    }
+                    current = resolveLocation(current, location);
+                    continue;
+                }
+                if (code != HttpURLConnection.HTTP_OK) {
+                    throw new IOException("Unexpected HTTP status " + code + " fetching " + current);
+                }
+                try (InputStream in = conn.getInputStream()) {
+                    return new Result(readBounded(in), current);
+                }
+            } finally {
+                conn.disconnect();
+            }
+        }
+        throw new IOException("Too many redirects (> " + MAX_REDIRECTS + ") fetching " + url);
+    }
+
+    /** Scheme + policy check; throws {@link XsdRefBlockedException} (unchecked) on any violation. */
+    private static void assertAllowed(String url, RemoteUrlValidator policy) {
+        if (!AccessControlledXmlResolver.isHttpOrHttps(url)) {
+            throw new XsdRefBlockedException("Blocked XSD reference with a non-HTTP(S) scheme: " + url);
+        }
+        try {
+            policy.validate(url);
+        } catch (APIManagementException e) {
+            throw new XsdRefBlockedException(
+                    "Blocked XSD reference not permitted by the network access-control policy: " + url, e);
+        }
+    }
+
+    /** Resolves a possibly-relative redirect {@code Location} against the current absolute URL. */
+    private static String resolveLocation(String currentUrl, String location) throws IOException {
+        try {
+            return new URI(currentUrl).resolve(location.trim()).toString();
+        } catch (URISyntaxException | RuntimeException e) {
+            throw new IOException("Malformed redirect Location '" + location + "' from " + currentUrl);
+        }
+    }
+
+    private static byte[] readBounded(InputStream in) throws IOException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        byte[] buf = new byte[8192];
+        int total = 0;
+        int n;
+        while ((n = in.read(buf)) != -1) {
+            total += n;
+            if (total > MAX_BYTES) {
+                throw new IOException("XSD document exceeds the " + MAX_BYTES + "-byte limit");
+            }
+            out.write(buf, 0, n);
+        }
+        return out.toByteArray();
+    }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/mediators/RemoteUrlValidator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/mediators/RemoteUrlValidator.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.apimgt.gateway.mediators;
+
+import org.wso2.carbon.apimgt.api.APIManagementException;
+
+/**
+ * Seam over the network access-control gate so the SSRF check can be unit-tested
+ * without the full {@code APIUtil} static context. Production wiring delegates to
+ * {@code APIUtil.validateRemoteURL(url, tenantDomain)}.
+ */
+@FunctionalInterface
+public interface RemoteUrlValidator {
+
+    /**
+     * @param url absolute URL to check.
+     * @throws APIManagementException if the URL is not permitted by the configured
+     *                                network access-control policy.
+     */
+    void validate(String url) throws APIManagementException;
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/mediators/XMLSchemaValidator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/mediators/XMLSchemaValidator.java
@@ -36,14 +36,15 @@ import org.wso2.carbon.apimgt.gateway.threatprotection.analyzer.APIMThreatAnalyz
 import org.wso2.carbon.apimgt.gateway.threatprotection.configuration.XMLConfig;
 import org.wso2.carbon.apimgt.gateway.threatprotection.utils.ThreatExceptionHandler;
 import org.wso2.carbon.apimgt.gateway.threatprotection.utils.ThreatProtectorConstants;
+import org.wso2.carbon.apimgt.api.APIManagementException;
 import org.wso2.carbon.apimgt.gateway.utils.GatewayUtils;
 import org.wso2.carbon.apimgt.impl.APIConstants;
 import org.wso2.carbon.apimgt.impl.APIManagerConfiguration;
+import org.wso2.carbon.apimgt.impl.utils.APIUtil;
 import org.xml.sax.SAXException;
 
 import javax.xml.XMLConstants;
 import javax.xml.stream.XMLStreamException;
-import javax.xml.transform.Source;
 import javax.xml.transform.stream.StreamSource;
 import javax.xml.validation.Schema;
 import javax.xml.validation.SchemaFactory;
@@ -52,7 +53,6 @@ import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.URL;
 import java.nio.charset.StandardCharsets;
 
 /**
@@ -285,40 +285,118 @@ public class XMLSchemaValidator extends AbstractMediator {
      */
     private boolean validateSchema(MessageContext messageContext, BufferedInputStream bufferedInputStream)
             throws APIMThreatAnalyzerException {
-        String xsdURL;
+        Object messageProperty = messageContext.getProperty(APIMgtGatewayConstants.XSD_URL);
+        if (messageProperty == null || String.valueOf(messageProperty).isEmpty()) {
+            return true;
+        }
+        String xsdURL = String.valueOf(messageProperty);
+        String tenantDomain = GatewayUtils.getTenantDomain();
+        RemoteUrlValidator policy = url -> APIUtil.validateRemoteURL(url, tenantDomain);
+        return validateXsdAndPayload(xsdURL, policy, bufferedInputStream);
+    }
+
+    /**
+     * The xsdURL gate, decoupled from the Synapse MessageContext so it is unit-testable with a mock
+     * {@link RemoteUrlValidator}: (A) validate the top-level xsdURL; (B) fetch it and every nested ref
+     * redirect-safely and compile the schema; (C) validate the payload with NO external resolution.
+     */
+    static boolean validateXsdAndPayload(String xsdURL, RemoteUrlValidator policy,
+                                         BufferedInputStream bufferedInputStream)
+            throws APIMThreatAnalyzerException {
         Schema schema;
-        SchemaFactory schemaFactory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
+        // total try: the gate only ever throws APIMThreatAnalyzerException (→ clean 400), never a 500
         try {
-            if (isSecureXMLProcessingEnabled) {
-                schemaFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-                schemaFactory.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "");
-                schemaFactory.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+            // (A) gate the top-level xsdURL before any fetch
+            assertXsdUrlAllowed(xsdURL, policy);
+
+            SchemaFactory schemaFactory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
+            // (B) hardening is unconditional — not gated on EnableSecureXMLProcessing
+            schemaFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+            // http/https only at the JAXP layer; the resolver enforces per-host policy on nested refs
+            schemaFactory.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "http,https");
+            schemaFactory.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "http,https");
+            schemaFactory.setResourceResolver(new AccessControlledXmlResolver(policy));
+
+            // compile from fetched bytes, not newSchema(URL) — a URL lets Xerces follow redirects (SSRF)
+            RedirectSafeXsdFetcher.Result topLevel;
+            try {
+                topLevel = RedirectSafeXsdFetcher.fetch(xsdURL, policy);
+            } catch (XsdRefBlockedException e) {
+                throw new APIMThreatAnalyzerException(e.getMessage());
+            } catch (IOException e) {
+                throw new APIMThreatAnalyzerException("Error occurred while fetching the XSD : " + e);
             }
 
-            Object messageProperty = messageContext.getProperty(APIMgtGatewayConstants.XSD_URL);
-            if (messageProperty == null) {
-                return true;
-            } else {
-                if (String.valueOf(messageProperty).isEmpty()) {
-                    return true;
-                } else {
-                    xsdURL = String.valueOf(messageProperty);
-                    URL schemaFile = new URL(xsdURL);
-                    schema = schemaFactory.newSchema(schemaFile);
-                    Source xmlFile = new StreamSource(bufferedInputStream);
-                    Validator validator = schema.newValidator();
-                    if (isSecureXMLProcessingEnabled) {
-                        validator.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-                        validator.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "");
-                        validator.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
-                    }
-                    validator.validate(xmlFile);
+            try {
+                schema = schemaFactory.newSchema(
+                        new StreamSource(new ByteArrayInputStream(topLevel.body), topLevel.finalUrl));
+            } catch (RuntimeException e) {
+                // a wrapped block still surfaces as "not trusted"; otherwise a clean bad-request
+                XsdRefBlockedException blocked = unwrapBlockedRef(e);
+                if (blocked != null) {
+                    throw new APIMThreatAnalyzerException(blocked.getMessage());
                 }
+                throw new APIMThreatAnalyzerException("Error occurred while building the XML schema : " + e);
             }
+
+            // (C) validate the payload with external resolution disabled
+            Validator validator = schema.newValidator();
+            validator.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+            validator.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+            validator.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+            validator.validate(new StreamSource(bufferedInputStream));
         } catch (SAXException | IOException e) {
+            XsdRefBlockedException blocked = unwrapBlockedRef(e);
+            if (blocked != null) {
+                throw new APIMThreatAnalyzerException(blocked.getMessage());
+            }
             throw new APIMThreatAnalyzerException("Error occurred while parsing XML payload : " + e);
+        } catch (RuntimeException e) {
+            // total fail-closed net: any other unchecked → clean 400; java.lang.Error is intentionally not caught
+            XsdRefBlockedException blocked = unwrapBlockedRef(e);
+            if (blocked != null) {
+                throw new APIMThreatAnalyzerException(blocked.getMessage());
+            }
+            throw new APIMThreatAnalyzerException("Error occurred while validating against the XSD : " + e);
         }
         return true;
+    }
+
+    /**
+     * Validates the top-level xsdURL against the network access-control policy. Only
+     * http/https are permitted. Throws {@link APIMThreatAnalyzerException} (mapped to a
+     * 400 by the mediate() handler) when the URL is blocked or uses another scheme.
+     *
+     * @param xsdURL the publisher-supplied schema URL.
+     * @param policy the network access-control gate.
+     */
+    static void assertXsdUrlAllowed(String xsdURL, RemoteUrlValidator policy)
+            throws APIMThreatAnalyzerException {
+        if (!AccessControlledXmlResolver.isHttpOrHttps(xsdURL)) {
+            throw new APIMThreatAnalyzerException(
+                    "The provided XSD URL is not trusted (only HTTP/HTTPS is allowed): " + xsdURL);
+        }
+        try {
+            policy.validate(xsdURL);
+        } catch (APIManagementException e) {
+            throw new APIMThreatAnalyzerException("The provided XSD URL is not trusted: " + xsdURL);
+        }
+    }
+
+    /**
+     * Walks the cause chain (including {@code t} itself) and returns the first
+     * {@link XsdRefBlockedException}, or {@code null} if none is present. Lets the
+     * mediator fail closed even when the XML parser wraps a resolver-thrown block in
+     * another exception type. Bounded to avoid pathological cause cycles.
+     */
+    static XsdRefBlockedException unwrapBlockedRef(Throwable t) {
+        Throwable cur = t;
+        for (int depth = 0; cur != null && depth < 50; depth++, cur = cur.getCause()) {
+            if (cur instanceof XsdRefBlockedException) {
+                return (XsdRefBlockedException) cur;
+            }
+        }
+        return null;
     }
 
     /**

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/mediators/XsdRefBlockedException.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/mediators/XsdRefBlockedException.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.apimgt.gateway.mediators;
+
+/**
+ * Thrown when a reference encountered while compiling an XSD (a nested
+ * xsd:import/include/redefine or an external DTD) is not permitted by the network
+ * access-control policy, or uses a non-HTTP(S) scheme. Unchecked because it must
+ * propagate out of {@link org.w3c.dom.ls.LSResourceResolver#resolveResource}, which
+ * cannot declare checked exceptions.
+ */
+public class XsdRefBlockedException extends RuntimeException {
+
+    public XsdRefBlockedException(String message) {
+        super(message);
+    }
+
+    public XsdRefBlockedException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/mediators/XsdRefFetchException.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/mediators/XsdRefFetchException.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.apimgt.gateway.mediators;
+
+/**
+ * Unchecked exception used to surface a network/protocol error while fetching a nested XSD reference from
+ * inside {@link AccessControlledXmlResolver#resolveResource} (whose signature cannot declare a checked
+ * exception). This is NOT a policy block — unlike {@link XsdRefBlockedException} — so the mediator maps it
+ * to a generic bad-request rather than a "not trusted" message.
+ */
+public class XsdRefFetchException extends RuntimeException {
+
+    public XsdRefFetchException(String message) {
+        super(message);
+    }
+
+    public XsdRefFetchException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/test/java/org/wso2/carbon/apimgt/gateway/mediators/AccessControlledXmlResolverTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/test/java/org/wso2/carbon/apimgt/gateway/mediators/AccessControlledXmlResolverTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.apimgt.gateway.mediators;
+
+import org.junit.Test;
+import org.wso2.carbon.apimgt.api.APIManagementException;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static javax.xml.XMLConstants.W3C_XML_SCHEMA_NS_URI;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+/**
+ * Unit tests for the validation/blocking logic of {@link AccessControlledXmlResolver}. The actual
+ * (redirect-safe) fetching of a permitted reference and the LSInput contract are exercised against a
+ * real HTTP server in {@link RedirectSafeXsdFetcherTest}.
+ */
+public class AccessControlledXmlResolverTest {
+
+    @Test(expected = XsdRefBlockedException.class)
+    public void testBlocksDeniedHost() {
+        AccessControlledXmlResolver resolver = new AccessControlledXmlResolver(url -> {
+            throw new APIManagementException("blocked");
+        });
+        resolver.resolveResource(W3C_XML_SCHEMA_NS_URI, null, null,
+                "http://10.0.0.5/internal.xsd", "http://schemas.example.com/main.xsd");
+    }
+
+    @Test(expected = XsdRefBlockedException.class)
+    public void testBlocksNonHttpScheme() {
+        AccessControlledXmlResolver resolver = new AccessControlledXmlResolver(url -> { });
+        resolver.resolveResource(W3C_XML_SCHEMA_NS_URI, null, null, "file:///etc/passwd", null);
+    }
+
+    @Test(expected = XsdRefBlockedException.class)
+    public void testBlocksUnresolvableSystemId() {
+        AccessControlledXmlResolver resolver = new AccessControlledXmlResolver(url -> { });
+        resolver.resolveResource(W3C_XML_SCHEMA_NS_URI, null, null, "relative/types.xsd", null);
+    }
+
+    @Test
+    public void testResolvesRelativeAgainstBaseBeforeValidating() {
+        List<String> validated = new ArrayList<>();
+        AccessControlledXmlResolver resolver = new AccessControlledXmlResolver(url -> {
+            validated.add(url);
+            throw new APIManagementException("stop before fetch");
+        });
+        try {
+            resolver.resolveResource(W3C_XML_SCHEMA_NS_URI, null, null,
+                    "common/types.xsd", "http://schemas.example.com/dir/main.xsd");
+            fail("expected XsdRefBlockedException");
+        } catch (XsdRefBlockedException expected) {
+        }
+        assertEquals("http://schemas.example.com/dir/common/types.xsd", validated.get(0));
+    }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/test/java/org/wso2/carbon/apimgt/gateway/mediators/RedirectSafeXsdFetcherTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/test/java/org/wso2/carbon/apimgt/gateway/mediators/RedirectSafeXsdFetcherTest.java
@@ -1,0 +1,245 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.apimgt.gateway.mediators;
+
+import com.sun.net.httpserver.HttpServer;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.wso2.carbon.apimgt.api.APIManagementException;
+import org.wso2.carbon.apimgt.gateway.threatprotection.APIMThreatAnalyzerException;
+
+import java.io.BufferedInputStream;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static javax.xml.XMLConstants.W3C_XML_SCHEMA_NS_URI;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * Regression tests for the redirect-safe fetch that closes the xsdURL redirect SSRF bypass.
+ *
+ * <p>Stands up a real loopback HTTP server where an allow-listed "edge" path 302-redirects to a "secret"
+ * path the policy blocks, and asserts the secret target is NEVER contacted (the redirect Location is
+ * re-validated, not auto-followed). Also covers the resolver path and direct/allowed/blocked/non-http.
+ */
+public class RedirectSafeXsdFetcherTest {
+
+    private static HttpServer server;
+    private static String base;
+
+    // Force the JDK's built-in SchemaFactory (test classpath also has xerces lacking ACCESS_EXTERNAL_*).
+    private static final String SCHEMA_FACTORY_KEY =
+            "javax.xml.validation.SchemaFactory:" + W3C_XML_SCHEMA_NS_URI;
+    private static final String JDK_SCHEMA_FACTORY =
+            "com.sun.org.apache.xerces.internal.jaxp.validation.XMLSchemaFactory";
+
+    /** Paths the HTTP server actually served (thread-safe). */
+    private static final List<String> hits = Collections.synchronizedList(new ArrayList<>());
+
+    private static final String CLEAN_XSD =
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+                    + "<xsd:schema xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\">"
+                    + "<xsd:element name=\"note\" type=\"xsd:string\"/></xsd:schema>";
+
+    /** Policy that blocks any URL containing "secret"; everything else is allowed. */
+    private static final RemoteUrlValidator BLOCK_SECRET = url -> {
+        if (url.contains("secret")) {
+            throw new APIManagementException("blocked by policy: " + url);
+        }
+    };
+
+    /** Policy that allows everything (for the payload-cannot-fetch test). */
+    private static final RemoteUrlValidator ALLOW_ALL = url -> { };
+
+    @BeforeClass
+    public static void startServer() throws IOException {
+        System.setProperty(SCHEMA_FACTORY_KEY, JDK_SCHEMA_FACTORY);
+        server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        int port = server.getAddress().getPort();
+        base = "http://127.0.0.1:" + port;
+        server.createContext("/", exchange -> {
+            String path = exchange.getRequestURI().getPath();
+            hits.add(path);
+            if ("/redirect-to-internal.xsd".equals(path)) {
+                exchange.getResponseHeaders().set("Location", base + "/secret.xsd");
+                exchange.sendResponseHeaders(302, -1);
+                exchange.close();
+                return;
+            }
+            if ("/edge-to-allowed.xsd".equals(path)) {
+                exchange.getResponseHeaders().set("Location", base + "/allowed.xsd");
+                exchange.sendResponseHeaders(302, -1);
+                exchange.close();
+                return;
+            }
+            byte[] body = CLEAN_XSD.getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().set("Content-Type", "application/xml");
+            exchange.sendResponseHeaders(200, body.length);
+            try (OutputStream os = exchange.getResponseBody()) {
+                os.write(body);
+            }
+        });
+        server.start();
+    }
+
+    @AfterClass
+    public static void stopServer() {
+        if (server != null) {
+            server.stop(0);
+        }
+        System.clearProperty(SCHEMA_FACTORY_KEY);
+    }
+
+    private static String read(RedirectSafeXsdFetcher.Result r) throws IOException {
+        return new String(r.body, StandardCharsets.UTF_8);
+    }
+
+    @Test
+    public void testDirectAllowedFetchReturnsBytes() throws Exception {
+        hits.clear();
+        RedirectSafeXsdFetcher.Result r = RedirectSafeXsdFetcher.fetch(base + "/allowed.xsd", BLOCK_SECRET);
+        assertTrue("expected the clean XSD body", read(r).contains("xsd:schema"));
+        assertEquals(base + "/allowed.xsd", r.finalUrl);
+        assertTrue(hits.contains("/allowed.xsd"));
+    }
+
+    @Test
+    public void testDirectBlockedThrowsAndIsNeverFetched() {
+        hits.clear();
+        try {
+            RedirectSafeXsdFetcher.fetch(base + "/secret.xsd", BLOCK_SECRET);
+            fail("expected XsdRefBlockedException");
+        } catch (XsdRefBlockedException expected) {
+        } catch (IOException e) {
+            fail("expected a block, got IOException: " + e);
+        }
+        assertFalse("blocked URL must never be fetched", hits.contains("/secret.xsd"));
+    }
+
+    @Test(expected = XsdRefBlockedException.class)
+    public void testNonHttpSchemeThrows() throws Exception {
+        RedirectSafeXsdFetcher.fetch("file:///etc/passwd", BLOCK_SECRET);
+    }
+
+    @Test
+    public void testRedirectToBlockedHostIsRefusedAndNeverContacted() {
+        hits.clear();
+        try {
+            RedirectSafeXsdFetcher.fetch(base + "/redirect-to-internal.xsd", BLOCK_SECRET);
+            fail("expected the redirect to the blocked host to be refused");
+        } catch (XsdRefBlockedException expected) {
+            // 302 Location re-validated, rejected
+        } catch (IOException e) {
+            fail("expected a block, got IOException: " + e);
+        }
+        assertTrue("the allow-listed edge is fetched", hits.contains("/redirect-to-internal.xsd"));
+        assertFalse("the redirect target must NEVER be contacted (this is the bypass)",
+                hits.contains("/secret.xsd"));
+    }
+
+    @Test
+    public void testRedirectToAllowedHostIsFollowed() throws Exception {
+        hits.clear();
+        RedirectSafeXsdFetcher.Result r =
+                RedirectSafeXsdFetcher.fetch(base + "/edge-to-allowed.xsd", BLOCK_SECRET);
+        assertEquals(base + "/allowed.xsd", r.finalUrl);
+        assertTrue(read(r).contains("xsd:schema"));
+        assertTrue(hits.contains("/edge-to-allowed.xsd"));
+        assertTrue(hits.contains("/allowed.xsd"));
+    }
+
+    @Test
+    public void testResolverRefusesRedirectToBlocked() {
+        hits.clear();
+        AccessControlledXmlResolver resolver = new AccessControlledXmlResolver(BLOCK_SECRET);
+        try {
+            resolver.resolveResource(W3C_XML_SCHEMA_NS_URI, null, null, base + "/redirect-to-internal.xsd", null);
+            fail("expected XsdRefBlockedException");
+        } catch (XsdRefBlockedException expected) {
+        }
+        assertFalse("the redirect target must NEVER be contacted via the resolver either",
+                hits.contains("/secret.xsd"));
+    }
+
+    @Test
+    public void testResolverReturnsFetchedBytesForAllowed() throws Exception {
+        hits.clear();
+        AccessControlledXmlResolver resolver = new AccessControlledXmlResolver(BLOCK_SECRET);
+        org.w3c.dom.ls.LSInput input =
+                resolver.resolveResource(W3C_XML_SCHEMA_NS_URI, null, null, base + "/allowed.xsd", null);
+        assertNotNull("a permitted reference must be returned as a populated LSInput", input);
+        try (InputStream in = input.getByteStream()) {
+            String content = new String(in.readAllBytes(), StandardCharsets.UTF_8);
+            assertTrue(content.contains("xsd:schema"));
+        }
+        assertEquals(base + "/allowed.xsd", input.getSystemId());
+        assertTrue(hits.contains("/allowed.xsd"));
+    }
+
+    private static BufferedInputStream payload(String xml) {
+        return new BufferedInputStream(new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)));
+    }
+
+    @Test
+    public void testValidateXsdAndPayloadRefusesRedirectToBlocked() {
+        hits.clear();
+        try {
+            XMLSchemaValidator.validateXsdAndPayload(
+                    base + "/redirect-to-internal.xsd", BLOCK_SECRET, payload("<note>hi</note>"));
+            fail("expected APIMThreatAnalyzerException for the redirect to a blocked host");
+        } catch (APIMThreatAnalyzerException expected) {
+        }
+        assertFalse("the redirect target must never be contacted via validateSchema either",
+                hits.contains("/secret.xsd"));
+    }
+
+    @Test
+    public void testValidateXsdAndPayloadAllowsCleanSchemaAndValidatesPayload() throws Exception {
+        hits.clear();
+        boolean ok = XMLSchemaValidator.validateXsdAndPayload(
+                base + "/allowed.xsd", BLOCK_SECRET, payload("<note>hi</note>"));
+        assertTrue("a permitted xsdURL with a conforming payload should validate", ok);
+        assertTrue(hits.contains("/allowed.xsd"));
+    }
+
+    @Test
+    public void testPayloadCannotFetchAnExternalDtd() {
+        hits.clear();
+        // step (C) disables external resolution: DTD must never be fetched
+        String evilPayload = "<?xml version=\"1.0\"?>"
+                + "<!DOCTYPE note SYSTEM \"" + base + "/payload-evil.dtd\"><note>hi</note>";
+        try {
+            XMLSchemaValidator.validateXsdAndPayload(base + "/allowed.xsd", ALLOW_ALL, payload(evilPayload));
+        } catch (APIMThreatAnalyzerException ignored) {
+        }
+        assertFalse("the payload's external DTD must never be fetched (step C)",
+                hits.contains("/payload-evil.dtd"));
+    }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/test/java/org/wso2/carbon/apimgt/gateway/mediators/XMLSchemaValidatorTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/test/java/org/wso2/carbon/apimgt/gateway/mediators/XMLSchemaValidatorTest.java
@@ -28,6 +28,8 @@ import org.mockito.Mockito;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
+import org.wso2.carbon.apimgt.api.APIManagementException;
+import org.wso2.carbon.apimgt.gateway.threatprotection.APIMThreatAnalyzerException;
 import org.wso2.carbon.apimgt.gateway.threatprotection.analyzer.APIMThreatAnalyzer;
 import org.wso2.carbon.apimgt.gateway.threatprotection.analyzer.XMLAnalyzer;
 import org.wso2.carbon.apimgt.gateway.threatprotection.configuration.XMLConfig;
@@ -35,7 +37,13 @@ import org.wso2.carbon.apimgt.gateway.threatprotection.utils.ThreatProtectorCons
 import org.wso2.carbon.apimgt.impl.APIManagerConfiguration;
 import org.wso2.carbon.apimgt.gateway.internal.ServiceReferenceHolder;
 
+import java.io.BufferedInputStream;
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 
 /**
  * This is the test case for {@link XMLSchemaValidator}
@@ -125,9 +133,7 @@ public class XMLSchemaValidatorTest {
     @Test
     public void testConfigureSchemaPropertiesAllowsDtdAndExternalEntitiesWhenSecureProcessingDisabled() {
         log.info("Running the test case to verify DTD/external entities follow message properties when secure XML processing is disabled.");
-        // Secure XML processing is disabled
         Mockito.when(apiManagerConfiguration.isEnableSecureXMLProcessing()).thenReturn(false);
-        // Message context properties enable DTD and external entities
         Mockito.when(messageContext.getProperty(ThreatProtectorConstants.DTD_ENABLED)).thenReturn("true");
         Mockito.when(messageContext.getProperty(ThreatProtectorConstants.EXTERNAL_ENTITIES_ENABLED)).thenReturn("true");
         Mockito.when(messageContext.getProperty(ThreatProtectorConstants.MAX_ELEMENT_COUNT)).thenReturn("5");
@@ -142,10 +148,8 @@ public class XMLSchemaValidatorTest {
         xmlSchemaValidator.isSecureXMLProcessingEnabled = false;
         XMLConfig testConfig = xmlSchemaValidator.configureSchemaProperties(messageContext);
 
-        // Since secure XML processing is disabled, DTD and external entities should follow message properties.
         assertEquals(true, testConfig.isDtdEnabled());
         assertEquals(true, testConfig.isExternalEntitiesEnabled());
-        // Verify other properties are set correctly
         assertEquals(5, testConfig.getMaxElementCount());
         assertEquals(5, testConfig.getMaxAttributeLength());
         assertEquals(5, testConfig.getMaxDepth());
@@ -154,5 +158,47 @@ public class XMLSchemaValidatorTest {
         assertEquals(5, testConfig.getEntityExpansionLimit());
 
         log.info("Successfully completed testConfigureSchemaPropertiesAllowsDtdAndExternalEntitiesWhenSecureProcessingDisabled test case.");
+    }
+
+    @Test
+    public void testAssertXsdUrlAllowedPassesForPermittedUrl() throws Exception {
+        RemoteUrlValidator allowAll = url -> { };
+        XMLSchemaValidator.assertXsdUrlAllowed("http://schemas.example.com/a.xsd", allowAll);
+    }
+
+    @Test(expected = APIMThreatAnalyzerException.class)
+    public void testAssertXsdUrlAllowedBlocksDeniedHost() throws Exception {
+        RemoteUrlValidator denyAll = url -> { throw new APIManagementException("blocked"); };
+        XMLSchemaValidator.assertXsdUrlAllowed("http://169.254.169.254/latest/meta-data/", denyAll);
+    }
+
+    @Test(expected = APIMThreatAnalyzerException.class)
+    public void testAssertXsdUrlAllowedBlocksNonHttpScheme() throws Exception {
+        RemoteUrlValidator allowAll = url -> { };
+        XMLSchemaValidator.assertXsdUrlAllowed("file:///etc/passwd", allowAll);
+    }
+
+    @Test
+    public void testUnwrapBlockedRefFindsDirectAndWrapped() {
+        XsdRefBlockedException blocked = new XsdRefBlockedException("not trusted");
+        assertSame(blocked, XMLSchemaValidator.unwrapBlockedRef(blocked));
+        assertSame(blocked, XMLSchemaValidator.unwrapBlockedRef(new org.xml.sax.SAXException(blocked)));
+        assertSame(blocked, XMLSchemaValidator.unwrapBlockedRef(
+                new RuntimeException(new RuntimeException(blocked))));
+    }
+
+    @Test
+    public void testUnwrapBlockedRefReturnsNullWhenNoBlockPresent() {
+        assertNull(XMLSchemaValidator.unwrapBlockedRef(new RuntimeException("genuine parse error")));
+        assertNull(XMLSchemaValidator.unwrapBlockedRef(null));
+    }
+
+    @Test(expected = APIMThreatAnalyzerException.class)
+    public void testValidateXsdAndPayloadConvertsPolicyRuntimeExceptionToFailClosed() throws Exception {
+        // unchecked RuntimeException must fail closed
+        RemoteUrlValidator boom = url -> { throw new IllegalStateException("malformed tenant-conf"); };
+        BufferedInputStream payload = new BufferedInputStream(
+                new ByteArrayInputStream("<note>hi</note>".getBytes(StandardCharsets.UTF_8)));
+        XMLSchemaValidator.validateXsdAndPayload("http://schemas.example.com/a.xsd", boom, payload);
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/test/java/org/wso2/carbon/apimgt/gateway/mediators/XmlSchemaSsrfResolverIntegrationTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/test/java/org/wso2/carbon/apimgt/gateway/mediators/XmlSchemaSsrfResolverIntegrationTest.java
@@ -1,0 +1,236 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.apimgt.gateway.mediators;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.wso2.carbon.apimgt.api.APIManagementException;
+
+import javax.xml.XMLConstants;
+import javax.xml.validation.SchemaFactory;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.List;
+import java.util.ArrayList;
+
+import static org.junit.Assert.*;
+
+/**
+ * JAXP integration test that empirically answers two questions:
+ * 1. Is the LSResourceResolver consulted for nested xsd:import references?
+ * 2. Is the LSResourceResolver consulted for external DTDs declared in an XSD?
+ *
+ * The test starts a real HTTP server on an ephemeral port, exercises
+ * SchemaFactory.newSchema() with the production wiring, and inspects both which
+ * URLs the resolver saw and which paths the HTTP server actually served.
+ */
+public class XmlSchemaSsrfResolverIntegrationTest {
+
+    private static HttpServer server;
+    private static int port;
+
+    /** Paths actually fetched by the HTTP server (thread-safe). */
+    private static final List<String> serverHits = Collections.synchronizedList(new ArrayList<>());
+
+    /**
+     * The JAXP SchemaFactory service-loader key for W3C XML Schema.
+     * We force the JDK's built-in Xerces implementation because:
+     * (a) the test classpath contains old standalone xerces jars (2.12.0) that preempt
+     *     the JDK's impl via ServiceLoader but do NOT support the ACCESS_EXTERNAL_SCHEMA /
+     *     ACCESS_EXTERNAL_DTD properties (pre-JAXP 1.5); and
+     * (b) the production validateSchema() code sets those properties without catching
+     *     SAXNotRecognizedException — it therefore MUST run on the JDK's built-in
+     *     com.sun.org.apache.xerces.internal impl (or another JAXP 1.5-capable impl).
+     * Pinning to the JDK impl in tests mirrors production reality.
+     */
+    private static final String SCHEMA_FACTORY_KEY =
+            "javax.xml.validation.SchemaFactory:" + XMLConstants.W3C_XML_SCHEMA_NS_URI;
+    private static final String JDK_SCHEMA_FACTORY =
+            "com.sun.org.apache.xerces.internal.jaxp.validation.XMLSchemaFactory";
+
+    @BeforeClass
+    public static void startServer() throws IOException {
+        System.setProperty(SCHEMA_FACTORY_KEY, JDK_SCHEMA_FACTORY);
+
+        server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        port = server.getAddress().getPort();
+
+        server.createContext("/", new HttpHandler() {
+            @Override
+            public void handle(HttpExchange exchange) throws IOException {
+                String path = exchange.getRequestURI().getPath();
+                serverHits.add(path);
+
+                byte[] body = buildResponse(path);
+                int status = (body != null) ? 200 : 404;
+                if (body == null) {
+                    body = ("Not found: " + path).getBytes(StandardCharsets.UTF_8);
+                }
+                exchange.getResponseHeaders().set("Content-Type", "application/xml");
+                exchange.sendResponseHeaders(status, body.length);
+                try (OutputStream os = exchange.getResponseBody()) {
+                    os.write(body);
+                }
+            }
+
+            private byte[] buildResponse(String path) {
+                String content;
+                switch (path) {
+                    case "/main.xsd":
+                        content = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+                                "<xsd:schema xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"\n" +
+                                "            targetNamespace=\"urn:ssrf:main\"\n" +
+                                "            xmlns:imp=\"urn:ssrf:imported\">\n" +
+                                "  <xsd:import namespace=\"urn:ssrf:imported\"\n" +
+                                "              schemaLocation=\"http://127.0.0.1:" + port + "/imported.xsd\"/>\n" +
+                                "  <xsd:element name=\"root\" type=\"xsd:string\"/>\n" +
+                                "</xsd:schema>\n";
+                        break;
+                    case "/imported.xsd":
+                        content = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+                                "<xsd:schema xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"\n" +
+                                "            targetNamespace=\"urn:ssrf:imported\">\n" +
+                                "  <xsd:element name=\"imported\" type=\"xsd:string\"/>\n" +
+                                "</xsd:schema>\n";
+                        break;
+                    case "/main-with-dtd.xsd":
+                        content = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+                                "<!DOCTYPE xsd:schema SYSTEM \"http://127.0.0.1:" + port + "/evil.dtd\">\n" +
+                                "<xsd:schema xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"\n" +
+                                "            targetNamespace=\"urn:ssrf:dtd\">\n" +
+                                "  <xsd:element name=\"root\" type=\"xsd:string\"/>\n" +
+                                "</xsd:schema>\n";
+                        break;
+                    case "/evil.dtd":
+                        content = "<!-- dtd -->";
+                        break;
+                    default:
+                        return null;
+                }
+                return content.getBytes(StandardCharsets.UTF_8);
+            }
+        });
+
+        server.start();
+    }
+
+    @AfterClass
+    public static void stopServer() {
+        if (server != null) {
+            server.stop(0);
+        }
+        System.clearProperty(SCHEMA_FACTORY_KEY);
+    }
+
+    private void newSchema(String schemaPath, RemoteUrlValidator policy) throws Exception {
+        SchemaFactory sf = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
+        sf.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+        sf.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "http,https");
+        sf.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "http,https");
+        sf.setResourceResolver(new AccessControlledXmlResolver(policy));
+        sf.newSchema(new URL("http://127.0.0.1:" + port + "/" + schemaPath));
+    }
+
+    @Test
+    public void testImportResolverConsultedAndFetchedWhenAllowed() throws Exception {
+        serverHits.clear();
+        List<String> validatedUrls = Collections.synchronizedList(new ArrayList<>());
+
+        RemoteUrlValidator recordOnly = validatedUrls::add;
+
+        newSchema("main.xsd", recordOnly);
+
+        assertTrue(
+                "Resolver was not consulted for /imported.xsd. Validated URLs: " + validatedUrls,
+                validatedUrls.stream().anyMatch(u -> u.contains("/imported.xsd")));
+
+        assertTrue(
+                "Server did not receive a request for /imported.xsd. Server hits: " + serverHits,
+                serverHits.contains("/imported.xsd"));
+    }
+
+    @Test
+    public void testImportBlockedPreventsFetch() throws Exception {
+        serverHits.clear();
+
+        RemoteUrlValidator blockImported = url -> {
+            if (url.contains("imported.xsd")) {
+                throw new APIManagementException("SSRF block: " + url);
+            }
+        };
+
+        Exception caught = null;
+        try {
+            newSchema("main.xsd", blockImported);
+            fail("newSchema should have thrown when the import was blocked");
+        } catch (Exception e) {
+            caught = e;
+        }
+
+        assertNotNull("newSchema should have thrown", caught);
+        assertNotNull(
+                "Expected XsdRefBlockedException in the cause chain, but got: " + caught,
+                XMLSchemaValidator.unwrapBlockedRef(caught));
+
+        assertFalse(
+                "Server fetched /imported.xsd even though the resolver blocked it. Server hits: "
+                        + serverHits,
+                serverHits.contains("/imported.xsd"));
+    }
+
+    // Secure outcome: external DTD must NOT be fetched; if it is, set ACCESS_EXTERNAL_DTD="" to fail closed.
+    @Test
+    public void testExternalDtdBehavior() throws Exception {
+        serverHits.clear();
+
+        RemoteUrlValidator blockDtd = url -> {
+            if (url.contains("evil.dtd")) {
+                throw new APIManagementException("SSRF block: " + url);
+            }
+        };
+
+        Exception caught = null;
+        try {
+            newSchema("main-with-dtd.xsd", blockDtd);
+        } catch (Exception e) {
+            caught = e;
+        }
+
+        assertFalse(
+                "SSRF GAP DETECTED: /evil.dtd was fetched even though the resolver should have " +
+                "blocked it. The LSResourceResolver is NOT consulted for external DTDs under " +
+                "ACCESS_EXTERNAL_DTD=\"http,https\". Production code must set " +
+                "ACCESS_EXTERNAL_DTD=\"\" to fail closed. Server hits: " + serverHits,
+                serverHits.contains("/evil.dtd"));
+
+        assertNotNull("newSchema should have thrown for the DTD-bearing XSD", caught);
+
+        assertNotNull(
+                "Expected XsdRefBlockedException in the cause chain for the DTD block, but got: "
+                        + caught,
+                XMLSchemaValidator.unwrapBlockedRef(caught));
+    }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIManagerConfiguration.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIManagerConfiguration.java
@@ -3243,6 +3243,10 @@ public class APIManagerConfiguration {
 
         String value = getFirstProperty(APIConstants.MEDIATION_CONFIG + "."
                 + APIConstants.ENABLE_SECURE_XML_PROCESSING);
+        // fail safe: missing/blank → secure; only an explicit "false" disables
+        if (value == null || value.isEmpty()) {
+            return true;
+        }
         return Boolean.parseBoolean(value);
     }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/restapi/publisher/ApisApiServiceImplUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/restapi/publisher/ApisApiServiceImplUtils.java
@@ -78,6 +78,7 @@ import org.wso2.carbon.apimgt.spec.parser.definitions.OAS2Parser;
 import org.wso2.carbon.apimgt.spec.parser.definitions.OAS3Parser;
 import org.wso2.carbon.apimgt.spec.parser.definitions.OASParserUtil;
 import org.wso2.carbon.base.ServerConfiguration;
+import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.core.util.CryptoException;
 import org.wso2.carbon.core.util.CryptoUtil;
 import org.wso2.carbon.utils.CarbonUtils;
@@ -650,9 +651,18 @@ public class ApisApiServiceImplUtils {
                                                                             String apiDefinition, String fileName,
                                                                             boolean returnContent)
             throws APIManagementException {
+        return validateOpenAPIDefinition(url, inputStream, apiDefinition, fileName, returnContent,
+                PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain());
+    }
+
+    public static APIDefinitionValidationResponse validateOpenAPIDefinition(String url, InputStream inputStream,
+                                                                            String apiDefinition, String fileName,
+                                                                            boolean returnContent, String tenantDomain)
+            throws APIManagementException {
         APIDefinitionValidationResponse validationResponse = new APIDefinitionValidationResponse();
-        OASParserOptions parserOptions = ServiceReferenceHolder.getInstance().getAPIMDependencyConfigurationService()
+        OASParserOptions baseOptions = ServiceReferenceHolder.getInstance().getAPIMDependencyConfigurationService()
                 .getAPIMDependencyConfigurations().getOasParserOptions();
+        OASParserOptions parserOptions = APIUtil.buildRefAwareOASParserOptions(baseOptions, tenantDomain);
         if (url != null) {
             try {
                 URL urlObj = new URL(url);

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
@@ -130,6 +130,7 @@ import org.wso2.carbon.apimgt.api.model.Identifier;
 import org.wso2.carbon.apimgt.api.model.KeyManagerConfiguration;
 import org.wso2.carbon.apimgt.api.model.KeyManagerConnectorConfiguration;
 import org.wso2.carbon.apimgt.api.model.Mediation;
+import org.wso2.carbon.apimgt.api.model.OASParserOptions;
 import org.wso2.carbon.apimgt.api.model.OperationPolicyData;
 import org.wso2.carbon.apimgt.api.model.OperationPolicyDefinition;
 import org.wso2.carbon.apimgt.api.model.OperationPolicySpecification;
@@ -6196,6 +6197,35 @@ public final class APIUtil {
         }
 
         return CommonAPIUtil.getHttpClient(protocol, configuration, getSSLContext());
+    }
+
+    /**
+     * Build the HTTP client used by the SSRF {@code $ref} crawl. Mirrors {@link #getHttpClient(int, String)}
+     * (platform truststore/TLS, proxy, pool, timeouts) but with HTTP redirect handling <b>disabled</b>, so the crawl
+     * re-validates every redirect {@code Location} before following it (a redirect-to-private bypass is otherwise
+     * possible). The argument order matches {@link OASParserOptions.HttpClientProvider#getClient(String, int)} so it
+     * can be supplied directly as {@code APIUtil::getCrawlHttpClient}.
+     *
+     * @param protocol service endpoint protocol http/https
+     * @param port     service endpoint port
+     * @return a redirect-disabled {@link HttpClient}
+     */
+    public static HttpClient getCrawlHttpClient(String protocol, int port) {
+
+        HttpClientConfigurationDTO configuration = ServiceReferenceHolder.getInstance().
+                getAPIManagerConfigurationService().getAPIManagerConfiguration().getHttpClientConfiguration();
+
+        if (log.isDebugEnabled()) {
+            log.debug("Creating redirect-disabled $ref crawl HTTP client with protocol: " + protocol
+                    + " port: " + port);
+        }
+
+        // Avoid unnecessary truststore work for plain HTTP
+        if (!APIConstants.HTTPS_PROTOCOL.equalsIgnoreCase(protocol)) {
+            return CommonAPIUtil.getHttpClient(protocol, configuration, SSLContexts.createDefault(), true);
+        }
+
+        return CommonAPIUtil.getHttpClient(protocol, configuration, getSSLContext(), true);
     }
 
     /**
@@ -12532,6 +12562,41 @@ public final class APIUtil {
             }
             applyAccessControlPolicy(host, tenantMode, tenantHosts, tenantBlockPrivate);
         }
+    }
+
+    public static OASParserOptions buildRefAwareOASParserOptions(OASParserOptions base, String tenantDomain)
+            throws APIManagementException {
+        OASParserOptions opts = new OASParserOptions(base);
+        populateRefResolutionPolicy(opts, tenantDomain);
+        return opts;
+    }
+
+    /**
+     * Wire the network-security hook onto the parser options. When the platform or tenant network-security policy
+     * is active, the OAS3 parser validates every external $ref URL (top-level, direct, and transitive/nested) through
+     * {@link #validateRemoteURL(String, String)} via the injected custom URL validator; when inactive, no validator
+     * is set and ref resolution behaves as before. The same {@code validateRemoteURL}/{@code applyAccessControlPolicy}
+     * engine is therefore authoritative for top-level URLs, direct refs, and nested refs alike.
+     */
+    public static void populateRefResolutionPolicy(OASParserOptions opts, String tenantDomain)
+            throws APIManagementException {
+        opts.setRefValidationTenantDomain(tenantDomain);
+
+        JSONObject tenantConfig = getTenantConfig(tenantDomain);
+        boolean tenantEnabled = tenantConfig != null && tenantConfig.get(
+                APIConstants.NetworkSecurityAccessControl.TENANT_CONFIG_KEY) != null;
+
+        if (!networkSecurityEnabled && !tenantEnabled) {
+            opts.setRefValidator(null);
+            opts.setHttpClientProvider(null);
+            return;
+        }
+        opts.setRefValidator(APIUtil::validateRemoteURL);
+        opts.setHttpClientProvider(APIUtil::getCrawlHttpClient);
+        // cap each fetched $ref at the configured OAS import size limit (default 10 MB)
+        opts.setRefFetchMaxFileSize(ServiceReferenceHolder.getInstance().getAPIManagerConfigurationService()
+                .getAPIManagerConfiguration()
+                .getFirstProperty(org.wso2.carbon.apimgt.api.APIConstants.API_PUBLISHER_IMPORT_OAS_FILE_SIZE_LIMIT));
     }
 
     /**

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/APIManagerConfigurationTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/APIManagerConfigurationTest.java
@@ -20,6 +20,7 @@ package org.wso2.carbon.apimgt.impl;
 import org.apache.axiom.om.OMElement;
 import org.apache.axiom.om.util.AXIOMUtil;
 import org.junit.Test;
+import org.mockito.Mockito;
 import org.testng.Assert;
 import org.wso2.carbon.apimgt.api.APIManagementException;
 import org.wso2.carbon.apimgt.api.model.Environment;
@@ -27,6 +28,9 @@ import org.wso2.carbon.apimgt.api.model.Environment;
 import javax.xml.stream.XMLStreamException;
 
 import java.util.Map;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class APIManagerConfigurationTest {
 
@@ -128,5 +132,34 @@ public class APIManagerConfigurationTest {
         Assert.assertFalse(environmentsList.isEmpty());
         Environment defaultEnv = environmentsList.get("Default");
         Assert.assertFalse(defaultEnv.getAdditionalProperties().isEmpty());
+    }
+
+    @Test
+    public void testIsEnableSecureXMLProcessingDefaultsToTrueWhenAbsent() {
+        APIManagerConfiguration config = Mockito.spy(new APIManagerConfiguration());
+        Mockito.doReturn(null).when(config).getFirstProperty(
+                APIConstants.MEDIATION_CONFIG + "." + APIConstants.ENABLE_SECURE_XML_PROCESSING);
+        assertTrue(config.isEnableSecureXMLProcessing());
+    }
+
+    @Test
+    public void testIsEnableSecureXMLProcessingDefaultsToTrueWhenBlank() {
+        APIManagerConfiguration config = Mockito.spy(new APIManagerConfiguration());
+        Mockito.doReturn("").when(config).getFirstProperty(Mockito.anyString());
+        assertTrue(config.isEnableSecureXMLProcessing());
+    }
+
+    @Test
+    public void testIsEnableSecureXMLProcessingFalseOnlyWhenExplicitlyFalse() {
+        APIManagerConfiguration config = Mockito.spy(new APIManagerConfiguration());
+        Mockito.doReturn("false").when(config).getFirstProperty(Mockito.anyString());
+        assertFalse(config.isEnableSecureXMLProcessing());
+    }
+
+    @Test
+    public void testIsEnableSecureXMLProcessingTrueWhenExplicitlyTrue() {
+        APIManagerConfiguration config = Mockito.spy(new APIManagerConfiguration());
+        Mockito.doReturn("true").when(config).getFirstProperty(Mockito.anyString());
+        assertTrue(config.isEnableSecureXMLProcessing());
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/utils/APIUtilAccessControlPolicyTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/utils/APIUtilAccessControlPolicyTest.java
@@ -1,0 +1,236 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.apimgt.impl.utils;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.powermock.reflect.Whitebox;
+import org.wso2.carbon.apimgt.api.APIManagementException;
+import org.wso2.carbon.apimgt.api.ExceptionCodes;
+
+import java.net.InetAddress;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Direct unit tests for the core network-security-access-control decision logic in
+ * {@link APIUtil} — the private statics {@code applyAccessControlPolicy},
+ * {@code isHostInList}, {@code isPrivateNetworkAddress}, {@code toWildcardRegex}.
+ * These are the heart of the SSRF gate and previously had no direct coverage (only slow
+ * integration suites / tests that mock {@code APIUtil} away).
+ *
+ * All cases are deterministic: hosts are LITERAL IPs (so {@code InetAddress.getAllByName}
+ * returns them without a DNS lookup), allow/deny hostname matches short-circuit before any
+ * resolution, and the unknown-host case uses a guaranteed-non-resolving {@code .invalid} name.
+ */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({APIUtil.class})
+public class APIUtilAccessControlPolicyTest {
+
+    private static final String PUBLIC_IP = "93.184.216.34";   // literal public IP, no DNS
+    private static final String PUBLIC_IP2 = "8.8.8.8";
+
+    private static List<String> list(String... v) {
+        return new ArrayList<>(Arrays.asList(v));
+    }
+
+    /** @return true if applyAccessControlPolicy BLOCKS the host (throws), false if it allows. */
+    private boolean blocked(String host, String mode, List<String> hosts, boolean blockPrivate) throws Exception {
+        try {
+            Whitebox.invokeMethod(APIUtil.class, "applyAccessControlPolicy", host, mode, hosts, blockPrivate);
+            return false;
+        } catch (APIManagementException e) {
+            return true;
+        }
+    }
+
+    private boolean hostInList(String host, List<String> hosts) throws Exception {
+        return (Boolean) Whitebox.invokeMethod(APIUtil.class, "isHostInList", host, hosts);
+    }
+
+    private boolean isPrivate(String ip) throws Exception {
+        return (Boolean) Whitebox.invokeMethod(APIUtil.class, "isPrivateNetworkAddress", InetAddress.getByName(ip));
+    }
+
+    // ---------------------------------------------------------------- allow mode
+
+    @Test
+    public void allowMode_listedLiteralIp_isAllowed() throws Exception {
+        Assert.assertFalse(blocked(PUBLIC_IP, "allow", list(PUBLIC_IP), false));
+    }
+
+    @Test
+    public void allowMode_unlistedLiteralIp_isBlocked() throws Exception {
+        Assert.assertTrue(blocked(PUBLIC_IP, "allow", list(PUBLIC_IP2), false));
+    }
+
+    @Test
+    public void allowMode_emptyHosts_failsClosed() throws Exception {
+        Assert.assertTrue(blocked(PUBLIC_IP, "allow", list(), true));
+    }
+
+    @Test
+    public void allowMode_wildcardHostnameMatch_isAllowedWithoutDns() throws Exception {
+        Assert.assertFalse(blocked("sub.example.com", "allow", list("*.example.com"), false));
+    }
+
+    @Test
+    public void allowMode_caseInsensitiveMatch() throws Exception {
+        Assert.assertFalse(blocked("API.WSO2.COM", "allow", list("*.wso2.com"), false));
+    }
+
+    @Test
+    public void allowMode_ignoresBlockPrivate_listedPrivateIpAllowed() throws Exception {
+        Assert.assertFalse(blocked("10.0.0.1", "allow", list("10.0.0.1"), true));
+    }
+
+    // ---------------------------------------------------------------- deny mode
+
+    @Test
+    public void denyMode_listedWildcardHost_isBlocked() throws Exception {
+        Assert.assertTrue(blocked("169.254.169.254", "deny", list("169.254.*"), false));
+    }
+
+    @Test
+    public void denyMode_unlistedPublicIp_isAllowed() throws Exception {
+        Assert.assertFalse(blocked(PUBLIC_IP, "deny", list("169.254.*"), true));
+    }
+
+    @Test
+    public void denyMode_privateIp_blockPrivateOn_isBlocked() throws Exception {
+        Assert.assertTrue(blocked("10.0.0.1", "deny", list(), true));
+    }
+
+    @Test
+    public void denyMode_privateIp_blockPrivateOff_isAllowed() throws Exception {
+        Assert.assertFalse(blocked("10.0.0.1", "deny", list("169.254.*"), false));
+    }
+
+    // ---------------------------------------------------------------- blank/absent mode
+
+    @Test
+    public void blankMode_privateIp_blockPrivateOn_isBlocked() throws Exception {
+        Assert.assertTrue(blocked("192.168.1.1", "", list(), true));
+    }
+
+    @Test
+    public void blankMode_publicIp_blockPrivateOn_isAllowed() throws Exception {
+        Assert.assertFalse(blocked(PUBLIC_IP, null, list(), true));
+    }
+
+    @Test
+    public void blankMode_privateIp_blockPrivateOff_isAllowed() throws Exception {
+        Assert.assertFalse(blocked("10.0.0.1", "", list(), false));
+    }
+
+    // ---------------------------------------------------------------- misconfiguration + fail-closed
+
+    @Test
+    public void garbageMode_isBlockedAsMisconfigured() throws Exception {
+        boolean threw = false;
+        try {
+            Whitebox.invokeMethod(APIUtil.class, "applyAccessControlPolicy", PUBLIC_IP, "garbage", list(), false);
+        } catch (APIManagementException e) {
+            threw = true;
+            Assert.assertEquals("garbage mode must surface the MISCONFIGURED error code",
+                    ExceptionCodes.NETWORK_SECURITY_ACCESS_CONTROL_MISCONFIGURED.getErrorCode(),
+                    e.getErrorHandler().getErrorCode());
+        }
+        Assert.assertTrue("a garbage mode value must block", threw);
+    }
+
+    @Test
+    public void unknownHost_allowMode_failsClosed() throws Exception {
+        Assert.assertTrue(blocked("nonexistent-host-xyz.invalid", "allow", list(PUBLIC_IP2), false));
+    }
+
+    @Test
+    public void unknownHost_denyMode_failsClosed() throws Exception {
+        Assert.assertTrue(blocked("nonexistent-host-xyz.invalid", "deny", list("169.254.*"), true));
+    }
+
+    // ---------------------------------------------------------------- wildcard matching (pure)
+
+    @Test
+    public void wildcard_subdomainMatchesButParentDoesNot() throws Exception {
+        Assert.assertTrue(hostInList("sub.example.com", list("*.example.com")));
+        Assert.assertFalse("'*.example.com' must NOT match the bare parent", hostInList("example.com", list("*.example.com")));
+        Assert.assertFalse("'*.example.com' must NOT match a same-suffix different host",
+                hostInList("evilexample.com", list("*.example.com")));
+    }
+
+    @Test
+    public void wildcard_middleAndStar() throws Exception {
+        Assert.assertTrue(hostInList("api.test.com", list("api.*.com")));
+        Assert.assertTrue("'*' matches any host", hostInList("anything.anywhere", list("*")));
+    }
+
+    @Test
+    public void wildcard_dotIsLiteralNotRegexAny() throws Exception {
+        Assert.assertFalse(hostInList("axb", list("a.b")));
+        Assert.assertTrue(hostInList("a.b", list("a.b")));
+    }
+
+    @Test
+    public void toWildcardRegex_producesAnchoredMatchingRegex() throws Exception {
+        String regex = (String) Whitebox.invokeMethod(APIUtil.class, "toWildcardRegex", "*.x.com");
+        Assert.assertTrue("sub.x.com".matches(regex));
+        Assert.assertFalse("sub.x.com.evil.com".matches(regex)); // anchored at end
+    }
+
+    // ---------------------------------------------------------------- private-range detection
+
+    @Test
+    public void privateRanges_areFlagged() throws Exception {
+        Assert.assertTrue(isPrivate("127.0.0.1"));   // IPv4 loopback
+        Assert.assertTrue(isPrivate("::1"));          // IPv6 loopback
+        Assert.assertTrue(isPrivate("10.0.0.1"));     // RFC1918 /8
+        Assert.assertTrue(isPrivate("172.16.0.1"));   // RFC1918 /12
+        Assert.assertTrue(isPrivate("192.168.1.1"));  // RFC1918 /16
+        Assert.assertTrue(isPrivate("169.254.0.1"));  // link-local
+        Assert.assertTrue(isPrivate("224.0.0.1"));    // multicast
+        Assert.assertTrue(isPrivate("0.0.0.0"));      // any-local
+        Assert.assertTrue(isPrivate("fc00::1"));      // IPv6 ULA fc00::/7
+        Assert.assertTrue(isPrivate("fd00::1"));      // IPv6 ULA fc00::/7
+    }
+
+    @Test
+    public void publicAddresses_areNotFlagged() throws Exception {
+        Assert.assertFalse(isPrivate(PUBLIC_IP));
+        Assert.assertFalse(isPrivate(PUBLIC_IP2));
+    }
+
+    // ---------------------------------------------------------------- KNOWN-LIMITATION guards (deferred fixes)
+
+    @Test
+    public void knownLimitation_G6_ipv6DenyEntryDoesNotMatchExpandedResolvedForm() throws Exception {
+        // G6: IPv6 literal deny entries dead vs expanded resolved form. Deferred.
+        Assert.assertFalse(hostInList("0:0:0:0:0:0:0:1", list("::1")));
+    }
+
+    @Test
+    public void knownLimitation_G7_trailingDotFqdnBypassesNameDenyList() throws Exception {
+        // G7: trailing-dot FQDN bypasses name-based deny patterns. Deferred.
+        Assert.assertFalse(hostInList("internal.corp.", list("internal.corp")));
+    }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/utils/APIUtilRefPolicyTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/utils/APIUtilRefPolicyTest.java
@@ -1,0 +1,138 @@
+/*
+ *  Copyright (c) 2026, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.apimgt.impl.utils;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.powermock.reflect.Whitebox;
+import org.wso2.carbon.apimgt.api.model.OASParserOptions;
+import org.wso2.carbon.apimgt.impl.APIManagerConfiguration;
+import org.wso2.carbon.apimgt.impl.APIManagerConfigurationService;
+import org.wso2.carbon.apimgt.impl.internal.ServiceReferenceHolder;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({APIUtil.class, ServiceReferenceHolder.class})
+public class APIUtilRefPolicyTest {
+
+    /**
+     * When a policy is active, {@code populateRefResolutionPolicy} reads the configured OAS import file-size limit
+     * from the API Manager configuration to cap the $ref crawl's per-document fetch. Stub that config chain so the
+     * unit tests can exercise the wiring without standing up the OSGi configuration service.
+     */
+    @Before
+    public void stubFileSizeConfig() {
+        APIManagerConfiguration config = Mockito.mock(APIManagerConfiguration.class);
+        Mockito.when(config.getFirstProperty(Mockito.anyString())).thenReturn("10");
+        APIManagerConfigurationService svc = Mockito.mock(APIManagerConfigurationService.class);
+        Mockito.when(svc.getAPIManagerConfiguration()).thenReturn(config);
+        ServiceReferenceHolder holder = Mockito.mock(ServiceReferenceHolder.class);
+        Mockito.when(holder.getAPIManagerConfigurationService()).thenReturn(svc);
+        PowerMockito.mockStatic(ServiceReferenceHolder.class);
+        PowerMockito.when(ServiceReferenceHolder.getInstance()).thenReturn(holder);
+    }
+
+    /**
+     * Drives {@link APIUtil#populateRefResolutionPolicy(OASParserOptions, String)} with the platform-level
+     * network-security policy toggled on/off and the tenant config stubbed out (null). Returns the populated
+     * options so callers can assert the new ref-validation wiring.
+     */
+    private OASParserOptions run(boolean platformEnabled) throws Exception {
+        PowerMockito.spy(APIUtil.class);
+        PowerMockito.doReturn(null).when(APIUtil.class, "getTenantConfig", org.mockito.ArgumentMatchers.anyString());
+        Whitebox.setInternalState(APIUtil.class, "networkSecurityEnabled", platformEnabled);
+        OASParserOptions o = new OASParserOptions();
+        APIUtil.populateRefResolutionPolicy(o, "carbon.super");
+        return o;
+    }
+
+    @Test public void testPlatformPolicyActiveSetsValidator() throws Exception {
+        OASParserOptions o = run(true);
+        Assert.assertNotNull("A platform policy must wire a ref validator", o.getRefValidator());
+        // fetch hook needed for nested/transitive refs
+        Assert.assertNotNull("A platform policy must wire the crawl HTTP client provider", o.getHttpClientProvider());
+        Assert.assertEquals("carbon.super", o.getRefValidationTenantDomain());
+    }
+
+    @Test public void testNoPolicyLeavesValidatorNull() throws Exception {
+        OASParserOptions o = run(false);
+        Assert.assertNull("With no active policy no ref validator must be set", o.getRefValidator());
+        Assert.assertNull("With no active policy no crawl HTTP client provider must be set",
+                o.getHttpClientProvider());
+        Assert.assertEquals("carbon.super", o.getRefValidationTenantDomain());
+    }
+
+    @Test public void testTenantPolicyActiveSetsValidator() throws Exception {
+        PowerMockito.spy(APIUtil.class);
+        Whitebox.setInternalState(APIUtil.class, "networkSecurityEnabled", false);
+        org.json.simple.JSONObject tenant = new org.json.simple.JSONObject();
+        org.json.simple.JSONObject ac = new org.json.simple.JSONObject();
+        org.json.simple.JSONArray hosts = new org.json.simple.JSONArray();
+        hosts.add("good.com");
+        ac.put("Hosts", hosts);
+        tenant.put("NetworkSecurityAccessControl", ac);
+        PowerMockito.doReturn(tenant).when(APIUtil.class, "getTenantConfig", org.mockito.ArgumentMatchers.anyString());
+        OASParserOptions o = new OASParserOptions();
+        APIUtil.populateRefResolutionPolicy(o, "carbon.super");
+        Assert.assertNotNull("An active tenant policy must wire a ref validator", o.getRefValidator());
+        Assert.assertEquals("carbon.super", o.getRefValidationTenantDomain());
+    }
+
+    @Test public void testPlatformAndTenantBothActiveSetsValidator() throws Exception {
+        PowerMockito.spy(APIUtil.class);
+        Whitebox.setInternalState(APIUtil.class, "networkSecurityEnabled", true);
+        org.json.simple.JSONObject tenant = new org.json.simple.JSONObject();
+        org.json.simple.JSONObject ac = new org.json.simple.JSONObject();
+        ac.put("Mode", "allow");
+        org.json.simple.JSONArray hosts = new org.json.simple.JSONArray();
+        hosts.add("x.com");
+        ac.put("Hosts", hosts);
+        tenant.put("NetworkSecurityAccessControl", ac);
+        PowerMockito.doReturn(tenant).when(APIUtil.class, "getTenantConfig", org.mockito.ArgumentMatchers.anyString());
+        OASParserOptions o = new OASParserOptions();
+        APIUtil.populateRefResolutionPolicy(o, "tenant.com");
+        Assert.assertNotNull(o.getRefValidator());
+        Assert.assertEquals("tenant.com", o.getRefValidationTenantDomain());
+    }
+
+    @Test public void testBuildSetsHook() throws Exception {
+        PowerMockito.spy(APIUtil.class);
+        PowerMockito.doReturn(null).when(APIUtil.class, "getTenantConfig", org.mockito.ArgumentMatchers.anyString());
+        Whitebox.setInternalState(APIUtil.class, "networkSecurityEnabled", true);
+        OASParserOptions o = APIUtil.buildRefAwareOASParserOptions(new OASParserOptions(), "carbon.super");
+        Assert.assertNotNull(o.getRefValidator());
+        Assert.assertNotNull("buildRefAwareOASParserOptions must wire the crawl HTTP client provider when active",
+                o.getHttpClientProvider());
+        Assert.assertEquals("carbon.super", o.getRefValidationTenantDomain());
+    }
+
+    @Test public void testBuildWithNoPolicyLeavesValidatorNull() throws Exception {
+        PowerMockito.spy(APIUtil.class);
+        PowerMockito.doReturn(null).when(APIUtil.class, "getTenantConfig", org.mockito.ArgumentMatchers.anyString());
+        Whitebox.setInternalState(APIUtil.class, "networkSecurityEnabled", false);
+        OASParserOptions o = APIUtil.buildRefAwareOASParserOptions(new OASParserOptions(), "carbon.super");
+        Assert.assertNull(o.getRefValidator());
+        Assert.assertNull(o.getHttpClientProvider());
+        Assert.assertEquals("carbon.super", o.getRefValidationTenantDomain());
+    }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ImportUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ImportUtils.java
@@ -61,6 +61,7 @@ import org.wso2.carbon.apimgt.api.model.Backend;
 import org.wso2.carbon.apimgt.api.model.Documentation;
 import org.wso2.carbon.apimgt.api.model.Environment;
 import org.wso2.carbon.apimgt.api.model.Identifier;
+import org.wso2.carbon.apimgt.api.model.OASParserOptions;
 import org.wso2.carbon.apimgt.api.model.OperationPolicy;
 import org.wso2.carbon.apimgt.api.model.OperationPolicyData;
 import org.wso2.carbon.apimgt.api.model.OperationPolicyDefinition;
@@ -2775,9 +2776,12 @@ public class ImportUtils {
     public static APIDefinitionValidationResponse retrieveValidatedSwaggerDefinition(String swaggerContent)
             throws APIManagementException {
 
+        OASParserOptions parserOptions = APIUtil.buildRefAwareOASParserOptions(
+                ServiceReferenceHolder.getInstance().getAPIMDependencyConfigurationService()
+                        .getAPIMDependencyConfigurations().getOasParserOptions(),
+                RestApiCommonUtil.getLoggedInUserTenantDomain());
         APIDefinitionValidationResponse validationResponse = OASParserUtil.validateAPIDefinition(swaggerContent,
-                Boolean.TRUE, ServiceReferenceHolder.getInstance().getAPIMDependencyConfigurationService()
-                        .getAPIMDependencyConfigurations().getOasParserOptions());
+                Boolean.TRUE, parserOptions);
         if (!validationResponse.isValid()) {
             String errorDescription = "";
             if (validationResponse.getErrorItems().size() > 0) {

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
@@ -3045,7 +3045,8 @@ public class ApisApiServiceImpl implements ApisApiService {
      */
     private String updateSwagger(String apiId, String apiDefinition, String organization)
             throws APIManagementException, FaultGatewaysException {
-        OASParserOptions oasParserOptions = CommonUtil.getOasParserOptions();
+        OASParserOptions oasParserOptions = APIUtil.buildRefAwareOASParserOptions(CommonUtil.getOasParserOptions(),
+                RestApiCommonUtil.getLoggedInUserTenantDomain());
         APIDefinitionValidationResponse response = OASParserUtil.validateAPIDefinition(apiDefinition, true,
                 oasParserOptions);
         if (!response.isValid()) {

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/McpServersApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/McpServersApiServiceImpl.java
@@ -53,6 +53,7 @@ import org.wso2.carbon.apimgt.api.model.Documentation;
 import org.wso2.carbon.apimgt.api.model.DocumentationContent;
 import org.wso2.carbon.apimgt.api.model.Environment;
 import org.wso2.carbon.apimgt.api.model.Label;
+import org.wso2.carbon.apimgt.api.model.OASParserOptions;
 import org.wso2.carbon.apimgt.api.model.OrganizationInfo;
 import org.wso2.carbon.apimgt.api.model.ResourceFile;
 import org.wso2.carbon.apimgt.api.model.ServiceEntry;
@@ -2452,11 +2453,12 @@ public class McpServersApiServiceImpl implements McpServersApiService {
 
             String definition = backendAPIDTO.getDefinition();
             if (StringUtils.isNotBlank(definition)) {
+                OASParserOptions parserOptions = APIUtil.buildRefAwareOASParserOptions(
+                        ServiceReferenceHolder.getInstance().getAPIMDependencyConfigurationService()
+                                .getAPIMDependencyConfigurations().getOasParserOptions(),
+                        RestApiCommonUtil.getLoggedInUserTenantDomain());
                 APIDefinitionValidationResponse validationResponse =
-                        OASParserUtil.validateAPIDefinition(definition, Boolean.TRUE,
-                                ServiceReferenceHolder.getInstance()
-                                        .getAPIMDependencyConfigurationService()
-                                        .getAPIMDependencyConfigurations().getOasParserOptions());
+                        OASParserUtil.validateAPIDefinition(definition, Boolean.TRUE, parserOptions);
                 if (!validationResponse.isValid()) {
                     List<ErrorListItemDTO> errorListItemDTOs =
                             APIMappingUtil.getErrorListItemsDTOsFromErrorHandlers(

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/utils/RestApiPublisherUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/utils/RestApiPublisherUtils.java
@@ -762,8 +762,15 @@ public class RestApiPublisherUtils {
         if (fileDetail != null) {
             fileName = fileDetail.getDataHandler().getName();
         }
-        validationResponse = ApisApiServiceImplUtils.validateOpenAPIDefinition(url, fileInputStream, apiDefinition,
-                fileName, returnContent);
+        try {
+            validationResponse = ApisApiServiceImplUtils.validateOpenAPIDefinition(url, fileInputStream, apiDefinition,
+                    fileName, returnContent, RestApiCommonUtil.getLoggedInUserTenantDomain());
+        } catch (APIManagementException e) {
+            if (e.getErrorHandler() != null && e.getErrorHandler().getHttpStatusCode() == 400) {
+                throw RestApiUtil.buildBadRequestException(e.getErrorHandler().getErrorDescription());
+            }
+            throw e;
+        }
         responseDTO = APIMappingUtil.getOpenAPIDefinitionValidationResponseFromModel(validationResponse,
                 returnContent);
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.service.catalog/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.service.catalog/pom.xml
@@ -196,6 +196,22 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <!-- JDK 17+/21: PowerMock and reflective test mocks require these module opens. -->
+                    <argLine>
+                        --add-opens=java.xml/jdk.xml.internal=ALL-UNNAMED
+                        --add-opens java.base/java.lang=ALL-UNNAMED
+                        --add-opens java.base/java.lang.reflect=ALL-UNNAMED
+                        --add-opens java.base/java.util=ALL-UNNAMED
+                        --add-opens java.base/java.util.concurrent=ALL-UNNAMED
+                        --add-opens java.base/java.util.regex=ALL-UNNAMED
+                        --add-opens java.base/java.net=ALL-UNNAMED
+                        --add-opens java.base/java.io=ALL-UNNAMED
+                        --add-opens java.base/java.security=ALL-UNNAMED
+                        --add-opens java.base/java.text=ALL-UNNAMED
+                        --add-opens java.base/java.math=ALL-UNNAMED
+                    </argLine>
+                </configuration>
                 <dependencies>
                     <dependency>
                         <groupId>org.apache.maven.surefire</groupId>

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.service.catalog/src/main/java/org/wso2/carbon/apimgt/rest/api/service/catalog/impl/ServicesApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.service.catalog/src/main/java/org/wso2/carbon/apimgt/rest/api/service/catalog/impl/ServicesApiServiceImpl.java
@@ -474,6 +474,10 @@ public class ServicesApiServiceImpl implements ServicesApiService {
             validationResponse = AsyncApiParserUtil.validateAsyncAPISpecification(schemaToBeValidated,
                     true, AsyncApiParserImplUtil.getParserOptionsFromConfig());
         } else if (url != null) {
+            // SSRF gate: validate the definition URL before fetching (no-op if policy unconfigured)
+            if (!isRemoteURLTrusted(url, validationResponse)) {
+                return validationResponse;
+            }
             try {
                 URL urlObj = new URL(url);
                 HttpClient httpClient = APIUtil.getHttpClient(urlObj.getPort(), urlObj.getProtocol());
@@ -504,10 +508,15 @@ public class ServicesApiServiceImpl implements ServicesApiService {
     private APIDefinitionValidationResponse validateOpenAPIDefinition(String url, String definitionContent)
             throws APIManagementException {
         APIDefinitionValidationResponse validationResponse = new APIDefinitionValidationResponse();
-        OASParserOptions parserOptions = CommonUtil.getOasParserOptions();
+        OASParserOptions parserOptions = APIUtil.buildRefAwareOASParserOptions(CommonUtil.getOasParserOptions(),
+                RestApiCommonUtil.getLoggedInUserTenantDomain());
         if (definitionContent != null) {
             validationResponse = OASParserUtil.validateAPIDefinition(definitionContent, true, parserOptions);
         } else if (url != null) {
+            // SSRF gate: validate the definition URL before fetching (no-op if policy unconfigured)
+            if (!isRemoteURLTrusted(url, validationResponse)) {
+                return validationResponse;
+            }
             try {
                 URL urlObj = new URL(url);
                 HttpClient httpClient = APIUtil.getHttpClient(urlObj.getPort(), urlObj.getProtocol());
@@ -533,6 +542,35 @@ public class ServicesApiServiceImpl implements ServicesApiService {
         errorDTO.setMoreInfo(info);
         errorDTO.setDescription(description);
         return errorDTO;
+    }
+
+    /**
+     * SSRF gate for the import-by-URL path. Validates the user-supplied top-level definition URL
+     * against the network security access control policy via {@link APIUtil#validateRemoteURL}
+     * BEFORE the URL is fetched. This mirrors the publisher import-by-URL gating
+     * (RestApiPublisherUtils#validateOpenAPIDefinition). It is a no-op when the policy is
+     * unconfigured (validateRemoteURL returns without throwing). When the host is blocked, the
+     * provided {@code validationResponse} is marked invalid and carries the "not trusted" error item
+     * so the caller surfaces a 400-style validation failure (the same outcome as a bad definition).
+     *
+     * @param url                the user-supplied definition URL to gate
+     * @param validationResponse the response to mark invalid (in place) if the URL is not trusted
+     * @return {@code true} if the URL is trusted (fetch may proceed); {@code false} if it was blocked
+     */
+    private boolean isRemoteURLTrusted(String url, APIDefinitionValidationResponse validationResponse) {
+        try {
+            APIUtil.validateRemoteURL(url, RestApiCommonUtil.getLoggedInUserTenantDomain());
+            return true;
+        } catch (APIManagementException e) {
+            log.error("The provided service definition URL is not trusted: " + url, e);
+            validationResponse.setValid(false);
+            if (e.getErrorHandler() != null) {
+                validationResponse.getErrorItems().add(e.getErrorHandler());
+            } else {
+                validationResponse.getErrorItems().add(ExceptionCodes.UNTRUSTED_URL);
+            }
+            return false;
+        }
     }
 
     private APIDefinitionValidationResponse validateAndRetrieveServiceDefinition(byte[] definitionFileByteArray,

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.service.catalog/src/test/java/org/wso2/carbon/apimgt/rest/api/service/catalog/impl/ServicesApiServiceImplTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.service.catalog/src/test/java/org/wso2/carbon/apimgt/rest/api/service/catalog/impl/ServicesApiServiceImplTest.java
@@ -18,16 +18,110 @@
 
 package org.wso2.carbon.apimgt.rest.api.service.catalog.impl;
 
+import org.apache.http.client.HttpClient;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.core.classloader.annotations.SuppressStaticInitializationFor;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.powermock.reflect.Whitebox;
+import org.wso2.carbon.apimgt.api.APIDefinitionValidationResponse;
+import org.wso2.carbon.apimgt.api.APIManagementException;
+import org.wso2.carbon.apimgt.api.ExceptionCodes;
+import org.wso2.carbon.apimgt.api.model.OASParserOptions;
+import org.wso2.carbon.apimgt.impl.importexport.utils.CommonUtil;
+import org.wso2.carbon.apimgt.impl.utils.APIUtil;
+import org.wso2.carbon.apimgt.impl.utils.AsyncApiParserImplUtil;
+import org.wso2.carbon.apimgt.rest.api.common.RestApiCommonUtil;
+import org.wso2.carbon.apimgt.spec.parser.definitions.AsyncApiParserUtil;
+import org.wso2.carbon.apimgt.spec.parser.definitions.OASParserUtil;
 
+import static org.junit.Assert.assertFalse;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.Mockito.never;
+
+/**
+ * Tests that the service-catalog import-by-URL path gates the user-supplied top-level definition
+ * URL through {@link APIUtil#validateRemoteURL(String, String)} (the SSRF gate) BEFORE the URL is
+ * fetched, for both the OpenAPI and AsyncAPI branches. Mirrors the publisher import-by-URL gating.
+ */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({APIUtil.class, RestApiCommonUtil.class, OASParserUtil.class, AsyncApiParserUtil.class,
+        CommonUtil.class, AsyncApiParserImplUtil.class})
+@SuppressStaticInitializationFor("org.wso2.carbon.apimgt.impl.utils.APIUtil")
 public class ServicesApiServiceImplTest {
 
+    private static final String BLOCKED_URL = "http://169.254.169.254/latest/meta-data";
+    private static final String TENANT_DOMAIN = "carbon.super";
+
     @Before
-    public void setUp() {
+    public void setUp() throws Exception {
+        PowerMockito.mockStatic(APIUtil.class);
+        PowerMockito.mockStatic(RestApiCommonUtil.class);
+        PowerMockito.mockStatic(OASParserUtil.class);
+        PowerMockito.mockStatic(AsyncApiParserUtil.class);
+        PowerMockito.mockStatic(CommonUtil.class);
+        PowerMockito.mockStatic(AsyncApiParserImplUtil.class);
+
+        PowerMockito.when(RestApiCommonUtil.getLoggedInUserTenantDomain()).thenReturn(TENANT_DOMAIN);
+        PowerMockito.when(APIUtil.getHttpClient(anyInt(), anyString()))
+                .thenReturn(Mockito.mock(HttpClient.class));
+        PowerMockito.when(CommonUtil.getOasParserOptions()).thenReturn(new OASParserOptions());
+        PowerMockito.when(APIUtil.buildRefAwareOASParserOptions(any(), anyString()))
+                .thenReturn(new OASParserOptions());
     }
 
+    /**
+     * The blocked URL must be rejected by the SSRF gate (APIUtil.validateRemoteURL) BEFORE the
+     * OAS definition is fetched from the URL. Asserts the by-URL fetch is never reached and the
+     * resulting validation response is invalid (so the caller surfaces a 400).
+     */
     @Test
-    public void testCreateService() {
+    public void testValidateOpenAPIDefinitionByUrlBlockedBeforeFetch() throws Exception {
+        PowerMockito.doThrow(new APIManagementException(
+                "The URL " + BLOCKED_URL + " is not trusted", ExceptionCodes.UNTRUSTED_URL))
+                .when(APIUtil.class);
+        APIUtil.validateRemoteURL(eq(BLOCKED_URL), nullable(String.class));
+
+        ServicesApiServiceImpl serviceImpl = new ServicesApiServiceImpl();
+        APIDefinitionValidationResponse response =
+                Whitebox.invokeMethod(serviceImpl, "validateOpenAPIDefinition", BLOCKED_URL, null);
+
+        PowerMockito.verifyStatic(APIUtil.class);
+        APIUtil.validateRemoteURL(eq(BLOCKED_URL), nullable(String.class));
+        PowerMockito.verifyStatic(OASParserUtil.class, never());
+        OASParserUtil.validateAPIDefinitionByURL(anyString(), any(), anyBoolean(), any(), anyString());
+        assertFalse("Blocked URL must yield an invalid definition response", response.isValid());
+    }
+
+    /**
+     * Same contract for the AsyncAPI by-URL branch: the SSRF gate must reject the blocked URL
+     * before AsyncApiParserUtil.validateAsyncAPISpecificationByURL fetches it.
+     */
+    @Test
+    public void testValidateAsyncAPISpecificationByUrlBlockedBeforeFetch() throws Exception {
+        PowerMockito.when(AsyncApiParserImplUtil.getParserOptionsFromConfig()).thenReturn(null);
+        PowerMockito.doThrow(new APIManagementException(
+                "The URL " + BLOCKED_URL + " is not trusted", ExceptionCodes.UNTRUSTED_URL))
+                .when(APIUtil.class);
+        APIUtil.validateRemoteURL(eq(BLOCKED_URL), nullable(String.class));
+
+        ServicesApiServiceImpl serviceImpl = new ServicesApiServiceImpl();
+        APIDefinitionValidationResponse response =
+                Whitebox.invokeMethod(serviceImpl, "validateAsyncAPISpecification", BLOCKED_URL, null);
+
+        PowerMockito.verifyStatic(APIUtil.class);
+        APIUtil.validateRemoteURL(eq(BLOCKED_URL), nullable(String.class));
+        PowerMockito.verifyStatic(AsyncApiParserUtil.class, never());
+        AsyncApiParserUtil.validateAsyncAPISpecificationByURL(anyString(), any(), anyBoolean(), any(), anyString());
+        assertFalse("Blocked URL must yield an invalid definition response", response.isValid());
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.spec.parser/src/main/java/org/wso2/carbon/apimgt/spec/parser/definitions/OAS3Parser.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.spec.parser/src/main/java/org/wso2/carbon/apimgt/spec/parser/definitions/OAS3Parser.java
@@ -962,8 +962,7 @@ public class OAS3Parser extends APIDefinition {
         APIDefinitionValidationResponse validationResponse = new APIDefinitionValidationResponse();
         String processedDefinition = OASParserUtil.preprocessYamlWithLimit(apiDefinition, parserOptions);
         OpenAPIV3Parser openAPIV3Parser = new OpenAPIV3Parser();
-        ParseOptions options = new ParseOptions();
-        options.setResolve(true);
+        ParseOptions options = buildParseOptions(parserOptions, true);
         SwaggerParseResult parseAttemptForV3 = openAPIV3Parser.readContents(processedDefinition, null, options);
         if (CollectionUtils.isNotEmpty(parseAttemptForV3.getMessages())) {
             validationResponse.setValid(false);
@@ -2034,8 +2033,22 @@ public class OAS3Parser extends APIDefinition {
     }
 
     private ParseOptions convertOptionsToParseOptions(OASParserOptions options) {
+        // resolve=false: getOpenAPI does not fetch external refs
+        return buildParseOptions(options, false);
+    }
+
+    /**
+     * Single source of truth for swagger-parser ParseOptions. SSRF protection for remote {@code $ref}s is enforced
+     * upstream of the parser by the recursive validation crawl ({@code OASParserUtil#validateRemoteRefsRecursively}),
+     * not by any library-side URL validator. This uses the stock parser only — no {@code setSafelyResolveURL} /
+     * {@code setCustomUrlValidator} (those required the forked/patched library, which has been dropped).
+     */
+    public static ParseOptions buildParseOptions(OASParserOptions options, boolean resolve) {
         ParseOptions parserOptions = new ParseOptions();
-        parserOptions.setExplicitStyleAndExplode(options.isExplicitStyleAndExplode());
+        parserOptions.setResolve(resolve);
+        if (options != null) {
+            parserOptions.setExplicitStyleAndExplode(options.isExplicitStyleAndExplode());
+        }
         return parserOptions;
     }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.spec.parser/src/main/java/org/wso2/carbon/apimgt/spec/parser/definitions/OASParserUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.spec.parser/src/main/java/org/wso2/carbon/apimgt/spec/parser/definitions/OASParserUtil.java
@@ -62,6 +62,8 @@ import io.swagger.v3.parser.ObjectMapperFactory;
 import io.swagger.v3.parser.OpenAPIV3Parser;
 import io.swagger.v3.parser.converter.SwaggerConverter;
 import io.swagger.v3.parser.core.models.ParseOptions;
+import io.swagger.v3.parser.core.models.SwaggerParseResult;
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
@@ -69,6 +71,9 @@ import org.apache.commons.logging.LogFactory;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
 import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.util.EntityUtils;
 import org.json.JSONArray;
@@ -100,20 +105,25 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URI;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * Provide common functions related to OAS
@@ -999,15 +1009,28 @@ public class OASParserUtil {
         } catch (IOException e) {
             throw new APIManagementException("Error reading master swagger file" + e);
         }
+        validateArchiveRemoteRefs(archiveDirectory, oasParserOptions);
         String openAPIContent = "";
         SwaggerVersion version;
         version = getSwaggerVersion(content);
         String filePath = masterSwagger.getAbsolutePath();
         if (SwaggerVersion.OPEN_API.equals(version)) {
             OpenAPIV3Parser openAPIV3Parser = new OpenAPIV3Parser();
-            ParseOptions options = new ParseOptions();
-            options.setResolve(true);
-            OpenAPI openAPI = openAPIV3Parser.read(filePath, null, options);
+            ParseOptions options = OAS3Parser.buildParseOptions(oasParserOptions, true);
+            SwaggerParseResult result = openAPIV3Parser.readLocation(filePath, null, options);
+            if (result.getOpenAPI() == null || CollectionUtils.isNotEmpty(result.getMessages())) {
+                APIDefinitionValidationResponse invalid = new APIDefinitionValidationResponse();
+                invalid.setValid(false);
+                if (CollectionUtils.isNotEmpty(result.getMessages())) {
+                    for (String m : result.getMessages()) {
+                        addErrorToValidationResponse(invalid, m);
+                    }
+                } else {
+                    addErrorToValidationResponse(invalid, "Could not resolve the OpenAPI archive references");
+                }
+                return invalid;
+            }
+            OpenAPI openAPI = result.getOpenAPI();
             openAPIContent = convertOAStoJSON(openAPI);
         } else if (SwaggerVersion.SWAGGER.equals(version)) {
             SwaggerParser parser = new SwaggerParser();
@@ -1089,6 +1112,7 @@ public class OASParserUtil {
     @UsedByMigrationClient
     public static APIDefinitionValidationResponse validateAPIDefinition(String apiDefinition, boolean returnJsonContent,
             OASParserOptions oasParserOptions) throws APIManagementException {
+        validateRemoteRefsRecursively(apiDefinition, null, oasParserOptions);
         String apiDefinitionProcessed = apiDefinition;
         if (!apiDefinition.trim().startsWith("{")) {
             try {
@@ -1307,6 +1331,7 @@ public class OASParserUtil {
                         buffer.write(chunk, 0, n);
                     }
                     String responseStr = buffer.toString(StandardCharsets.UTF_8.name());
+                    validateRemoteRefsRecursively(responseStr, url, oasParserOptions);
                     String responseStrProcessed = responseStr;
                     if (!responseStr.trim().startsWith("{")) {
                         try {
@@ -2350,4 +2375,328 @@ public class OASParserUtil {
             throw new APIManagementException("Error while parsing YAML with configured codePointLimit", e);
         }
     }
+
+    /**
+     * Collect every {@code $ref} string that has a file/URL part (absolute or relative); ignore pure "#/..."
+     * in-document fragments. Never throws on malformed content (JSON parse with a YAML fallback; returns what it
+     * could parse / empty).
+     *
+     * @param content raw OpenAPI/Swagger definition (JSON or YAML)
+     * @return set of raw $ref strings with a file/URL part (may be empty, never null)
+     */
+    static Set<String> extractRefStrings(String content) {
+        Set<String> refs = new LinkedHashSet<>();
+        if (StringUtils.isBlank(content)) {
+            return refs;
+        }
+        JsonNode root;
+        try {
+            root = new ObjectMapper().readTree(content);
+        } catch (Exception jsonEx) {
+            try {
+                root = new ObjectMapper(new YAMLFactory()).readTree(content);
+            } catch (Exception yamlEx) {
+                if (log.isDebugEnabled()) {
+                    log.debug("Could not parse content to extract $refs", yamlEx);
+                }
+                return refs;
+            }
+        }
+        collectRefStrings(root, refs);
+        return refs;
+    }
+
+    private static void collectRefStrings(JsonNode node, Set<String> refs) {
+        if (node == null) {
+            return;
+        }
+        if (node.isObject()) {
+            JsonNode ref = node.get("$ref");
+            if (ref != null && ref.isTextual()) {
+                String value = ref.textValue().trim();
+                if (!value.isEmpty() && !value.startsWith("#")) {
+                    refs.add(value);
+                }
+            }
+            Iterator<JsonNode> it = node.elements();
+            while (it.hasNext()) {
+                collectRefStrings(it.next(), refs);
+            }
+        } else if (node.isArray()) {
+            for (JsonNode child : node) {
+                collectRefStrings(child, refs);
+            }
+        }
+    }
+
+    /**
+     * Resolve a raw {@code $ref} to an absolute http(s) URL, or {@code null} if it is in-document, non-http, or an
+     * unfollowable relative ref. Absolute http(s) refs pass through (fragment stripped); relative refs resolve against
+     * {@code baseUri} only when that base is itself a remote http(s) URL.
+     *
+     * @param rawRef  raw $ref string (may include a "#/..." fragment)
+     * @param baseUri the base URI for relative resolution, or {@code null}
+     * @return absolute http(s) URL, or {@code null} when not a followable remote ref
+     */
+    static String resolveToHttpUrl(String rawRef, String baseUri) {
+        if (rawRef == null) {
+            return null;
+        }
+        String filePart = rawRef.split("#", 2)[0].trim();
+        if (filePart.isEmpty()) {
+            return null;
+        }
+        String lower = filePart.toLowerCase(Locale.ROOT);
+        if (lower.startsWith("http://") || lower.startsWith("https://")) {
+            return filePart;
+        }
+        if (baseUri == null) {
+            return null;
+        }
+        try {
+            URI base = URI.create(baseUri);
+            String baseScheme = base.getScheme();
+            if (baseScheme == null
+                    || !(baseScheme.equalsIgnoreCase("http") || baseScheme.equalsIgnoreCase("https"))) {
+                return null;
+            }
+            URI resolved = base.resolve(filePart);
+            String scheme = resolved.getScheme();
+            if (scheme != null && (scheme.equalsIgnoreCase("http") || scheme.equalsIgnoreCase("https"))) {
+                return resolved.toString();
+            }
+            return null;
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
+    }
+
+    /**
+     * Build the visited-set dedup key for an absolute URL. Only the scheme and authority (host[:port]) are
+     * case-folded; the path and query are kept verbatim because they are case-sensitive on the origin server
+     * (e.g. {@code /A} and {@code /a} can be distinct resources). Lowercasing the whole URL would let a
+     * case-distinct path collide and be skipped, leaving its nested $refs unscanned — an under-validation vector.
+     *
+     * @param absUrl an absolute http(s) URL
+     * @return a normalized key safe for dedup
+     */
+    static String dedupKey(String absUrl) {
+        try {
+            URI u = URI.create(absUrl);
+            String scheme = u.getScheme() == null ? "" : u.getScheme().toLowerCase(Locale.ROOT);
+            String authority = u.getRawAuthority() == null ? "" : u.getRawAuthority().toLowerCase(Locale.ROOT);
+            String rest = absUrl.substring(scheme.length());
+            String afterScheme = rest.startsWith("://") ? rest.substring(3) : rest;
+            // authority ends at the first '/', '?', or '#' — keep the query even on a path-less URL
+            int authorityEnd = afterScheme.length();
+            for (char delim : new char[] {'/', '?', '#'}) {
+                int i = afterScheme.indexOf(delim);
+                if (i >= 0 && i < authorityEnd) {
+                    authorityEnd = i;
+                }
+            }
+            String tail = afterScheme.substring(authorityEnd);
+            return scheme + "://" + authority + tail;
+        } catch (IllegalArgumentException e) {
+            // unparseable URL: fall back to the exact string (never under-dedup)
+            return absUrl;
+        }
+    }
+
+    // Timeouts + redirect bound aligned with swagger-parser's RemoteUrl; no depth/total-ref cap (visited-set terminates cycles).
+    private static final int REF_CRAWL_CONNECT_TIMEOUT_MS = 30000;
+    private static final int REF_CRAWL_READ_TIMEOUT_MS = 60000;
+    private static final int REF_CRAWL_MAX_REDIRECTS = 5;
+    // fallback size cap, used only when the configured OAS import limit isn't carried on the options (e.g. a unit test)
+    private static final int REF_CRAWL_MAX_BYTES = 10 * 1024 * 1024;
+
+    /**
+     * Recursively validate (and, to discover nested refs, fetch) every remote {@code $ref} reachable from
+     * {@code content}. No-op when policy is inactive (no RefValidator hook set). Fail-closed: the first blocked ref
+     * or any fetch/IO error on an allowed ref aborts the whole crawl. There is no depth or total-ref cap (matching
+     * swagger-parser); the visited-set terminates cycles.
+     *
+     * @param content the raw OpenAPI/Swagger definition to scan
+     * @param baseUri  the base URI of {@code content} for resolving relative refs, or {@code null}
+     * @param options  parser options carrying the RefValidator + HttpClientProvider hooks
+     * @throws APIManagementException UNTRUSTED_URL (HTTP 400) on a blocked ref; generic on a fetch error
+     */
+    public static void validateRemoteRefsRecursively(String content, String baseUri, OASParserOptions options)
+            throws APIManagementException {
+        if (options == null || options.getRefValidator() == null) {
+            return;
+        }
+        Map<String, CloseableHttpClient> clients = new HashMap<>();
+        try {
+            crawlRefs(content, baseUri, options, new HashSet<>(), clients);
+        } finally {
+            closeCrawlClients(clients);
+        }
+    }
+
+    private static void crawlRefs(String content, String baseUri, OASParserOptions options,
+                                 Set<String> visited, Map<String, CloseableHttpClient> clients)
+            throws APIManagementException {
+        for (String rawRef : extractRefStrings(content)) {
+            String absUrl = resolveToHttpUrl(rawRef, baseUri);
+            if (absUrl == null) {
+                continue;
+            }
+            if (!visited.add(dedupKey(absUrl))) {
+                continue;
+            }
+            // validate BEFORE any fetch — throws UNTRUSTED_URL on block
+            options.getRefValidator().validate(absUrl, options.getRefValidationTenantDomain());
+
+            if (options.getHttpClientProvider() == null) {
+                // validate-only fallback (no client wired) — unit-test path; prod always wires both hooks
+                continue;
+            }
+            FetchedRef fetched = fetchRefForValidation(absUrl, options, visited, 0, clients);
+            // recurse with the post-redirect final URL as the base for relative refs
+            crawlRefs(fetched.body, fetched.finalUrl, options, visited, clients);
+        }
+    }
+
+    /** A fetched remote document plus the URL it was ultimately served from (after any followed redirects). */
+    private static final class FetchedRef {
+        private final String body;
+        private final String finalUrl;
+        private FetchedRef(String body, String finalUrl) {
+            this.body = body;
+            this.finalUrl = finalUrl;
+        }
+    }
+
+    /**
+     * Fetch a validated ref with redirects disabled; on 3xx, re-validate and follow the Location manually (bounded).
+     * Returns the body together with the final URL it was served from. Fail-closed on any error.
+     */
+    private static FetchedRef fetchRefForValidation(String url, OASParserOptions options, Set<String> visited,
+                                                    int redirects, Map<String, CloseableHttpClient> clients)
+            throws APIManagementException {
+        if (redirects > REF_CRAWL_MAX_REDIRECTS) {
+            throw new APIManagementException("Too many redirects resolving $ref: " + url, ExceptionCodes.UNTRUSTED_URL);
+        }
+        String redirectTarget = null;
+        String body = null;
+        try {
+            URL u = new URL(url);
+            CloseableHttpClient client = crawlClientFor(u.getProtocol(), u.getPort(), options, clients);
+            HttpGet get = new HttpGet(url);
+            get.setConfig(RequestConfig.custom()
+                    .setRedirectsEnabled(false)
+                    .setSocketTimeout(REF_CRAWL_READ_TIMEOUT_MS)
+                    .setConnectTimeout(REF_CRAWL_CONNECT_TIMEOUT_MS)
+                    .build());
+            try (CloseableHttpResponse response = client.execute(get)) {
+                int status = response.getStatusLine().getStatusCode();
+                if (status >= 300 && status < 400) {
+                    org.apache.http.Header location = response.getFirstHeader("Location");
+                    if (location == null) {
+                        throw new APIManagementException("Redirect without Location for $ref: " + url);
+                    }
+                    redirectTarget = resolveToHttpUrl(location.getValue(), url);
+                    if (redirectTarget == null) {
+                        throw new APIManagementException("Unsupported redirect target for $ref: " + url);
+                    }
+                } else if (status != 200) {
+                    throw new APIManagementException("Failed to fetch $ref (HTTP " + status + "): " + url);
+                } else {
+                    body = readBodyCapped(response, options.getRefFetchMaxBytes());
+                }
+            }
+        } catch (IOException e) {
+            throw new APIManagementException("Error fetching $ref for validation: " + url, e);
+        }
+        if (redirectTarget != null) {
+            // re-validate the redirect target before following
+            options.getRefValidator().validate(redirectTarget, options.getRefValidationTenantDomain());
+            visited.add(dedupKey(redirectTarget));
+            return fetchRefForValidation(redirectTarget, options, visited, redirects + 1, clients);
+        }
+        return new FetchedRef(body, url);
+    }
+
+    private static String readBodyCapped(HttpResponse response, long maxBytes)
+            throws IOException, APIManagementException {
+        if (response.getEntity() == null) {
+            return "";
+        }
+        // >0 ? configured cap : fallback — never hand a 0-byte limit to SizeLimitedInputStream (would over-block)
+        long limit = maxBytes > 0 ? maxBytes : REF_CRAWL_MAX_BYTES;
+        try (InputStream rawStream = response.getEntity().getContent();
+                SizeLimitedInputStream in = new SizeLimitedInputStream(rawStream, limit);
+                ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+            byte[] buf = new byte[8192];
+            int n;
+            while ((n = in.read(buf)) != -1) {
+                out.write(buf, 0, n);
+            }
+            return out.toString(StandardCharsets.UTF_8.name());
+        } catch (FileSizeLimitExceededException e) {
+            throw new APIManagementException("Remote $ref document exceeds the size limit", e);
+        }
+    }
+
+    /**
+     * Scan EVERY bundled file under an extracted archive and crawl its remote {@code $ref}s through a shared
+     * visited-set. The stock parser resolves a local {@code $ref} to <em>any</em> file path regardless of
+     * extension, so a remote {@code $ref} hidden in a non-{@code .json}/{@code .yaml} file must still be validated;
+     * {@code extractRefStrings} no-ops on content it cannot parse, so non-OAS files contribute nothing. No-op when
+     * policy is inactive. Fail-closed.
+     *
+     * @param extractRoot the directory the archive was extracted into (parent of the master swagger file)
+     * @param options     parser options carrying the RefValidator + HttpClientProvider hooks
+     * @throws APIManagementException UNTRUSTED_URL on a blocked ref; generic on a fetch/scan error
+     */
+    public static void validateArchiveRemoteRefs(File extractRoot, OASParserOptions options)
+            throws APIManagementException {
+        if (options == null || options.getRefValidator() == null || extractRoot == null
+                || !extractRoot.isDirectory()) {
+            return;
+        }
+        Set<String> visited = new HashSet<>();
+        Map<String, CloseableHttpClient> clients = new HashMap<>();
+        try (Stream<java.nio.file.Path> paths = Files.walk(extractRoot.toPath())) {
+            for (java.nio.file.Path p : (Iterable<java.nio.file.Path>) paths::iterator) {
+                File f = p.toFile();
+                if (!f.isFile()) {
+                    continue;
+                }
+                String content = new String(Files.readAllBytes(p), StandardCharsets.UTF_8);
+                // base = null: only absolute http(s) refs in each file are followed
+                crawlRefs(content, null, options, visited, clients);
+            }
+        } catch (IOException e) {
+            throw new APIManagementException("Error scanning archive for remote $refs", e);
+        } finally {
+            closeCrawlClients(clients);
+        }
+    }
+
+    /** Reuse one crawl HTTP client per protocol:port for the duration of a single crawl. */
+    private static CloseableHttpClient crawlClientFor(String protocol, int port, OASParserOptions options,
+                                                      Map<String, CloseableHttpClient> clients)
+            throws APIManagementException {
+        String key = protocol + ":" + port;
+        CloseableHttpClient client = clients.get(key);
+        if (client == null) {
+            client = (CloseableHttpClient) options.getHttpClientProvider().getClient(protocol, port);
+            clients.put(key, client);
+        }
+        return client;
+    }
+
+    /** Close every HTTP client (and its connection pool) created during a crawl. */
+    private static void closeCrawlClients(Map<String, CloseableHttpClient> clients) {
+        for (CloseableHttpClient client : clients.values()) {
+            try {
+                client.close();
+            } catch (IOException e) {
+                log.warn("Error closing remote-$ref crawl HTTP client", e);
+            }
+        }
+    }
+
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.spec.parser/src/test/java/org/wso2/carbon/apimgt/spec/parser/definitions/OAS3ParserTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.spec.parser/src/test/java/org/wso2/carbon/apimgt/spec/parser/definitions/OAS3ParserTest.java
@@ -80,7 +80,6 @@ public class OAS3ParserTest extends OASTestBase {
         String oas3Resources = IOUtils.toString(getClass().getClassLoader().getResourceAsStream(relativePath), "UTF-8");
         OpenAPIV3Parser openAPIV3Parser = new OpenAPIV3Parser();
 
-        // check remove vendor extensions
         String definition = testGenerateAPIDefinitionWithExtension(oas3Parser, oas3Resources);
         SwaggerParseResult parseAttemptForV3 = openAPIV3Parser.readContents(definition, null, null);
         OpenAPI openAPI = parseAttemptForV3.getOpenAPI();
@@ -98,11 +97,9 @@ public class OAS3ParserTest extends OASTestBase {
             }
         }
 
-        // check updated scopes in security definition
         Operation itemGet = openAPI.getPaths().get("/items").getGet();
         Assert.assertTrue(itemGet.getSecurity().get(0).get("default").contains("newScope"));
 
-        // check available scopes in security definition
         SecurityScheme securityScheme = openAPI.getComponents().getSecuritySchemes().get("default");
         OAuthFlow implicityOauth = securityScheme.getFlows().getImplicit();
         Assert.assertTrue(implicityOauth.getScopes().containsKey("newScope"));
@@ -299,29 +296,22 @@ public class OAS3ParserTest extends OASTestBase {
         String response = parser.getOASDefinitionForPublisher(api, oasDefinition);
         Assert.assertEquals(oasDefinitionEdited, response);
     }
-    // Test case for an API with clientCredentials security scheme
     @Test
     public void testProcessOtherSchemeScopesWithClientCredentialsScheme() throws Exception {
         String OPENAPI_SECURITY_SCHEMA_KEY = "default";
         String OPENAPI_DEFAULT_AUTHORIZATION_URL = "https://test.com";
 
-        //Read the API definition file
         String relativePath = "definitions" + File.separator + "oas3" + File.separator
                 + "oas3_client_credential_security_scheme.yaml";
         String swaggerContent = IOUtils.toString(getClass().getClassLoader().getResourceAsStream(relativePath),
                 "UTF-8");
         swaggerContent = oas3Parser.processOtherSchemeScopes(swaggerContent);
         OpenAPI openAPI = oas3Parser.getOpenAPI(swaggerContent);
-        //Take the default security schema, where only the token url is not null
         SecurityScheme defaultSecScheme = openAPI.getComponents().getSecuritySchemes()
                 .get(OPENAPI_SECURITY_SCHEMA_KEY);
-        //Check whether the default security schema is not null
         Assert.assertNotNull(defaultSecScheme);
-        //Check whether the default security flows are not null
         Assert.assertNotNull(defaultSecScheme.getFlows());
-        //Check whether the token url is available
         Assert.assertNotNull(defaultSecScheme.getFlows().getClientCredentials().getTokenUrl());
-        //Check whether the authorization url is null
         Assert.assertNull(defaultSecScheme.getFlows().getClientCredentials().getAuthorizationUrl());
 
     }
@@ -550,5 +540,21 @@ public class OAS3ParserTest extends OASTestBase {
         apiScopes.add(globalScope);
         apiScopes.add(petLocalScope);
         return apiScopes;
+    }
+
+    @Test
+    public void testBuildParseOptionsResolveAndStyle() {
+        // stock parser only: must not wire any library-side SSRF gate
+        OASParserOptions opts = new OASParserOptions();
+        opts.setRefValidationTenantDomain("carbon.super");
+        opts.setRefValidator((url, tenantDomain) -> { });
+        io.swagger.v3.parser.core.models.ParseOptions po = OAS3Parser.buildParseOptions(opts, true);
+        Assert.assertTrue(po.isResolve());
+
+        io.swagger.v3.parser.core.models.ParseOptions noResolve = OAS3Parser.buildParseOptions(opts, false);
+        Assert.assertFalse(noResolve.isResolve());
+
+        io.swagger.v3.parser.core.models.ParseOptions nullOpts = OAS3Parser.buildParseOptions(null, true);
+        Assert.assertTrue(nullOpts.isResolve());
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.spec.parser/src/test/java/org/wso2/carbon/apimgt/spec/parser/definitions/OASArchiveRefTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.spec.parser/src/test/java/org/wso2/carbon/apimgt/spec/parser/definitions/OASArchiveRefTest.java
@@ -1,0 +1,120 @@
+/*
+ *   Copyright (c) 2026, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *   WSO2 Inc. licenses this file to you under the Apache License,
+ *   Version 2.0 (the "License"); you may not use this file except
+ *   in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ *
+ */
+
+package org.wso2.carbon.apimgt.spec.parser.definitions;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.wso2.carbon.apimgt.api.APIManagementException;
+import org.wso2.carbon.apimgt.api.ExceptionCodes;
+import org.wso2.carbon.apimgt.api.model.OASParserOptions;
+
+import java.io.*;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+public class OASArchiveRefTest {
+    @Test
+    public void testArchiveBlockedRefNotFetched() throws Exception {
+        AtomicInteger hits = new AtomicInteger();
+        com.sun.net.httpserver.HttpServer server =
+                com.sun.net.httpserver.HttpServer.create(new java.net.InetSocketAddress("127.0.0.1", 0), 0);
+        server.createContext("/internal.yaml", ex -> { hits.incrementAndGet();
+            byte[] b = "type: object".getBytes(StandardCharsets.UTF_8);
+            ex.sendResponseHeaders(200, b.length); ex.getResponseBody().write(b); ex.close(); });
+        server.start();
+        int port = server.getAddress().getPort();
+        File zip = File.createTempFile("ssrf-arch", ".zip");
+        try (ZipOutputStream zos = new ZipOutputStream(new FileOutputStream(zip))) {
+            zos.putNextEntry(new ZipEntry("api/swagger.yaml"));
+            String master = "openapi: 3.0.0\ninfo: {title: t, version: '1.0'}\npaths:\n  /a:\n    get:\n" +
+                "      responses:\n        '200':\n          description: ok\n          content:\n" +
+                "            application/json:\n              schema:\n" +
+                "                $ref: 'http://127.0.0.1:" + port + "/internal.yaml'\n";
+            zos.write(master.getBytes(StandardCharsets.UTF_8)); zos.closeEntry();
+        }
+        try {
+            OASParserOptions opts = new OASParserOptions();
+            opts.setRefValidationTenantDomain("carbon.super");
+            opts.setRefValidator((url, t) -> {
+                if (url.contains("127.0.0.1")) {
+                    throw new APIManagementException("blocked " + url, ExceptionCodes.UNTRUSTED_URL);
+                }
+            });
+            try (FileInputStream fis = new FileInputStream(zip)) {
+                OASParserUtil.extractAndValidateOpenAPIArchive(fis, false, opts);
+                Assert.fail("expected UNTRUSTED_URL from Layer-1 ref validation on the blocked archive ref");
+            } catch (APIManagementException e) {
+                Assert.assertEquals(ExceptionCodes.UNTRUSTED_URL.getErrorCode(),
+                        e.getErrorHandler().getErrorCode());
+            }
+            Assert.assertEquals(0, hits.get());
+        } finally {
+            server.stop(0);
+            zip.delete();
+        }
+    }
+
+    @Test
+    public void remoteRefInBundledLocalFileIsBlocked() throws Exception {
+        // remote $ref nested in a bundled local sibling
+        AtomicInteger hits = new AtomicInteger();
+        com.sun.net.httpserver.HttpServer server =
+                com.sun.net.httpserver.HttpServer.create(new java.net.InetSocketAddress("127.0.0.1", 0), 0);
+        server.createContext("/secret", ex -> { hits.incrementAndGet();
+            byte[] b = "type: object".getBytes(StandardCharsets.UTF_8);
+            ex.sendResponseHeaders(200, b.length); ex.getResponseBody().write(b); ex.close(); });
+        server.start();
+        int port = server.getAddress().getPort();
+        File zip = File.createTempFile("ssrf-arch-nested", ".zip");
+        try (ZipOutputStream zos = new ZipOutputStream(new FileOutputStream(zip))) {
+            zos.putNextEntry(new ZipEntry("api/swagger.yaml"));
+            String master = "openapi: 3.0.0\ninfo: {title: t, version: '1.0'}\npaths:\n  /a:\n    get:\n" +
+                "      responses:\n        '200':\n          description: ok\n          content:\n" +
+                "            application/json:\n              schema:\n" +
+                "                $ref: './internal.yaml'\n";
+            zos.write(master.getBytes(StandardCharsets.UTF_8)); zos.closeEntry();
+            zos.putNextEntry(new ZipEntry("api/internal.yaml"));
+            String internal = "type: object\nproperties:\n  x:\n    $ref: 'http://127.0.0.1:" + port + "/secret'\n";
+            zos.write(internal.getBytes(StandardCharsets.UTF_8)); zos.closeEntry();
+        }
+        try {
+            OASParserOptions opts = new OASParserOptions();
+            opts.setRefValidationTenantDomain("carbon.super");
+            opts.setRefValidator((url, t) -> {
+                if (url.contains("127.0.0.1")) {
+                    throw new APIManagementException("blocked " + url, ExceptionCodes.UNTRUSTED_URL);
+                }
+            });
+            try (FileInputStream fis = new FileInputStream(zip)) {
+                OASParserUtil.extractAndValidateOpenAPIArchive(fis, false, opts);
+                Assert.fail("expected UNTRUSTED_URL from the remote $ref inside the bundled local file");
+            } catch (APIManagementException e) {
+                Assert.assertEquals(ExceptionCodes.UNTRUSTED_URL.getErrorCode(),
+                        e.getErrorHandler().getErrorCode());
+            }
+            Assert.assertEquals(0, hits.get());
+        } finally {
+            server.stop(0);
+            zip.delete();
+        }
+    }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.spec.parser/src/test/java/org/wso2/carbon/apimgt/spec/parser/definitions/OASRefArchiveSweepTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.spec.parser/src/test/java/org/wso2/carbon/apimgt/spec/parser/definitions/OASRefArchiveSweepTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.carbon.apimgt.spec.parser.definitions;
+
+import com.sun.net.httpserver.HttpServer;
+import org.apache.http.impl.client.HttpClients;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.wso2.carbon.apimgt.api.APIManagementException;
+import org.wso2.carbon.apimgt.api.model.OASParserOptions;
+
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.Executors;
+
+import static org.junit.Assert.fail;
+
+public class OASRefArchiveSweepTest {
+
+    private HttpServer server;
+    private Path root;
+
+    @Before public void setUp() throws Exception {
+        server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.setExecutor(Executors.newCachedThreadPool());
+        server.start();
+        root = Files.createTempDirectory("ssrf-arc");
+    }
+    @After public void tearDown() throws Exception {
+        server.stop(0);
+        Files.walk(root).sorted((a, b) -> b.compareTo(a)).forEach(p -> p.toFile().delete());
+    }
+
+    private OASParserOptions opts() {
+        OASParserOptions o = new OASParserOptions();
+        o.setRefValidationTenantDomain("carbon.super");
+        o.setRefValidator((url, tenant) -> {
+            if (url.contains("blocked.invalid")) {
+                throw new APIManagementException("blocked: " + url);
+            }
+        });
+        o.setHttpClientProvider((protocol, port) -> HttpClients.custom().disableRedirectHandling().build());
+        return o;
+    }
+
+    @Test
+    public void remoteRefHiddenInBundledLocalFileIsCaught() throws Exception {
+        Files.write(root.resolve("swagger.yaml"),
+            "openapi: 3.0.1\ncomponents:\n  schemas:\n    A: { $ref: './internal.yaml' }\n"
+                    .getBytes(StandardCharsets.UTF_8));
+        Files.write(root.resolve("internal.yaml"),
+            "openapi: 3.0.1\ncomponents:\n  schemas:\n    B: { $ref: 'http://blocked.invalid/x.yaml' }\n"
+                    .getBytes(StandardCharsets.UTF_8));
+        try {
+            OASParserUtil.validateArchiveRemoteRefs(root.toFile(), opts());
+            fail("expected block on remote ref inside a bundled local file");
+        } catch (APIManagementException expected) {
+        }
+    }
+
+    @Test
+    public void cleanArchivePasses() throws Exception {
+        Files.write(root.resolve("swagger.yaml"),
+            "openapi: 3.0.1\ncomponents:\n  schemas:\n    A: { $ref: './internal.yaml' }\n"
+                    .getBytes(StandardCharsets.UTF_8));
+        Files.write(root.resolve("internal.yaml"),
+            "openapi: 3.0.1\ncomponents: {}\n".getBytes(StandardCharsets.UTF_8));
+        OASParserUtil.validateArchiveRemoteRefs(root.toFile(), opts());
+    }
+
+    @Test
+    public void remoteRefInNonStandardExtensionFileIsCaught() throws Exception {
+        // local $ref resolves regardless of extension
+        Files.write(root.resolve("swagger.yaml"),
+            "openapi: 3.0.1\ncomponents:\n  schemas:\n    A: { $ref: './internal.def' }\n"
+                    .getBytes(StandardCharsets.UTF_8));
+        Files.write(root.resolve("internal.def"),
+            "openapi: 3.0.1\ncomponents:\n  schemas:\n    B: { $ref: 'http://blocked.invalid/x.yaml' }\n"
+                    .getBytes(StandardCharsets.UTF_8));
+        try {
+            OASParserUtil.validateArchiveRemoteRefs(root.toFile(), opts());
+            fail("expected block on remote ref inside a non-standard-extension bundled file");
+        } catch (APIManagementException expected) {
+        }
+    }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.spec.parser/src/test/java/org/wso2/carbon/apimgt/spec/parser/definitions/OASRefCrawlTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.spec.parser/src/test/java/org/wso2/carbon/apimgt/spec/parser/definitions/OASRefCrawlTest.java
@@ -1,0 +1,238 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.carbon.apimgt.spec.parser.definitions;
+
+import com.sun.net.httpserver.HttpServer;
+import org.apache.http.impl.client.HttpClients;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.wso2.carbon.apimgt.api.APIManagementException;
+import org.wso2.carbon.apimgt.api.model.OASParserOptions;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.function.Predicate;
+
+import static org.junit.Assert.*;
+
+public class OASRefCrawlTest {
+
+    private HttpServer server;
+    private String base;                 // http://127.0.0.1:<port>
+    private final ConcurrentHashMap<String, Integer> hits = new ConcurrentHashMap<>();
+
+    @Before
+    public void start() throws IOException {
+        server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.setExecutor(Executors.newCachedThreadPool());
+        server.start();
+        base = "http://127.0.0.1:" + server.getAddress().getPort();
+    }
+
+    @After
+    public void stop() {
+        server.stop(0);
+    }
+
+    private void serve(String path, int status, String body, String location) {
+        server.createContext(path, ex -> {
+            hits.merge(path, 1, Integer::sum);
+            if (location != null) {
+                ex.getResponseHeaders().add("Location", location);
+            }
+            byte[] b = body == null ? new byte[0] : body.getBytes(StandardCharsets.UTF_8);
+            ex.sendResponseHeaders(status, b.length == 0 ? -1 : b.length);
+            if (b.length > 0) {
+                try (OutputStream os = ex.getResponseBody()) {
+                    os.write(b);
+                }
+            }
+            ex.close();
+        });
+    }
+
+    /** Options whose validator throws UNTRUSTED_URL when allow.test(url) is false; provider returns a redirect-disabled client. */
+    private OASParserOptions opts(Predicate<String> allow) {
+        OASParserOptions o = new OASParserOptions();
+        o.setRefValidationTenantDomain("carbon.super");
+        o.setRefValidator((url, tenant) -> {
+            if (!allow.test(url)) {
+                throw new APIManagementException("blocked: " + url);
+            }
+        });
+        o.setHttpClientProvider((protocol, port) -> HttpClients.custom().disableRedirectHandling().build());
+        return o;
+    }
+
+    private String refDoc(String refUrl) {
+        return "openapi: 3.0.1\ncomponents:\n  schemas:\n    X: { $ref: '" + refUrl + "' }\n";
+    }
+
+    @Test
+    public void allowedTransitiveChainIsFetched() throws Exception {
+        serve("/a.yaml", 200, refDoc(base + "/b.yaml"), null);
+        serve("/b.yaml", 200, "openapi: 3.0.1\ncomponents: {}\n", null);
+        OASParserUtil.validateRemoteRefsRecursively(refDoc(base + "/a.yaml"), null, opts(u -> true));
+        assertEquals(Integer.valueOf(1), hits.get("/a.yaml"));
+        assertEquals(Integer.valueOf(1), hits.get("/b.yaml"));
+    }
+
+    @Test
+    public void transitiveBlockedRefThrowsAndIsNeverFetched() {
+        serve("/a.yaml", 200, refDoc("http://blocked.invalid/evil.yaml"), null);
+        try {
+            OASParserUtil.validateRemoteRefsRecursively(refDoc(base + "/a.yaml"), null,
+                    opts(u -> !u.contains("blocked.invalid")));
+            fail("expected APIManagementException");
+        } catch (APIManagementException expected) {
+            assertEquals(Integer.valueOf(1), hits.get("/a.yaml"));
+        }
+    }
+
+    @Test
+    public void relativeRefUnderRemoteRootIsResolvedAndValidated() {
+        serve("/dir/main.yaml", 200, refDoc("./inner.yaml"), null);     // relative ref
+        serve("/dir/inner.yaml", 200, refDoc("http://blocked.invalid/x"), null);
+        try {
+            OASParserUtil.validateRemoteRefsRecursively(refDoc(base + "/dir/main.yaml"), null,
+                    opts(u -> !u.contains("blocked.invalid")));
+            fail("expected block on transitive ref reached via a relative ref");
+        } catch (APIManagementException expected) {
+            assertEquals(Integer.valueOf(1), hits.get("/dir/main.yaml"));
+            assertEquals(Integer.valueOf(1), hits.get("/dir/inner.yaml"));
+        }
+    }
+
+    @Test
+    public void cycleTerminates() throws Exception {
+        serve("/a.yaml", 200, refDoc(base + "/b.yaml"), null);
+        serve("/b.yaml", 200, refDoc(base + "/a.yaml"), null);     // cycle
+        OASParserUtil.validateRemoteRefsRecursively(refDoc(base + "/a.yaml"), null, opts(u -> true));
+        assertEquals(Integer.valueOf(1), hits.get("/a.yaml"));
+        assertEquals(Integer.valueOf(1), hits.get("/b.yaml"));
+    }
+
+    @Test
+    public void redirectToBlockedHostIsReValidatedAndThrows() {
+        serve("/r.yaml", 302, null, "http://blocked.invalid/x.yaml");
+        try {
+            OASParserUtil.validateRemoteRefsRecursively(refDoc(base + "/r.yaml"), null,
+                    opts(u -> !u.contains("blocked.invalid")));
+            fail("expected block on redirect target");
+        } catch (APIManagementException expected) {
+            assertEquals(Integer.valueOf(1), hits.get("/r.yaml"));
+        }
+    }
+
+    @Test
+    public void caseDistinctPathsAreBothCrawled() throws Exception {
+        // case-sensitive paths must not be deduped (under-validation)
+        serve("/A.yaml", 200, "openapi: 3.0.1\ncomponents: {}\n", null);
+        serve("/a.yaml", 200, "openapi: 3.0.1\ncomponents: {}\n", null);
+        String root = "openapi: 3.0.1\ncomponents:\n  schemas:\n"
+                + "    U: { $ref: '" + base + "/A.yaml' }\n"
+                + "    L: { $ref: '" + base + "/a.yaml' }\n";
+        OASParserUtil.validateRemoteRefsRecursively(root, null, opts(u -> true));
+        assertEquals("upper-case path must be fetched", Integer.valueOf(1), hits.get("/A.yaml"));
+        assertEquals("lower-case path must be fetched", Integer.valueOf(1), hits.get("/a.yaml"));
+    }
+
+    @Test
+    public void hostIsDedupedCaseInsensitively() throws Exception {
+        // scheme+host case-folded, so case-different host dedups to one fetch
+        serve("/x.yaml", 200, "openapi: 3.0.1\ncomponents: {}\n", null);
+        int port = server.getAddress().getPort();
+        String root = "openapi: 3.0.1\ncomponents:\n  schemas:\n"
+                + "    A: { $ref: 'http://127.0.0.1:" + port + "/x.yaml' }\n"
+                + "    B: { $ref: 'HTTP://127.0.0.1:" + port + "/x.yaml' }\n";
+        OASParserUtil.validateRemoteRefsRecursively(root, null, opts(u -> true));
+        assertEquals("host/scheme case variants must dedup to one fetch", Integer.valueOf(1), hits.get("/x.yaml"));
+    }
+
+    @Test
+    public void wideFanOutIsFullyCrawled() throws Exception {
+        // no total-ref cap (matching swagger-parser)
+        StringBuilder sb = new StringBuilder("openapi: 3.0.1\ncomponents:\n  schemas:\n");
+        for (int i = 0; i < 150; i++) {
+            serve("/n" + i + ".yaml", 200, "openapi: 3.0.1\ncomponents: {}\n", null);
+            sb.append("    S").append(i).append(": { $ref: '").append(base).append("/n").append(i).append(".yaml' }\n");
+        }
+        OASParserUtil.validateRemoteRefsRecursively(sb.toString(), null, opts(u -> true));
+        for (int i = 0; i < 150; i++) {
+            assertEquals("ref n" + i + " must be fetched (no ref-count cap)", Integer.valueOf(1),
+                    hits.get("/n" + i + ".yaml"));
+        }
+    }
+
+    @Test
+    public void deepRefChainIsFullyCrawled() throws Exception {
+        // no depth cap (matching swagger-parser)
+        int depth = 25;
+        for (int i = 0; i < depth; i++) {
+            serve("/c" + i + ".yaml", 200, refDoc(base + "/c" + (i + 1) + ".yaml"), null);
+        }
+        serve("/c" + depth + ".yaml", 200, "openapi: 3.0.1\ncomponents: {}\n", null);   // leaf
+        OASParserUtil.validateRemoteRefsRecursively(refDoc(base + "/c0.yaml"), null, opts(u -> true));
+        assertEquals(Integer.valueOf(1), hits.get("/c0.yaml"));
+        assertEquals("a chain deeper than the old depth-10 cap must be fully followed", Integer.valueOf(1),
+                hits.get("/c" + depth + ".yaml"));
+    }
+
+    @Test
+    public void oversizedRefBodyFailsClosed() {
+        String big = "openapi: 3.0.1\ncomponents: {}\n# " + new String(new char[4000]).replace('\0', 'x') + "\n";
+        serve("/big.yaml", 200, big, null);
+        OASParserOptions o = opts(u -> true);
+        o.setRefFetchMaxFileSize("0.001");   // ~1048 bytes; body exceeds
+        try {
+            OASParserUtil.validateRemoteRefsRecursively(refDoc(base + "/big.yaml"), null, o);
+            fail("expected fail-closed on oversized ref body");
+        } catch (APIManagementException expected) {
+            assertTrue("message should explain the size limit",
+                    expected.getMessage() != null && expected.getMessage().contains("exceeds the size limit"));
+            assertEquals("oversized ref is still fetched (blocked during read, not pre-fetch)",
+                    Integer.valueOf(1), hits.get("/big.yaml"));
+        }
+    }
+
+    @Test
+    public void refBodyWithinConfiguredCapIsFetched() throws Exception {
+        serve("/small.yaml", 200, "openapi: 3.0.1\ncomponents: {}\n", null);
+        OASParserOptions o = opts(u -> true);
+        o.setRefFetchMaxFileSize("0.001");   // ~1048 bytes; body under cap
+        OASParserUtil.validateRemoteRefsRecursively(refDoc(base + "/small.yaml"), null, o);
+        assertEquals(Integer.valueOf(1), hits.get("/small.yaml"));
+    }
+
+    @Test
+    public void redirectTargetIsDedupedAgainstDirectRef() throws Exception {
+        serve("/leaf.yaml", 200, "openapi: 3.0.1\ncomponents: {}\n", null);
+        serve("/r.yaml", 302, null, base + "/leaf.yaml");
+        String root = "openapi: 3.0.1\ncomponents:\n  schemas:\n"
+                + "    R: { $ref: '" + base + "/r.yaml' }\n"
+                + "    L: { $ref: '" + base + "/leaf.yaml' }\n";
+        OASParserUtil.validateRemoteRefsRecursively(root, null, opts(u -> true));
+        assertEquals(Integer.valueOf(1), hits.get("/r.yaml"));
+        assertEquals("redirect target must not be re-fetched as a direct ref",
+                Integer.valueOf(1), hits.get("/leaf.yaml"));
+    }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.spec.parser/src/test/java/org/wso2/carbon/apimgt/spec/parser/definitions/OASRefDedupKeyTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.spec.parser/src/test/java/org/wso2/carbon/apimgt/spec/parser/definitions/OASRefDedupKeyTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.carbon.apimgt.spec.parser.definitions;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+/**
+ * Unit tests for {@link OASParserUtil#dedupKey(String)} — the visited-set normalization that decides whether the
+ * remote $ref crawl treats two URLs as the same node (skip the second) or distinct nodes (validate + crawl both).
+ *
+ * <p>The key must: (a) case-fold ONLY scheme + authority so case-flips on the host can't mint endless "new" nodes;
+ * (b) preserve path AND query verbatim so two distinct documents are never collapsed (which would leave the
+ * second's nested $refs unscanned — an under-validation vector); (c) fall back to the exact string on an
+ * unparseable URL so it never under-dedups.</p>
+ */
+public class OASRefDedupKeyTest {
+
+    /**
+     * Regression: a PATH-LESS URL with a query must keep the query in the key. Before the fix the authority was
+     * split on the first '/' only, so a query-only URL (no path) dropped the query and two distinct documents
+     * collapsed to one key — the second was never fetched and its nested $refs went unvalidated.
+     */
+    @Test
+    public void pathLessQueryOnlyUrlsStayDistinct() {
+        String a = OASParserUtil.dedupKey("https://api.example.com?doc=public");
+        String b = OASParserUtil.dedupKey("https://api.example.com?doc=internal");
+        assertNotEquals("path-less URLs differing only by query must not collapse", a, b);
+        assertEquals("https://api.example.com?doc=public", a);
+        assertEquals("https://api.example.com?doc=internal", b);
+    }
+
+    /** Scheme and authority (host[:port], userinfo) are case-folded, so trivial case-flips collapse (intended). */
+    @Test
+    public void schemeAndAuthorityAreCaseFolded() {
+        assertEquals(OASParserUtil.dedupKey("http://host.com/A"),
+                OASParserUtil.dedupKey("HTTP://Host.com/A"));
+        assertEquals(OASParserUtil.dedupKey("https://HOST:8080/p"),
+                OASParserUtil.dedupKey("https://host:8080/p"));
+        assertEquals("https://host:8080/p", OASParserUtil.dedupKey("https://HOST:8080/p"));
+    }
+
+    /** Path case is preserved: /A and /a are different resources on the origin and must NOT collapse. */
+    @Test
+    public void pathCaseIsPreserved() {
+        assertNotEquals(OASParserUtil.dedupKey("http://h/A"),
+                OASParserUtil.dedupKey("http://h/a"));
+    }
+
+    /** Query case (and query value) is preserved when a path is present — unchanged by the fix. */
+    @Test
+    public void queryIsPreservedWithPath() {
+        assertNotEquals(OASParserUtil.dedupKey("http://h/p?X=1"),
+                OASParserUtil.dedupKey("http://h/p?x=1"));
+        assertEquals("http://h/p?token=abc", OASParserUtil.dedupKey("http://h/p?token=abc"));
+    }
+
+    /** A URL with neither path nor query is normalized to scheme://authority (no spurious trailing chars). */
+    @Test
+    public void bareAuthorityNormalizes() {
+        assertEquals("http://host.com", OASParserUtil.dedupKey("HTTP://Host.com"));
+        assertEquals(OASParserUtil.dedupKey("http://host.com"),
+                OASParserUtil.dedupKey("HTTP://HOST.COM"));
+    }
+
+    /** A fragment (if one ever reaches dedupKey) does not cause the query to be dropped on a path-less URL. */
+    @Test
+    public void fragmentDoesNotDropQuery() {
+        // authority ends at '?', query kept
+        assertNotEquals(OASParserUtil.dedupKey("http://h?q=a#frag"),
+                OASParserUtil.dedupKey("http://h?q=b#frag"));
+    }
+
+    /** Unparseable URL: fall back to the exact (case-sensitive) string, so we never under-dedup. */
+    @Test
+    public void unparseableUrlFallsBackToExactString() {
+        String raw = "http://exa mple.com/a";   // space → unparseable
+        assertEquals(raw, OASParserUtil.dedupKey(raw));
+        assertNotEquals(OASParserUtil.dedupKey("http://exa mple.com/A"),
+                OASParserUtil.dedupKey("http://exa mple.com/a"));
+    }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.spec.parser/src/test/java/org/wso2/carbon/apimgt/spec/parser/definitions/OASRefExtractTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.spec.parser/src/test/java/org/wso2/carbon/apimgt/spec/parser/definitions/OASRefExtractTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.carbon.apimgt.spec.parser.definitions;
+
+import org.junit.Test;
+import java.util.Set;
+import static org.junit.Assert.*;
+
+public class OASRefExtractTest {
+
+    @Test
+    public void extractsRefsWithFilePartIgnoresPureFragments() {
+        String yaml =
+            "openapi: 3.0.1\n" +
+            "components:\n" +
+            "  schemas:\n" +
+            "    A: { $ref: 'http://h/a.yaml#/X' }\n" +
+            "    B: { $ref: './b.yaml' }\n" +
+            "    C: { $ref: '#/components/schemas/A' }\n";
+        Set<String> refs = OASParserUtil.extractRefStrings(yaml);
+        assertTrue(refs.contains("http://h/a.yaml#/X"));
+        assertTrue(refs.contains("./b.yaml"));
+        assertFalse("in-document fragments are ignored",
+                refs.contains("#/components/schemas/A"));
+    }
+
+    @Test
+    public void resolvesAbsoluteRelativeAndRejectsNonHttp() {
+        assertEquals("http://h/a.yaml",
+                OASParserUtil.resolveToHttpUrl("http://h/a.yaml#/X", null));
+        assertEquals("http://h/dir/b.yaml",
+                OASParserUtil.resolveToHttpUrl("./b.yaml", "http://h/dir/main.yaml"));
+        assertEquals("http://h/c.yaml",
+                OASParserUtil.resolveToHttpUrl("../c.yaml", "http://h/dir/main.yaml"));
+        assertNull(OASParserUtil.resolveToHttpUrl("./b.yaml", null));
+        assertNull(OASParserUtil.resolveToHttpUrl("./b.yaml", "file:/tmp/main.yaml")); // local base
+        assertNull(OASParserUtil.resolveToHttpUrl("#/x", "http://h/m.yaml"));
+        assertNull(OASParserUtil.resolveToHttpUrl("file:///etc/passwd", null));
+    }
+
+    @Test
+    public void malformedContentReturnsEmptyNeverThrows() {
+        assertTrue(OASParserUtil.extractRefStrings(":::not yaml or json:::").isEmpty());
+        assertTrue(OASParserUtil.extractRefStrings(null).isEmpty());
+    }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.spec.parser/src/test/java/org/wso2/carbon/apimgt/spec/parser/definitions/OASRefHookTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.spec.parser/src/test/java/org/wso2/carbon/apimgt/spec/parser/definitions/OASRefHookTest.java
@@ -1,0 +1,56 @@
+/*
+ *   Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ *   WSO2 Inc. licenses this file to you under the Apache License,
+ *   Version 2.0 (the "License"); you may not use this file except
+ *   in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ *
+ */
+
+package org.wso2.carbon.apimgt.spec.parser.definitions;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.wso2.carbon.apimgt.api.APIManagementException;
+import org.wso2.carbon.apimgt.api.ExceptionCodes;
+import org.wso2.carbon.apimgt.api.model.OASParserOptions;
+
+public class OASRefHookTest {
+
+    private OASParserOptions optsBlockingLoopback() {
+        OASParserOptions o = new OASParserOptions();
+        o.setRefValidationTenantDomain("carbon.super");
+        o.setRefValidator((url, t) -> {
+            if (url.contains("127.0.0.1")) {
+                throw new APIManagementException("blocked " + url, ExceptionCodes.UNTRUSTED_URL);
+            }
+        });
+        return o;
+    }
+
+    @Test
+    public void testValidateAPIDefinitionRunsHook() {
+        try {
+            OASParserUtil.validateAPIDefinition("{\"$ref\":\"http://127.0.0.1/x.yaml\"}", false, optsBlockingLoopback());
+            Assert.fail("expected UNTRUSTED_URL from Layer-1 hook");
+        } catch (APIManagementException e) {
+            Assert.assertEquals(ExceptionCodes.UNTRUSTED_URL.getErrorCode(), e.getErrorHandler().getErrorCode());
+        }
+    }
+
+    @Test
+    public void testNoHookNoLayer1() throws Exception {
+        OASParserOptions o = new OASParserOptions(); // no validator => Layer-1 skipped
+        OASParserUtil.validateAPIDefinition("openapi: 3.0.0\ninfo: {title: t, version: '1.0'}\npaths: {}\n", false, o);
+    }
+}


### PR DESCRIPTION
Superseded by #13893 (branch renamed for clarity; no content change).