### PR TITLE
Wrap Redis errors in DistributedCounterException

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/RedisBaseDistributedCountManager.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/RedisBaseDistributedCountManager.java
@@ -20,13 +20,16 @@ package org.wso2.carbon.apimgt.gateway;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.apache.synapse.commons.throttle.core.DistributedCounterException;
 import org.apache.synapse.commons.throttle.core.DistributedCounterManager;
 import org.wso2.carbon.apimgt.impl.dto.RedisConfig;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisPool;
 import redis.clients.jedis.Response;
 import redis.clients.jedis.Transaction;
+import redis.clients.jedis.exceptions.JedisConnectionException;
 import redis.clients.jedis.exceptions.JedisException;
+import redis.clients.jedis.exceptions.JedisExhaustedPoolException;
 import redis.clients.jedis.params.SetParams;
 
 import java.util.List;
@@ -495,6 +498,9 @@ public class RedisBaseDistributedCountManager implements DistributedCounterManag
                 }
                 return acquired;
             }
+        } catch (JedisException e) {
+            throw new DistributedCounterException(
+                    "Redis error acquiring lock for key: " + key, e, toKind(e));
         } finally {
             if (log.isTraceEnabled()) {
                 log.trace("Time Taken to setLockWithExpiry :" + (System.currentTimeMillis() - startTime));
@@ -573,8 +579,8 @@ public class RedisBaseDistributedCountManager implements DistributedCounterManag
                 }
             }
         } catch (JedisException e) {
-            log.error("Redis error in getWindowState for key: " + key, e);
-            throw e;
+            throw new DistributedCounterException(
+                    "Redis error in getWindowState for key: " + key, e, toKind(e));
         } finally {
             if (log.isTraceEnabled()) {
                 log.trace("Time Taken to getWindowState :" + (System.currentTimeMillis() - startTime));
@@ -586,35 +592,21 @@ public class RedisBaseDistributedCountManager implements DistributedCounterManag
     public void setWindow(String key, long count, long ts, long expiryTime) {
         long startTime = System.currentTimeMillis();
         try {
-            // Reject already-expired windows upfront: pexpireAt with a past timestamp
-            // would immediately delete the hash, wasting a Redis round-trip and silently
-            // returning success to the caller.
-            long now = startTime;
-            if (expiryTime <= now) {
-                throw new JedisException("setWindow called with already-expired expiryTime="
-                        + expiryTime + " (now=" + now + ") for key: " + key
-                        + ". Window TTL would be zero or negative.");
-            }
             try (Jedis jedis = redisPool.getResource()) {
-                now = System.currentTimeMillis();
-                if (expiryTime <= now) {
-                    throw new JedisException("setWindow called with already-expired expiryTime="
-                            + expiryTime + " (now=" + now + ") for key: " + key
-                            + ". Window expired while waiting for Redis connection.");
-                }
                 Transaction tx = jedis.multi();
                 tx.hset(key, "ts", String.valueOf(ts));
                 tx.hset(key, "counter", String.valueOf(count));
                 tx.pexpireAt(key, expiryTime);
                 List<Object> results = tx.exec();
                 if (results == null || results.size() < 3) {
-                    throw new JedisException("Transaction failed for setWindow on key: "
-                            + key + " results=" + results);
+                    throw new DistributedCounterException(
+                            "Transaction failed for setWindow on key: " + key
+                            + " results=" + results, null, DistributedCounterException.Kind.TRANSACTION_ABORT);
                 }
             }
         } catch (JedisException e) {
-            log.error("Redis error in setWindow for key: " + key, e);
-            throw e;
+            throw new DistributedCounterException(
+                    "Redis error in setWindow for key: " + key, e, toKind(e));
         } finally {
             if (log.isTraceEnabled()) {
                 log.trace("Time Taken to setWindow :" + (System.currentTimeMillis() - startTime));
@@ -626,23 +618,7 @@ public class RedisBaseDistributedCountManager implements DistributedCounterManag
     public long incrWindowCounter(String key, long delta, long expiryTime) {
         long startTime = System.currentTimeMillis();
         try {
-            // Reject already-expired TTLs upfront: pexpireAt with a past timestamp would
-            // immediately delete the hash (including the just-incremented counter), causing
-            // the caller to skip its local commit and re-push the same delta next tick.
-            long now = startTime;
-            if (expiryTime <= now) {
-                throw new JedisException("incrWindowCounter called with already-expired expiryTime="
-                        + expiryTime + " (now=" + now + ") for key: " + key
-                        + ". Refusing to push delta=" + delta + " to an expired window.");
-            }
             try (Jedis jedis = redisPool.getResource()) {
-                now = System.currentTimeMillis();
-                if (expiryTime <= now) {
-                    throw new JedisException("incrWindowCounter called with already-expired expiryTime="
-                            + expiryTime + " (now=" + now + ") for key: " + key
-                            + ". Window expired while waiting for Redis connection."
-                            + " Refusing to push delta=" + delta + ".");
-                }
                 Transaction tx = jedis.multi();
                 Response<Long> counterResp = tx.hincrBy(key, "counter", delta);
                 // pexpireAt guards against the narrow race where the hash TTL fires between
@@ -651,23 +627,35 @@ public class RedisBaseDistributedCountManager implements DistributedCounterManag
                 tx.pexpireAt(key, expiryTime);
                 List<Object> results = tx.exec();
                 if (results == null || results.size() < 2) {
-                    throw new JedisException("Transaction failed for incrWindowCounter on key: "
-                            + key + " results=" + results);
+                    throw new DistributedCounterException(
+                            "Transaction failed for incrWindowCounter on key: " + key
+                            + " results=" + results, null, DistributedCounterException.Kind.TRANSACTION_ABORT);
                 }
                 Long newCounter = counterResp.get();
                 if (newCounter == null) {
-                    throw new JedisException("Counter increment returned null for key: " + key);
+                    throw new DistributedCounterException(
+                            "Counter increment returned null for key: " + key, null,
+                            DistributedCounterException.Kind.SERVER_ERROR);
                 }
                 return newCounter;
             }
         } catch (JedisException e) {
-            log.error("Redis error in incrWindowCounter for key: " + key, e);
-            throw e;
+            throw new DistributedCounterException(
+                    "Redis error in incrWindowCounter for key: " + key, e, toKind(e));
         } finally {
             if (log.isTraceEnabled()) {
                 log.trace("Time Taken to incrWindowCounter :" + (System.currentTimeMillis() - startTime));
             }
         }
     }
-}
 
+    private static DistributedCounterException.Kind toKind(JedisException e) {
+        if (e instanceof JedisExhaustedPoolException) {
+            return DistributedCounterException.Kind.POOL_EXHAUSTED;
+        }
+        if (e instanceof JedisConnectionException) {
+            return DistributedCounterException.Kind.CONNECTION_FAILURE;
+        }
+        return DistributedCounterException.Kind.SERVER_ERROR;
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -2106,7 +2106,7 @@
         <carbon.commons.version>4.13.3</carbon.commons.version>
 
         <carbon.registry.version>4.9.13</carbon.registry.version>
-        <carbon.mediation.version>4.8.19</carbon.mediation.version>
+        <carbon.mediation.version>4.8.20</carbon.mediation.version>
 
         <mongodb.driver.version>4.1.0</mongodb.driver.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -2188,7 +2188,7 @@
         <imp.package.version.osgi.framework>[1.6.0, 2.0.0)</imp.package.version.osgi.framework>
 
         <!-- Misc Versions -->
-        <synapse.version>4.1.0-wso2v57</synapse.version>
+        <synapse.version>4.1.0-wso2v59</synapse.version>
         <orbit.version.json>3.0.0.wso2v7</orbit.version.json>
 
         <!-- orbit httpmime versions-->


### PR DESCRIPTION
### Description

This pull request refactors error handling in the `RedisBaseDistributedCountManager` class to standardize and improve exception reporting for Redis operations. It introduces the use of `DistributedCounterException` in place of direct `JedisException` usage, provides better error context, and removes redundant early-expiry checks for window operations.

**Error handling improvements:**

* Replaces all direct `JedisException` throws and logs in `setLockWithExpiry`, `getWindowState`, `setWindow`, and `incrWindowCounter` with `DistributedCounterException`, including additional context and error kind classification using a new `toKind` helper method. [[1]](diffhunk://#diff-7bc14acf7420fc908a6db1393bc7c04509c998f188a45223a1b3622defee5816R501-R503) [[2]](diffhunk://#diff-7bc14acf7420fc908a6db1393bc7c04509c998f188a45223a1b3622defee5816L576-R583) [[3]](diffhunk://#diff-7bc14acf7420fc908a6db1393bc7c04509c998f188a45223a1b3622defee5816L589-R609) [[4]](diffhunk://#diff-7bc14acf7420fc908a6db1393bc7c04509c998f188a45223a1b3622defee5816L654-R661)
* Adds a private `toKind(JedisException)` method to map specific Jedis exceptions to `DistributedCounterException.Kind` values, improving error diagnostics.

**Code simplification:**

* Removes redundant checks for already-expired window TTLs in `setWindow` and `incrWindowCounter`, relying on Redis behavior and simplifying the code paths. [[1]](diffhunk://#diff-7bc14acf7420fc908a6db1393bc7c04509c998f188a45223a1b3622defee5816L589-R609) [[2]](diffhunk://#diff-7bc14acf7420fc908a6db1393bc7c04509c998f188a45223a1b3622defee5816L629-L645)

**Dependency updates:**

* Adds missing imports for `DistributedCounterException`, `JedisConnectionException`, and `JedisExhaustedPoolException` to support the new error handling logic.

### Related Issue
- https://github.com/wso2/api-manager/issues/5113