### PR TITLE
Add atomic Redis window state operations

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/RedisBaseDistributedCountManager.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/RedisBaseDistributedCountManager.java
@@ -29,9 +29,7 @@ import redis.clients.jedis.Transaction;
 import redis.clients.jedis.exceptions.JedisException;
 import redis.clients.jedis.params.SetParams;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 /**
  * Redis Base Distributed Counter Manager for Throttler.
@@ -553,8 +551,18 @@ public class RedisBaseDistributedCountManager implements DistributedCounterManag
                     return new long[]{0L, 0L};
                 }
                 try {
-                    long ts      = (vals.get(0) != null) ? Long.parseLong(vals.get(0)) : 0L;
-                    long counter = (vals.get(1) != null) ? Long.parseLong(vals.get(1)) : 0L;
+                    String tsValue      = vals.get(0);
+                    String counterValue = vals.get(1);
+                    if (tsValue == null || counterValue == null) {
+                        if (tsValue != null || counterValue != null) {
+                            log.warn("Incomplete window state in Redis for key: " + key
+                                    + " (ts=" + tsValue + ", counter=" + counterValue
+                                    + "). Treating as empty window.");
+                        }
+                        return new long[]{0L, 0L};
+                    }
+                    long ts      = Long.parseLong(tsValue);
+                    long counter = Long.parseLong(counterValue);
                     return new long[]{ts, counter};
                 } catch (RuntimeException e) {
                     // Catches NumberFormatException (corrupted field value) and
@@ -588,6 +596,12 @@ public class RedisBaseDistributedCountManager implements DistributedCounterManag
                         + ". Window TTL would be zero or negative.");
             }
             try (Jedis jedis = redisPool.getResource()) {
+                now = System.currentTimeMillis();
+                if (expiryTime <= now) {
+                    throw new JedisException("setWindow called with already-expired expiryTime="
+                            + expiryTime + " (now=" + now + ") for key: " + key
+                            + ". Window expired while waiting for Redis connection.");
+                }
                 Transaction tx = jedis.multi();
                 tx.hset(key, "ts", String.valueOf(ts));
                 tx.hset(key, "counter", String.valueOf(count));
@@ -622,6 +636,13 @@ public class RedisBaseDistributedCountManager implements DistributedCounterManag
                         + ". Refusing to push delta=" + delta + " to an expired window.");
             }
             try (Jedis jedis = redisPool.getResource()) {
+                now = System.currentTimeMillis();
+                if (expiryTime <= now) {
+                    throw new JedisException("incrWindowCounter called with already-expired expiryTime="
+                            + expiryTime + " (now=" + now + ") for key: " + key
+                            + ". Window expired while waiting for Redis connection."
+                            + " Refusing to push delta=" + delta + ".");
+                }
                 Transaction tx = jedis.multi();
                 Response<Long> counterResp = tx.hincrBy(key, "counter", delta);
                 // pexpireAt guards against the narrow race where the hash TTL fires between

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/RedisBaseDistributedCountManager.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/RedisBaseDistributedCountManager.java
@@ -551,7 +551,7 @@ public class RedisBaseDistributedCountManager implements DistributedCounterManag
                     return new long[]{0L, 0L};
                 }
                 try {
-                    String tsValue      = vals.get(0);
+                    String tsValue = vals.get(0);
                     String counterValue = vals.get(1);
                     if (tsValue == null || counterValue == null) {
                         if (tsValue != null || counterValue != null) {
@@ -561,7 +561,7 @@ public class RedisBaseDistributedCountManager implements DistributedCounterManag
                         }
                         return new long[]{0L, 0L};
                     }
-                    long ts      = Long.parseLong(tsValue);
+                    long ts = Long.parseLong(tsValue);
                     long counter = Long.parseLong(counterValue);
                     return new long[]{ts, counter};
                 } catch (RuntimeException e) {

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/RedisBaseDistributedCountManager.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/RedisBaseDistributedCountManager.java
@@ -29,6 +29,10 @@ import redis.clients.jedis.Transaction;
 import redis.clients.jedis.exceptions.JedisException;
 import redis.clients.jedis.params.SetParams;
 
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 /**
  * Redis Base Distributed Counter Manager for Throttler.
  */
