### PR TITLE
Preserve MCP tool metadata (annotations, _meta, outputSchema) when proxying MCP servers

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/utils/MCPPayloadGenerator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/utils/MCPPayloadGenerator.java
@@ -22,6 +22,7 @@ package org.wso2.carbon.apimgt.gateway.utils;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import org.wso2.carbon.apimgt.api.model.subscription.URLMapping;
 import org.wso2.carbon.apimgt.gateway.mcp.response.InitializeResult;
@@ -99,31 +100,58 @@ public class MCPPayloadGenerator {
         return data;
     }
 
-    //write a method to generate the tool list payload
+    /**
+     * Generates the tools/list response payload for the given operations. Each stored schema
+     * definition may be either the bare input schema or a wrapper object that additionally
+     * carries metadata such as annotations, _meta and outputSchema; both formats are emitted
+     * as valid tool definitions.
+     *
+     * @param id                 id of the request
+     * @param extendedOperations tool operations of the MCP server
+     * @param isThirdParty       whether the MCP server proxies a third-party MCP server
+     * @return the tools/list response payload as a String
+     */
     public static String generateToolListPayload(Object id, List<URLMapping> extendedOperations, boolean isThirdParty) {
-        McpResponse<ToolListResult> toolListResponse = new McpResponse<>(id);
-        ToolListResult toolListResult = new ToolListResult();
-        List<ToolListResult.ToolInfo> toolInfoList = new ArrayList<>();
+        McpResponse<JsonObject> toolListResponse = new McpResponse<>(id);
+        JsonArray toolsArray = new JsonArray();
 
         for (URLMapping extendedOperation : extendedOperations) {
-            ToolListResult.ToolInfo tool = new ToolListResult.ToolInfo();
-            tool.setName(extendedOperation.getUrlPattern());
-            tool.setDescription(extendedOperation.getDescription());
+            JsonObject toolObj = new JsonObject();
+            toolObj.addProperty(APIConstants.MCP.TOOL_NAME_KEY, extendedOperation.getUrlPattern());
+            if (extendedOperation.getDescription() != null) {
+                toolObj.addProperty(APIConstants.MCP.TOOL_DESCRIPTION_KEY, extendedOperation.getDescription());
+            }
             String schema = extendedOperation.getSchemaDefinition();
             if (schema != null) {
-                ToolListResult.JsonSchema schemaObject = gson.fromJson(schema, ToolListResult.JsonSchema.class);
-                if (!isThirdParty) {
-                    tool.setInputSchema(sanitizeInputSchema(schemaObject));
+                JsonObject schemaJson = gson.fromJson(schema, JsonObject.class);
+                if (schemaJson != null && schemaJson.has(APIConstants.MCP.TOOL_INPUT_SCHEMA_KEY)) {
+                    JsonObject inputSchemaJson = schemaJson.getAsJsonObject(APIConstants.MCP.TOOL_INPUT_SCHEMA_KEY);
+                    ToolListResult.JsonSchema inputSchema = gson.fromJson(inputSchemaJson, ToolListResult.JsonSchema.class);
+                    if (!isThirdParty) {
+                        inputSchema = sanitizeInputSchema(inputSchema);
+                    }
+                    toolObj.add(APIConstants.MCP.TOOL_INPUT_SCHEMA_KEY, gson.toJsonTree(inputSchema));
+                    for (Map.Entry<String, JsonElement> entry : schemaJson.entrySet()) {
+                        if (!APIConstants.MCP.TOOL_INPUT_SCHEMA_KEY.equals(entry.getKey())) {
+                            toolObj.add(entry.getKey(), entry.getValue());
+                        }
+                    }
                 } else {
-                    // For third-party tools, we do not sanitize the input schema
-                    tool.setInputSchema(schemaObject);
+                    ToolListResult.JsonSchema inputSchema = gson.fromJson(schema, ToolListResult.JsonSchema.class);
+                    if (!isThirdParty) {
+                        toolObj.add(APIConstants.MCP.TOOL_INPUT_SCHEMA_KEY,
+                                gson.toJsonTree(sanitizeInputSchema(inputSchema)));
+                    } else {
+                        toolObj.add(APIConstants.MCP.TOOL_INPUT_SCHEMA_KEY, gson.toJsonTree(inputSchema));
+                    }
                 }
-
             }
-            toolInfoList.add(tool);
+            toolsArray.add(toolObj);
         }
-        toolListResult.setTools(toolInfoList);
-        toolListResponse.setResult(toolListResult);
+
+        JsonObject result = new JsonObject();
+        result.add(APIConstants.MCP.TOOLS_KEY, toolsArray);
+        toolListResponse.setResult(result);
         return gson.toJson(toolListResponse);
     }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/utils/MCPPayloadGenerator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/utils/MCPPayloadGenerator.java
@@ -125,24 +125,30 @@ public class MCPPayloadGenerator {
             if (schema != null) {
                 JsonObject schemaJson = gson.fromJson(schema, JsonObject.class);
                 if (schemaJson != null && schemaJson.has(APIConstants.MCP.TOOL_INPUT_SCHEMA_KEY)) {
-                    JsonObject inputSchemaJson = schemaJson.getAsJsonObject(APIConstants.MCP.TOOL_INPUT_SCHEMA_KEY);
-                    ToolListResult.JsonSchema inputSchema = gson.fromJson(inputSchemaJson, ToolListResult.JsonSchema.class);
                     if (!isThirdParty) {
-                        inputSchema = sanitizeInputSchema(inputSchema);
+                        ToolListResult.JsonSchema inputSchema = gson.fromJson(
+                                schemaJson.getAsJsonObject(APIConstants.MCP.TOOL_INPUT_SCHEMA_KEY),
+                                ToolListResult.JsonSchema.class);
+                        toolObj.add(APIConstants.MCP.TOOL_INPUT_SCHEMA_KEY,
+                                gson.toJsonTree(sanitizeInputSchema(inputSchema)));
+                    } else {
+                        // For third-party tools, pass the input schema through unchanged
+                        toolObj.add(APIConstants.MCP.TOOL_INPUT_SCHEMA_KEY,
+                                schemaJson.get(APIConstants.MCP.TOOL_INPUT_SCHEMA_KEY));
                     }
-                    toolObj.add(APIConstants.MCP.TOOL_INPUT_SCHEMA_KEY, gson.toJsonTree(inputSchema));
                     for (Map.Entry<String, JsonElement> entry : schemaJson.entrySet()) {
                         if (!APIConstants.MCP.TOOL_INPUT_SCHEMA_KEY.equals(entry.getKey())) {
                             toolObj.add(entry.getKey(), entry.getValue());
                         }
                     }
                 } else {
-                    ToolListResult.JsonSchema inputSchema = gson.fromJson(schema, ToolListResult.JsonSchema.class);
                     if (!isThirdParty) {
+                        ToolListResult.JsonSchema inputSchema = gson.fromJson(schema, ToolListResult.JsonSchema.class);
                         toolObj.add(APIConstants.MCP.TOOL_INPUT_SCHEMA_KEY,
                                 gson.toJsonTree(sanitizeInputSchema(inputSchema)));
                     } else {
-                        toolObj.add(APIConstants.MCP.TOOL_INPUT_SCHEMA_KEY, gson.toJsonTree(inputSchema));
+                        // For third-party tools, pass the input schema through unchanged
+                        toolObj.add(APIConstants.MCP.TOOL_INPUT_SCHEMA_KEY, schemaJson);
                     }
                 }
             }

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/test/java/org/wso2/carbon/apimgt/gateway/utils/MCPPayloadGeneratorTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/test/java/org/wso2/carbon/apimgt/gateway/utils/MCPPayloadGeneratorTest.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.apimgt.gateway.utils;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import org.junit.Assert;
+import org.junit.Test;
+import org.wso2.carbon.apimgt.api.model.subscription.URLMapping;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Unit tests for {@link MCPPayloadGenerator#generateToolListPayload(Object, List, boolean)} — the gateway
+ * builder for the {@code tools/list} response. Pins the metadata-preservation fix: a stored tool definition
+ * may be a bare input schema OR a wrapper additionally carrying {@code title}, {@code annotations},
+ * {@code _meta}, {@code outputSchema} and {@code execution}; the builder must emit ALL of those fields, while
+ * still sanitizing the input schema for non third-party (OpenAPI/API-generated) servers.
+ */
+public class MCPPayloadGeneratorTest {
+
+    private static final Gson GSON = new Gson();
+
+    private JsonArray toolsOf(String payload) {
+        JsonObject root = GSON.fromJson(payload, JsonObject.class);
+        Assert.assertTrue("payload must carry a result object", root.has("result"));
+        JsonObject result = root.getAsJsonObject("result");
+        Assert.assertTrue("result must carry a tools array", result.has("tools"));
+        return result.getAsJsonArray("tools");
+    }
+
+    private URLMapping tool(String name, String description, String schemaDefinition) {
+        URLMapping mapping = new URLMapping();
+        mapping.setUrlPattern(name);
+        mapping.setDescription(description);
+        mapping.setSchemaDefinition(schemaDefinition);
+        return mapping;
+    }
+
+    /**
+     * Regression core — a proxied (third-party) tool whose stored definition wraps the input schema together
+     * with annotations, _meta and outputSchema must have EVERY one of those fields emitted in tools/list, and
+     * the input schema passed through UNCHANGED (proxy schemas are not sanitized). Before the fix only
+     * name/description/inputSchema were emitted.
+     */
+    @Test
+    public void testProxyToolPreservesMetadataInToolsList() {
+
+        String schema = "{"
+                + "\"inputSchema\":{\"type\":\"object\",\"properties\":{\"query_city\":{\"type\":\"string\"}},"
+                + "  \"required\":[\"query_city\"]},"
+                + "\"title\":\"Weather Lookup\","
+                + "\"annotations\":{\"readOnlyHint\":true,\"title\":\"Weather\"},"
+                + "\"_meta\":{\"vendor\":\"wso2\"},"
+                + "\"outputSchema\":{\"type\":\"object\",\"properties\":{\"temp\":{\"type\":\"number\"}},"
+                + "  \"required\":[\"temp\"]},"
+                + "\"execution\":{\"mode\":\"async\",\"timeout\":30}"
+                + "}";
+        List<URLMapping> ops = Collections.singletonList(tool("get_weather", "Returns the weather", schema));
+
+        JsonArray tools = toolsOf(MCPPayloadGenerator.generateToolListPayload(1, ops, true));
+        Assert.assertEquals(1, tools.size());
+        JsonObject t = tools.get(0).getAsJsonObject();
+
+        Assert.assertEquals("get_weather", t.get("name").getAsString());
+        Assert.assertEquals("Returns the weather", t.get("description").getAsString());
+
+        Assert.assertEquals("top-level title must be preserved", "Weather Lookup", t.get("title").getAsString());
+        Assert.assertTrue("execution must be preserved", t.has("execution"));
+        Assert.assertEquals("execution.mode value must be preserved", "async",
+                t.getAsJsonObject("execution").get("mode").getAsString());
+        Assert.assertEquals("execution.timeout value must be preserved", 30,
+                t.getAsJsonObject("execution").get("timeout").getAsInt());
+
+        Assert.assertTrue("annotations must be preserved", t.has("annotations"));
+        Assert.assertTrue("annotations.readOnlyHint value must be preserved",
+                t.getAsJsonObject("annotations").get("readOnlyHint").getAsBoolean());
+        Assert.assertEquals("annotations.title value must be preserved", "Weather",
+                t.getAsJsonObject("annotations").get("title").getAsString());
+
+        Assert.assertTrue("_meta must be preserved", t.has("_meta"));
+        Assert.assertEquals("wso2", t.getAsJsonObject("_meta").get("vendor").getAsString());
+
+        Assert.assertTrue("outputSchema must be preserved", t.has("outputSchema"));
+        Assert.assertEquals("outputSchema contents must be preserved verbatim", "number",
+                t.getAsJsonObject("outputSchema").getAsJsonObject("properties")
+                        .getAsJsonObject("temp").get("type").getAsString());
+        Assert.assertEquals("outputSchema.required must be preserved verbatim", "temp",
+                t.getAsJsonObject("outputSchema").getAsJsonArray("required").get(0).getAsString());
+
+        // Proxy input schema is passed through verbatim (not sanitized).
+        JsonObject inputSchema = t.getAsJsonObject("inputSchema");
+        Assert.assertTrue("proxy inputSchema must be passed through unchanged",
+                inputSchema.getAsJsonObject("properties").has("query_city"));
+    }
+
+    /**
+     * Backward compatibility — a proxied tool stored in the LEGACY shape (the definition is the bare input
+     * schema, with no {@code inputSchema} wrapper key) is still emitted with its input schema, unchanged.
+     */
+    @Test
+    public void testProxyToolWithLegacyBareSchemaIsPassedThrough() {
+
+        // Prefixed key: the third-party path must pass it through unchanged.
+        String bareSchema = "{\"type\":\"object\",\"properties\":{\"query_message\":{\"type\":\"string\"}},"
+                + "\"required\":[\"query_message\"]}";
+        List<URLMapping> ops = Collections.singletonList(tool("echo", "Echoes the message", bareSchema));
+
+        JsonArray tools = toolsOf(MCPPayloadGenerator.generateToolListPayload(1, ops, true));
+        JsonObject t = tools.get(0).getAsJsonObject();
+
+        Assert.assertEquals("echo", t.get("name").getAsString());
+        Assert.assertTrue("inputSchema must be emitted", t.has("inputSchema"));
+        JsonObject properties = t.getAsJsonObject("inputSchema").getAsJsonObject("properties");
+        Assert.assertTrue("bare proxy schema must be passed through unchanged (prefix retained)",
+                properties.has("query_message"));
+        Assert.assertFalse("prefix must NOT be stripped on the third-party path", properties.has("message"));
+        Assert.assertEquals("required must retain the prefixed key", "query_message",
+                t.getAsJsonObject("inputSchema").getAsJsonArray("required").get(0).getAsString());
+        Assert.assertFalse("no metadata should be invented for a bare schema", t.has("annotations"));
+    }
+
+    /**
+     * For a NON third-party (OpenAPI/API-generated) server the input schema is SANITIZED (header/query/path
+     * prefixes stripped, {@code contentType} removed) — while any sibling metadata is still emitted.
+     */
+    @Test
+    public void testNonProxyToolSanitizesInputSchemaButKeepsMetadata() {
+
+        String schema = "{"
+                + "\"inputSchema\":{\"type\":\"object\","
+                + "  \"properties\":{\"query_city\":{\"type\":\"string\"},\"contentType\":{\"type\":\"string\"}},"
+                + "  \"required\":[\"query_city\"]},"
+                + "\"annotations\":{\"readOnlyHint\":true}"
+                + "}";
+        List<URLMapping> ops = Collections.singletonList(tool("get_weather", "Returns the weather", schema));
+
+        JsonArray tools = toolsOf(MCPPayloadGenerator.generateToolListPayload(1, ops, false));
+        JsonObject t = tools.get(0).getAsJsonObject();
+
+        JsonObject properties = t.getAsJsonObject("inputSchema").getAsJsonObject("properties");
+        Assert.assertTrue("query_ prefix must be stripped for non-proxy", properties.has("city"));
+        Assert.assertFalse("prefixed key must not remain", properties.has("query_city"));
+        Assert.assertFalse("contentType must be removed", properties.has("contentType"));
+        Assert.assertTrue("required prefix must be stripped",
+                t.getAsJsonObject("inputSchema").getAsJsonArray("required").get(0).getAsString().equals("city"));
+        Assert.assertTrue("sibling metadata must still be emitted", t.has("annotations"));
+        Assert.assertTrue("annotations.readOnlyHint value must be preserved on the non-proxy path",
+                t.getAsJsonObject("annotations").get("readOnlyHint").getAsBoolean());
+    }
+
+    /**
+     * A null description is omitted from the emitted tool object (never serialized as a null/empty field).
+     */
+    @Test
+    public void testNullDescriptionIsOmitted() {
+
+        List<URLMapping> ops = Collections.singletonList(tool("echo", null, null));
+
+        JsonArray tools = toolsOf(MCPPayloadGenerator.generateToolListPayload(1, ops, true));
+        JsonObject t = tools.get(0).getAsJsonObject();
+
+        Assert.assertEquals("echo", t.get("name").getAsString());
+        Assert.assertFalse("null description must be omitted", t.has("description"));
+    }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/MCPInitializerAndToolFetcher.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/MCPInitializerAndToolFetcher.java
@@ -281,6 +281,25 @@ public class MCPInitializerAndToolFetcher {
     }
 
     /**
+     * Build the schema definition for a tool: all tool fields except name and description
+     * (i.e. the input schema plus any metadata such as annotations, _meta and outputSchema).
+     *
+     * @param toolJson Tool definition returned by the MCP server
+     * @return JSON object containing all tool fields except name and description
+     */
+    public static org.json.JSONObject buildToolMetadata(org.json.JSONObject toolJson) {
+
+        org.json.JSONObject toolMetadata = new org.json.JSONObject();
+        for (String key : toolJson.keySet()) {
+            if (!APIConstants.MCP.TOOL_NAME_KEY.equals(key)
+                    && !APIConstants.MCP.TOOL_DESCRIPTION_KEY.equals(key)) {
+                toolMetadata.put(key, toolJson.get(key));
+            }
+        }
+        return toolMetadata;
+    }
+
+    /**
      * Extract the tools array from a tools/list response.
      *
      * @param toolsJson Raw JSON returned by tools/list

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/MCPInitializerAndToolFetcher.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/MCPInitializerAndToolFetcher.java
@@ -287,9 +287,9 @@ public class MCPInitializerAndToolFetcher {
      * @param toolJson Tool definition returned by the MCP server
      * @return JSON object containing all tool fields except name and description
      */
-    public static org.json.JSONObject buildToolMetadata(org.json.JSONObject toolJson) {
+    public static JSONObject buildToolMetadata(JSONObject toolJson) {
 
-        org.json.JSONObject toolMetadata = new org.json.JSONObject();
+        JSONObject toolMetadata = new JSONObject();
         for (String key : toolJson.keySet()) {
             if (!APIConstants.MCP.TOOL_NAME_KEY.equals(key)
                     && !APIConstants.MCP.TOOL_DESCRIPTION_KEY.equals(key)) {

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/restapi/publisher/ApisApiServiceImplUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/restapi/publisher/ApisApiServiceImplUtils.java
@@ -927,7 +927,8 @@ public class ApisApiServiceImplUtils {
                         ExceptionCodes.PARAMETER_NOT_PROVIDED);
             }
 
-            schemaByToolName.put(toolName, inputSchema);
+            schemaByToolName.put(toolName,
+                    MCPInitializerAndToolFetcher.buildToolMetadata(toolJson).toString());
             descriptionByToolName.put(toolName, toolDescription);
         }
     }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/MCPInitializerAndToolFetcherTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/MCPInitializerAndToolFetcherTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.apimgt.impl;
+
+import org.json.JSONObject;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link MCPInitializerAndToolFetcher#buildToolMetadata(JSONObject)} — the helper that,
+ * for a proxied MCP server, retains the complete tool definition (every field except {@code name} and
+ * {@code description}, which are served from their own columns) so metadata such as {@code annotations},
+ * {@code _meta} and {@code outputSchema} is not lost.
+ */
+public class MCPInitializerAndToolFetcherTest {
+
+    /**
+     * A tool carrying metadata beyond the basic three fields keeps every field EXCEPT name/description —
+     * this is the core of the metadata-preservation fix (annotations, _meta, outputSchema, title, execution
+     * survive).
+     */
+    @Test
+    public void testBuildToolMetadataRetainsAllFieldsExceptNameAndDescription() {
+
+        JSONObject inputSchema = new JSONObject()
+                .put("type", "object")
+                .put("properties", new JSONObject().put("message", new JSONObject().put("type", "string")));
+        JSONObject annotations = new JSONObject().put("readOnlyHint", true).put("title", "Echo");
+        JSONObject meta = new JSONObject().put("vendor", "wso2").put("weight", 5);
+        JSONObject outputSchema = new JSONObject()
+                .put("type", "object")
+                .put("properties", new JSONObject().put("result", new JSONObject().put("type", "string")));
+        JSONObject execution = new JSONObject().put("mode", "async").put("timeout", 30);
+
+        JSONObject toolJson = new JSONObject()
+                .put("name", "echo")
+                .put("description", "Echoes the provided message")
+                .put("title", "Echo Tool")
+                .put("inputSchema", inputSchema)
+                .put("annotations", annotations)
+                .put("_meta", meta)
+                .put("outputSchema", outputSchema)
+                .put("execution", execution);
+
+        JSONObject result = MCPInitializerAndToolFetcher.buildToolMetadata(toolJson);
+
+        Assert.assertFalse("name must not be retained in the schema definition", result.has("name"));
+        Assert.assertFalse("description must not be retained in the schema definition", result.has("description"));
+
+        Assert.assertTrue("inputSchema must be retained", result.has("inputSchema"));
+        Assert.assertTrue("annotations must be retained", result.has("annotations"));
+        Assert.assertTrue("_meta must be retained", result.has("_meta"));
+        Assert.assertTrue("outputSchema must be retained", result.has("outputSchema"));
+        Assert.assertTrue("title must be retained", result.has("title"));
+        Assert.assertTrue("execution must be retained", result.has("execution"));
+
+        Assert.assertEquals("Echo Tool", result.getString("title"));
+        Assert.assertTrue("annotations value must be preserved verbatim",
+                annotations.similar(result.getJSONObject("annotations")));
+        Assert.assertTrue("_meta value must be preserved verbatim",
+                meta.similar(result.getJSONObject("_meta")));
+        Assert.assertTrue("outputSchema value must be preserved verbatim",
+                outputSchema.similar(result.getJSONObject("outputSchema")));
+        Assert.assertTrue("inputSchema value must be preserved verbatim",
+                inputSchema.similar(result.getJSONObject("inputSchema")));
+        Assert.assertTrue("execution value must be preserved verbatim",
+                execution.similar(result.getJSONObject("execution")));
+    }
+
+    /**
+     * A minimal tool with only name and description yields an empty metadata object (nothing to retain).
+     */
+    @Test
+    public void testBuildToolMetadataWithOnlyNameAndDescriptionYieldsEmptyObject() {
+
+        JSONObject toolJson = new JSONObject()
+                .put("name", "ping")
+                .put("description", "No-op tool");
+
+        JSONObject result = MCPInitializerAndToolFetcher.buildToolMetadata(toolJson);
+
+        Assert.assertEquals("no fields other than name/description should remain", 0, result.length());
+    }
+
+    /**
+     * The common legacy shape (name/description/inputSchema, no extra metadata) yields exactly the input
+     * schema under the {@code inputSchema} key — proving backward compatibility of the stored definition.
+     */
+    @Test
+    public void testBuildToolMetadataWithInputSchemaOnlyRetainsInputSchema() {
+
+        JSONObject inputSchema = new JSONObject().put("type", "object").put("properties", new JSONObject());
+        JSONObject toolJson = new JSONObject()
+                .put("name", "get_pets")
+                .put("description", "Returns the list of pets")
+                .put("inputSchema", inputSchema);
+
+        JSONObject result = MCPInitializerAndToolFetcher.buildToolMetadata(toolJson);
+
+        Assert.assertEquals("only inputSchema should remain", 1, result.length());
+        Assert.assertTrue("inputSchema must be retained", result.has("inputSchema"));
+        Assert.assertTrue(inputSchema.similar(result.getJSONObject("inputSchema")));
+    }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/PublisherCommonUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/PublisherCommonUtils.java
@@ -5221,7 +5221,8 @@ public class PublisherCommonUtils {
             serverOperation.setFeature(MCPServerOperationDTO.FeatureEnum.TOOL);
             serverOperation.setTarget(toolName);
             serverOperation.setDescription(toolDescription);
-            serverOperation.setSchemaDefinition(inputSchema);
+            serverOperation.setSchemaDefinition(
+                    MCPInitializerAndToolFetcher.buildToolMetadata(toolJsonObject).toString());
             operationList.add(serverOperation);
         }
         return operationList;

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/PublisherCommonUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/PublisherCommonUtils.java
@@ -5280,7 +5280,8 @@ public class PublisherCommonUtils {
             serverOperation.setFeature(MCPServerOperationDTO.FeatureEnum.TOOL);
             serverOperation.setTarget(toolName);
             serverOperation.setDescription(toolDescription);
-            serverOperation.setSchemaDefinition(inputSchema);
+            serverOperation.setSchemaDefinition(
+                    MCPInitializerAndToolFetcher.buildToolMetadata(toolJsonObject).toString());
             operationList.add(serverOperation);
         }
         return operationList;


### PR DESCRIPTION
### Problem
When an MCP server is proxied through API Manager ("Proxy Existing MCP Server"), the `tools/list` response only returned `name`, `description`, and `inputSchema`. Other tool-level fields sent by the upstream server (`annotations`, `_meta`, `outputSchema`, `title`, `execution`, etc.) were dropped, so clients saw less metadata than on a direct connection.

**Root cause:** Only the tool's `inputSchema` was persisted in `AM_API_URL_MAPPING.SCHEMA_DEFINITION`, and the `tools/list` builder could emit only `name`/`description`/`inputSchema`.

Related Issue : https://github.com/wso2/api-manager/issues/5120

### Fix
Retain the complete tool definition for proxied MCP servers and return all of its fields in the tools/list response. Fully backward compatible .MCP servers created before this change continue to work as before.

### Scope
* Only the proxy (`SERVER_PROXY`) path stores the richer definition.
* OpenAPI and existing-API creation paths are unchanged (their sources carry no such metadata).
* `name` and `description` continue to be served from their own columns.