### PR TITLE
Fix orphan AM_API_REVISION_METADATA rows on product revision delete

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/ApiMgtDAO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/ApiMgtDAO.java
@@ -22665,6 +22665,8 @@ public class ApiMgtDAO {
                 removeGraphQLComplexityStatement.setInt(1, apiId);
                 removeGraphQLComplexityStatement.setString(2, apiRevision.getRevisionUUID());
                 removeGraphQLComplexityStatement.executeUpdate();
+                // Removing revision metadata entry from AM_API_REVISION_METADATA table
+                deleteAPIRevisionMetaData(connection, apiRevision.getApiUUID(), apiRevision.getRevisionUUID());
 
                 // Removing related revision entries for operation policies
                 deleteAllAPISpecificOperationPoliciesByAPIUUID(connection, apiRevision.getApiUUID(), apiRevision.getRevisionUUID());


### PR DESCRIPTION
### Purpose

Implements a proactive code-level fix to delete entries from AM_API_REVISION_METADATA table upon deleting the respective API Product revision.

Related issue: https://github.com/wso2/api-manager/issues/5105