### PR TITLE
Add OAS validation for direct backend MCP servers and fix unit test

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.common/src/main/resources/publisher-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.common/src/main/resources/publisher-api.yaml
@@ -15024,6 +15024,8 @@ components:
           example: APPROVED
         protocolVersion:
           type: string
+        mcpPathAppended:
+          type: string
         createdTime:
           type: string
         lastUpdatedTimestamp:

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/dto/MCPServerDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/dto/MCPServerDTO.java
@@ -197,6 +197,7 @@ return null;
     private APICorsConfigurationDTO corsConfiguration = null;
     private String workflowStatus = null;
     private String protocolVersion = null;
+    private String mcpPathAppended = null;
     private String createdTime = null;
     private String lastUpdatedTimestamp = null;
     @Scope(name = "apim:mcp_server_publish", description="", value ="")
@@ -922,6 +923,23 @@ return null;
 
   /**
    **/
+  public MCPServerDTO mcpPathAppended(String mcpPathAppended) {
+    this.mcpPathAppended = mcpPathAppended;
+    return this;
+  }
+
+  
+  @ApiModelProperty(value = "")
+  @JsonProperty("mcpPathAppended")
+  public String getMcpPathAppended() {
+    return mcpPathAppended;
+  }
+  public void setMcpPathAppended(String mcpPathAppended) {
+    this.mcpPathAppended = mcpPathAppended;
+  }
+
+  /**
+   **/
   public MCPServerDTO createdTime(String createdTime) {
     this.createdTime = createdTime;
     return this;
@@ -1165,6 +1183,7 @@ return null;
         Objects.equals(corsConfiguration, mcPServer.corsConfiguration) &&
         Objects.equals(workflowStatus, mcPServer.workflowStatus) &&
         Objects.equals(protocolVersion, mcPServer.protocolVersion) &&
+        Objects.equals(mcpPathAppended, mcPServer.mcpPathAppended) &&
         Objects.equals(createdTime, mcPServer.createdTime) &&
         Objects.equals(lastUpdatedTimestamp, mcPServer.lastUpdatedTimestamp) &&
         Objects.equals(lastUpdatedTime, mcPServer.lastUpdatedTime) &&
@@ -1180,7 +1199,7 @@ return null;
 
   @Override
   public int hashCode() {
-    return Objects.hash(id, name, displayName, description, context, endpointConfig, version, provider, lifeCycleStatus, hasThumbnail, isDefaultVersion, isRevision, revisionedMCPServerId, revisionId, enableSchemaValidation, audiences, transport, tags, policies, organizationPolicies, throttlingPolicy, authorizationHeader, apiKeyHeader, securityScheme, maxTps, visibility, visibleRoles, visibleTenants, visibleOrganizations, mcpServerPolicies, subscriptionAvailability, subscriptionAvailableTenants, additionalPropertiesMap, monetization, accessControl, accessControlRoles, businessInformation, corsConfiguration, workflowStatus, protocolVersion, createdTime, lastUpdatedTimestamp, lastUpdatedTime, subtypeConfiguration, scopes, operations, categories, keyManagers, gatewayVendor, gatewayType, initiatedFromGateway);
+    return Objects.hash(id, name, displayName, description, context, endpointConfig, version, provider, lifeCycleStatus, hasThumbnail, isDefaultVersion, isRevision, revisionedMCPServerId, revisionId, enableSchemaValidation, audiences, transport, tags, policies, organizationPolicies, throttlingPolicy, authorizationHeader, apiKeyHeader, securityScheme, maxTps, visibility, visibleRoles, visibleTenants, visibleOrganizations, mcpServerPolicies, subscriptionAvailability, subscriptionAvailableTenants, additionalPropertiesMap, monetization, accessControl, accessControlRoles, businessInformation, corsConfiguration, workflowStatus, protocolVersion, mcpPathAppended, createdTime, lastUpdatedTimestamp, lastUpdatedTime, subtypeConfiguration, scopes, operations, categories, keyManagers, gatewayVendor, gatewayType, initiatedFromGateway);
   }
 
   @Override
@@ -1228,6 +1247,7 @@ return null;
     sb.append("    corsConfiguration: ").append(toIndentedString(corsConfiguration)).append("\n");
     sb.append("    workflowStatus: ").append(toIndentedString(workflowStatus)).append("\n");
     sb.append("    protocolVersion: ").append(toIndentedString(protocolVersion)).append("\n");
+    sb.append("    mcpPathAppended: ").append(toIndentedString(mcpPathAppended)).append("\n");
     sb.append("    createdTime: ").append(toIndentedString(createdTime)).append("\n");
     sb.append("    lastUpdatedTimestamp: ").append(toIndentedString(lastUpdatedTimestamp)).append("\n");
     sb.append("    lastUpdatedTime: ").append(toIndentedString(lastUpdatedTime)).append("\n");

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/APIMappingUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/APIMappingUtil.java
@@ -821,6 +821,10 @@ public class APIMappingUtil {
         if (protocolVersion != null && !protocolVersion.isEmpty()) {
             model.getMetadata().put(APIConstants.MCP.PROTOCOL_VERSION_KEY, protocolVersion);
         }
+        String mcpPathAppended = dto.getMcpPathAppended();
+        if (mcpPathAppended != null && !mcpPathAppended.isEmpty()) {
+            model.getMetadata().put(APIConstants.MCP.MCP_PATH_APPENDED_METADATA_KEY, mcpPathAppended);
+        }
         String displayName = dto.getDisplayName();
         if (displayName != null && !displayName.trim().isEmpty()) {
             model.setDisplayName(displayName);
@@ -2515,6 +2519,14 @@ public class APIMappingUtil {
                 ? model.getMetadata().get(APIConstants.MCP.PROTOCOL_VERSION_KEY) : null;
         if (protocolVersion != null) {
             dto.setProtocolVersion(protocolVersion);
+        }
+        // Carry the mcpPathAppended metadata through the artifact so gateway template resolution
+        // reflects the stored value. Otherwise the value is lost on export/import and the gateway
+        // falls back to its append default, doubling the /mcp path for proxy MCP servers.
+        String mcpPathAppended = model.getMetadata() != null
+                ? model.getMetadata().get(APIConstants.MCP.MCP_PATH_APPENDED_METADATA_KEY) : null;
+        if (mcpPathAppended != null) {
+            dto.setMcpPathAppended(mcpPathAppended);
         }
         return dto;
     }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ImportUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ImportUtils.java
@@ -822,13 +822,16 @@ public class ImportUtils {
                     backend.setEndpointConfig(importedBackend.getEndpointConfig());
                     String importedDefinition = importedBackend.getDefinition();
                     if (StringUtils.isNotBlank(importedDefinition)) {
-                        if (log.isDebugEnabled()) {
-                            log.debug("Validating and updating backend definition for API: " + targetApi.getUuid());
-                        }
-                        retrieveValidatedSwaggerDefinition(importedDefinition);
-                        if (log.isDebugEnabled()) {
-                            log.debug("Backend API definition validated successfully for backend: "
-                                    + targetApi.getUuid());
+                        if (APIConstants.API_SUBTYPE_DIRECT_BACKEND.equals(subtype)) {
+                            if (log.isDebugEnabled()) {
+                                log.debug("Validating and updating backend definition for API: "
+                                        + targetApi.getUuid());
+                            }
+                            retrieveValidatedSwaggerDefinition(importedDefinition);
+                            if (log.isDebugEnabled()) {
+                                log.debug("Backend API definition validated successfully for backend: "
+                                        + targetApi.getUuid());
+                            }
                         }
                         backend.setDefinition(importedDefinition);
                     }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ImportUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ImportUtils.java
@@ -194,6 +194,9 @@ public class ImportUtils {
                 JsonElement jsonObject = retrieveValidatedDTOObject(extractedFolderPath, preserveProvider,
                         userName, ImportExportConstants.TYPE_MCP_SERVER);
                 importedApiDTO = new Gson().fromJson(jsonObject, MCPServerDTO.class);
+                if (importedApiDTO != null && importedApiDTO.getMcpPathAppended() == null) {
+                    importedApiDTO.setMcpPathAppended(Boolean.TRUE.toString());
+                }
             }
         } catch (IOException e) {
             throw new APIManagementException(

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/test/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ImportUtilsMCPDefinitionUpdateTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/test/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ImportUtilsMCPDefinitionUpdateTest.java
@@ -50,7 +50,7 @@ import java.util.LinkedHashMap;
  * Covers:
  * - Backend definition is updated when provided in import artifact
  * - Backend definition is NOT updated when absent in import artifact
- * - Definition validation is invoked for imported definitions
+ * - Definition validation is invoked only for DIRECT_BACKEND imported definitions
  * - Both DIRECT_BACKEND and SERVER_PROXY subtypes
  */
 @RunWith(PowerMockRunner.class)
@@ -333,8 +333,8 @@ public class ImportUtilsMCPDefinitionUpdateTest {
         Assert.assertEquals("SERVER_PROXY backend definition should be updated",
                 NEW_DEFINITION, capturedBackend.getDefinition());
 
-        PowerMockito.verifyPrivate(ImportUtils.class)
-                .invoke("retrieveValidatedSwaggerDefinition", NEW_DEFINITION);
+        PowerMockito.verifyPrivate(ImportUtils.class, Mockito.never())
+                .invoke("retrieveValidatedSwaggerDefinition", ArgumentMatchers.anyString());
     }
 
     // -------------------------------------------------------------------------

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/McpServersApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/McpServersApiServiceImpl.java
@@ -2409,6 +2409,8 @@ public class McpServersApiServiceImpl implements McpServersApiService {
             if (oldBackend == null) {
                 RestApiUtil.handleResourceNotFoundError(RestApiConstants.RESOURCE_MCP_SERVER, mcpServerId, log);
             }
+            API existingApi = apiProvider.getAPIbyUUID(mcpServerId, organization);
+            String subtype = existingApi.getSubtype();
             Backend backend = new Backend(oldBackend);
             Object endpointConfigObj = backendAPIDTO.getEndpointConfig();
             if (endpointConfigObj == null) {
@@ -2425,18 +2427,20 @@ public class McpServersApiServiceImpl implements McpServersApiService {
             }
             String definition = backendAPIDTO.getDefinition();
             if (StringUtils.isNotBlank(definition)) {
-                APIDefinitionValidationResponse validationResponse =
-                        OASParserUtil.validateAPIDefinition(definition, Boolean.TRUE,
-                                ServiceReferenceHolder.getInstance()
-                                        .getAPIMDependencyConfigurationService()
-                                        .getAPIMDependencyConfigurations().getOasParserOptions());
-                if (!validationResponse.isValid()) {
-                    List<ErrorListItemDTO> errorListItemDTOs =
-                            APIMappingUtil.getErrorListItemsDTOsFromErrorHandlers(
-                                    validationResponse.getErrorItems());
-                    ErrorDTO errorDTO =
-                            APIMappingUtil.getErrorDTOFromErrorListItems(errorListItemDTOs);
-                    throw RestApiUtil.buildBadRequestException(errorDTO);
+                if (APIConstants.API_SUBTYPE_DIRECT_BACKEND.equals(subtype)) {
+                    APIDefinitionValidationResponse validationResponse =
+                            OASParserUtil.validateAPIDefinition(definition, Boolean.TRUE,
+                                    ServiceReferenceHolder.getInstance()
+                                            .getAPIMDependencyConfigurationService()
+                                            .getAPIMDependencyConfigurations().getOasParserOptions());
+                    if (!validationResponse.isValid()) {
+                        List<ErrorListItemDTO> errorListItemDTOs =
+                                APIMappingUtil.getErrorListItemsDTOsFromErrorHandlers(
+                                        validationResponse.getErrorItems());
+                        ErrorDTO errorDTO =
+                                APIMappingUtil.getErrorDTOFromErrorListItems(errorListItemDTOs);
+                        throw RestApiUtil.buildBadRequestException(errorDTO);
+                    }
                 }
                 backend.setDefinition(definition);
             }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/resources/publisher-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/resources/publisher-api.yaml
@@ -15024,6 +15024,8 @@ components:
           example: APPROVED
         protocolVersion:
           type: string
+        mcpPathAppended:
+          type: string
         createdTime:
           type: string
         lastUpdatedTimestamp:

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.util/src/main/resources/publisher-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.util/src/main/resources/publisher-api.yaml
@@ -12281,6 +12281,8 @@ components:
           example: APPROVED
         protocolVersion:
           type: string
+        mcpPathAppended:
+          type: string
         createdTime:
           type: string
         lastUpdatedTimestamp:


### PR DESCRIPTION
This pull request updates the logic for validating and updating backend API definitions to ensure that definition validation is only performed for APIs of subtype `DIRECT_BACKEND`. It also updates corresponding tests and adds subtype retrieval in the backend update flow. This change prevents unnecessary validation for other subtypes such as `SERVER_PROXY`.

**Backend Definition Validation Logic:**

* In `ImportUtils.importMCPServer`, validation of the backend definition using `retrieveValidatedSwaggerDefinition` is now performed only if the API subtype is `DIRECT_BACKEND`.
* In `McpServersApiServiceImpl.updateMCPServerBackend`, validation of the backend definition is similarly restricted to the `DIRECT_BACKEND` subtype. The subtype is retrieved from the existing API before validation. [[1]](diffhunk://#diff-ed1d6a37304067120f3cba0bd8fd30b0f50825c96dac2775102e4d4e7b020d4fR2412-R2413) [[2]](diffhunk://#diff-ed1d6a37304067120f3cba0bd8fd30b0f50825c96dac2775102e4d4e7b020d4fR2430) [[3]](diffhunk://#diff-ed1d6a37304067120f3cba0bd8fd30b0f50825c96dac2775102e4d4e7b020d4fR2444)

**Test Updates:**

* The test class documentation and behavior are updated to clarify and enforce that definition validation is invoked only for `DIRECT_BACKEND` imported definitions, not for `SERVER_PROXY`. [[1]](diffhunk://#diff-1571e52fb97b88faa13bd768fbb49e14fa33c30d4b50646f5b6fbb956da70486L53-R53) [[2]](diffhunk://#diff-1571e52fb97b88faa13bd768fbb49e14fa33c30d4b50646f5b6fbb956da70486L336-R337)