@@ -535,6 +539,112 @@ public class RedisBaseDistributedCountManager implements DistributedCounterManag
         } finally {
             if (log.isTraceEnabled()) {
                 log.trace("Time Taken to remove lock :" + (System.currentTimeMillis() - startTime));
+            }
+        }
+    }
+
+    @Override
+    public long[] getWindowState(String key) {
+        long startTime = System.currentTimeMillis();
+        try {
+            try (Jedis jedis = redisPool.getResource()) {
+                List<String> vals = jedis.hmget(key, "ts", "counter");
+                if (vals == null) {
+                    return new long[]{0L, 0L};
+                }
+                try {
+                    long ts      = (vals.get(0) != null) ? Long.parseLong(vals.get(0)) : 0L;
+                    long counter = (vals.get(1) != null) ? Long.parseLong(vals.get(1)) : 0L;
+                    return new long[]{ts, counter};
+                } catch (RuntimeException e) {
+                    // Catches NumberFormatException (corrupted field value) and
+                    // IndexOutOfBoundsException (unexpected short list from Jedis).
+                    log.warn("Corrupted or unexpected window state in Redis for key: " + key
+                            + " vals=" + vals + ". Treating as empty window.", e);
+                    return new long[]{0L, 0L};
+                }
+            }
+        } catch (JedisException e) {
+            log.error("Redis error in getWindowState for key: " + key, e);
+            throw e;
+        } finally {
+            if (log.isTraceEnabled()) {
+                log.trace("Time Taken to getWindowState :" + (System.currentTimeMillis() - startTime));
+            }
+        }
+    }
+
+    @Override
+    public void setWindow(String key, long count, long ts, long expiryTime) {
+        long startTime = System.currentTimeMillis();
+        try {
+            // Reject already-expired windows upfront: pexpireAt with a past timestamp
+            // would immediately delete the hash, wasting a Redis round-trip and silently
+            // returning success to the caller.
+            long now = startTime;
+            if (expiryTime <= now) {
+                throw new JedisException("setWindow called with already-expired expiryTime="
+                        + expiryTime + " (now=" + now + ") for key: " + key
+                        + ". Window TTL would be zero or negative.");
+            }
+            try (Jedis jedis = redisPool.getResource()) {
+                Transaction tx = jedis.multi();
+                tx.hset(key, "ts", String.valueOf(ts));
+                tx.hset(key, "counter", String.valueOf(count));
+                tx.pexpireAt(key, expiryTime);
+                List<Object> results = tx.exec();
+                if (results == null || results.size() < 3) {
+                    throw new JedisException("Transaction failed for setWindow on key: "
+                            + key + " results=" + results);
+                }
+            }
+        } catch (JedisException e) {
+            log.error("Redis error in setWindow for key: " + key, e);
+            throw e;
+        } finally {
+            if (log.isTraceEnabled()) {
+                log.trace("Time Taken to setWindow :" + (System.currentTimeMillis() - startTime));
+            }
+        }
+    }
+
+    @Override
+    public long incrWindowCounter(String key, long delta, long expiryTime) {
+        long startTime = System.currentTimeMillis();
+        try {
+            // Reject already-expired TTLs upfront: pexpireAt with a past timestamp would
+            // immediately delete the hash (including the just-incremented counter), causing
+            // the caller to skip its local commit and re-push the same delta next tick.
+            long now = startTime;
+            if (expiryTime <= now) {
+                throw new JedisException("incrWindowCounter called with already-expired expiryTime="
+                        + expiryTime + " (now=" + now + ") for key: " + key
+                        + ". Refusing to push delta=" + delta + " to an expired window.");
+            }
+            try (Jedis jedis = redisPool.getResource()) {
+                Transaction tx = jedis.multi();
+                Response<Long> counterResp = tx.hincrBy(key, "counter", delta);
+                // pexpireAt guards against the narrow race where the hash TTL fires between
+                // the caller's pre-check and this call: HINCRBY auto-creates a bare hash
+                // with no TTL; pexpireAt ensures it always expires at the window boundary.
+                tx.pexpireAt(key, expiryTime);
+                List<Object> results = tx.exec();
+                if (results == null || results.size() < 2) {
+                    throw new JedisException("Transaction failed for incrWindowCounter on key: "
+                            + key + " results=" + results);
+                }
+                Long newCounter = counterResp.get();
+                if (newCounter == null) {
+                    throw new JedisException("Counter increment returned null for key: " + key);
+                }
+                return newCounter;
+            }
+        } catch (JedisException e) {
+            log.error("Redis error in incrWindowCounter for key: " + key, e);
+            throw e;
+        } finally {
+            if (log.isTraceEnabled()) {
+                log.trace("Time Taken to incrWindowCounter :" + (System.currentTimeMillis() - startTime));
             }
         }
     }

--- a/pom.xml
+++ b/pom.xml
@@ -2106,7 +2106,7 @@
         <carbon.commons.version>4.13.3</carbon.commons.version>
 
         <carbon.registry.version>4.9.13</carbon.registry.version>
-        <carbon.mediation.version>4.8.16</carbon.mediation.version>
+        <carbon.mediation.version>4.8.19</carbon.mediation.version>
 
         <mongodb.driver.version>4.1.0</mongodb.driver.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -2188,7 +2188,7 @@
         <imp.package.version.osgi.framework>[1.6.0, 2.0.0)</imp.package.version.osgi.framework>
 
         <!-- Misc Versions -->
-        <synapse.version>4.1.0-wso2v40</synapse.version>
+        <synapse.version>4.1.0-wso2v57</synapse.version>
         <orbit.version.json>3.0.0.wso2v7</orbit.version.json>
 
         <!-- orbit httpmime versions-->


### PR DESCRIPTION
### Description

This pull request introduces improvements to the Redis-based distributed counter manager, focusing on supporting windowed counters for throttling, and updates the Synapse dependency version. The main enhancements include new methods for managing window state in Redis with robust error handling, as well as a version bump for a critical dependency.

**Redis windowed counter support:**

* Added `getWindowState`, `setWindow`, and `incrWindowCounter` methods to `RedisBaseDistributedCountManager`, enabling atomic retrieval, update, and increment of windowed counters with expiry handling and comprehensive error checking.
* Improved exception handling and logging for Redis operations, ensuring corrupted or unexpected data is handled gracefully and operational issues are surfaced clearly.
* Imported additional Java utility classes (`HashMap`, `List`, `Map`) to support new method implementations.

**Dependency updates:**

* Updated `synapse.version` in `pom.xml` from `4.1.0-wso2v40` to `4.1.0-wso2v57` to align with the latest supported version.

### Related issue: 
- https://github.com/wso2/api-manager/issues/5032
- https://github.com/wso2/api-manager/issues/5048

### Related PRs
- https://github.com/wso2/wso2-synapse/pull/2564