### PR TITLE
Improve distributed throttle counter reset reliability and add Redis connection pool config

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -1852,6 +1852,8 @@ public final class APIConstants {
     public static final String DISTRIBUTED_THROTTLE_MIN_EVICTABLE_IDLE_TIME_IN_MILLIS = "MinEvictableIdleTimeMillis";
     public static final String DISTRIBUTED_THROTTLE_TIME_BETWEEN_EVICTION_RUNS_IN_MILLIS = "TimeBetweenEvictionRunsMillis";
     public static final String DISTRIBUTED_THROTTLE_NUM_TESTS_PER_EVICTION_RUNS = "NumTestsPerEvictionRun";
+    public static final String DISTRIBUTED_THROTTLE_SOCKET_TIMEOUT = "SocketTimeout";
+    public static final String DISTRIBUTED_THROTTLE_MAX_WAIT_MILLIS = "MaxWaitMillis";
 
     // Solace Configurations
     public static final String SOLACE_CONFIG = "SolaceConfig";

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIManagerConfiguration.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIManagerConfiguration.java
@@ -618,6 +618,7 @@ public class APIManagerConfiguration {
                     OMElement password = propertiesElement.getFirstChildWithName(new QName(APIConstants.DISTRIBUTED_THROTTLE_PASSWORD));
                     OMElement databaseId = propertiesElement.getFirstChildWithName(new QName(APIConstants.DISTRIBUTED_THROTTLE_DATABASE_ID));
                     OMElement connectionTimeout = propertiesElement.getFirstChildWithName(new QName(APIConstants.DISTRIBUTED_THROTTLE_CONNECTION_TIMEOUT));
+                    OMElement socketTimeout = propertiesElement.getFirstChildWithName(new QName(APIConstants.DISTRIBUTED_THROTTLE_SOCKET_TIMEOUT));
                     OMElement isSslEnabled = propertiesElement.getFirstChildWithName(new QName(APIConstants.DISTRIBUTED_THROTTLE_IS_SSL_ENABLED));
 
                     if (host != null && StringUtils.isNotBlank(host.getText())) {
@@ -654,7 +655,15 @@ public class APIManagerConfiguration {
                             distributedThrottleConfig.setConnectionTimeout(Integer.parseInt(connectionTimeout.getText().trim()));
                         } catch (NumberFormatException e) {
                             log.warn("Invalid connectionTimeout value: " + connectionTimeout.getText(), e);
-                        }                    }
+                        }
+                    }
+                    if (socketTimeout != null) {
+                        try {
+                            distributedThrottleConfig.setSocketTimeout(Integer.parseInt(socketTimeout.getText().trim()));
+                        } catch (NumberFormatException e) {
+                            log.warn("Invalid socketTimeout value: " + socketTimeout.getText(), e);
+                        }
+                    }
                     if (isSslEnabled != null) {
                         distributedThrottleConfig.setSslEnabled(Boolean.parseBoolean(isSslEnabled.getText().trim()));
                     }
@@ -683,6 +692,8 @@ public class APIManagerConfiguration {
                                 distributedThrottleConfig.setTimeBetweenEvictionRunsMillis(Long.parseLong(propertyNode.getText()));
                             } else if (APIConstants.DISTRIBUTED_THROTTLE_NUM_TESTS_PER_EVICTION_RUNS.equals(propertyNode.getLocalName())) {
                                 distributedThrottleConfig.setNumTestsPerEvictionRun(Integer.parseInt(propertyNode.getText()));
+                            } else if (APIConstants.DISTRIBUTED_THROTTLE_MAX_WAIT_MILLIS.equals(propertyNode.getLocalName())) {
+                                distributedThrottleConfig.setMaxWaitMillis(Long.parseLong(propertyNode.getText()));
                             }
                         }
                     }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dto/DistributedThrottleConfig.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dto/DistributedThrottleConfig.java
@@ -47,6 +47,8 @@ public class DistributedThrottleConfig {
     private int numTestsPerEvictionRun = -1;
     private boolean isSslEnabled;
     private int connectionTimeout;
+    private int socketTimeout;
+    private long maxWaitMillis = 3000L;
 
     public String getHost() {
         return host;
@@ -223,4 +225,19 @@ public class DistributedThrottleConfig {
         this.databaseId = databaseId;
     }
 
+    public int getSocketTimeout() {
+        return socketTimeout;
+    }
+
+    public void setSocketTimeout(int socketTimeout) {
+        this.socketTimeout = socketTimeout;
+    }
+
+    public long getMaxWaitMillis() {
+        return maxWaitMillis;
+    }
+
+    public void setMaxWaitMillis(long maxWaitMillis) {
+        this.maxWaitMillis = maxWaitMillis;
+    }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.throttling.siddhi.extension/src/main/java/org/wso2/carbon/apimgt/throttling/siddhi/extension/DistributedCountAttributeAggregator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.throttling.siddhi.extension/src/main/java/org/wso2/carbon/apimgt/throttling/siddhi/extension/DistributedCountAttributeAggregator.java
@@ -24,6 +24,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -42,7 +43,7 @@ import org.wso2.siddhi.query.api.definition.Attribute;
 public class DistributedCountAttributeAggregator extends AttributeAggregator {
 
     private static final Log log = LogFactory.getLog(DistributedCountAttributeAggregator.class);
-    private static Attribute.Type type = Attribute.Type.LONG;
+    private static final Attribute.Type type = Attribute.Type.LONG;
     private KeyValueStoreClient kvStoreClient;
     private String key;
     private final AtomicLong localCounter = new AtomicLong(0L);
@@ -68,8 +69,11 @@ public class DistributedCountAttributeAggregator extends AttributeAggregator {
 
     // Static shared scheduler for all aggregators
     private static ScheduledExecutorService kvStoreSyncScheduler = null;
-    private static final ScheduledExecutorService masterScheduler =
-            Executors.newSingleThreadScheduledExecutor(r -> new Thread(r, Thread.currentThread().getName()));
+    private static ScheduledFuture<?> masterSyncTask = null;
+    private static ScheduledExecutorService masterScheduler = null;
+    private volatile boolean pendingReset = false;
+    private volatile long storedWindowExpiry = 0L;
+    private volatile boolean keyHasTTL = false;
 
 
     /**
@@ -83,13 +87,16 @@ public class DistributedCountAttributeAggregator extends AttributeAggregator {
         if (DISTRIBUTED_THROTTLE_CONFIG == null) {
             synchronized (DistributedCountAttributeAggregator.class) {
                 if (DISTRIBUTED_THROTTLE_CONFIG == null) {
-                    DISTRIBUTED_THROTTLE_CONFIG = getDistributedThrottleConfig();
+                    DistributedThrottleConfig config = getDistributedThrottleConfig();
+                    if (config != null) {
+                        // Plain writes BEFORE the volatile store — any thread that later reads
+                        // DISTRIBUTED_THROTTLE_CONFIG as non-null sees these via JMM happens-before.
+                        distributedThrottlingEnabled = config.isEnabled();
+                        corePoolSize = config.getCorePoolSize();
+                        kvStoreSyncIntervalMilliseconds = config.getSyncInterval();
+                        DISTRIBUTED_THROTTLE_CONFIG = config; // volatile write last
+                    }
                 }
-            }
-            if (DISTRIBUTED_THROTTLE_CONFIG != null) {
-                distributedThrottlingEnabled = DISTRIBUTED_THROTTLE_CONFIG.isEnabled();
-                corePoolSize = DISTRIBUTED_THROTTLE_CONFIG.getCorePoolSize();
-                kvStoreSyncIntervalMilliseconds = DISTRIBUTED_THROTTLE_CONFIG.getSyncInterval();
             }
         }
         String throttleKey = QuerySelector.getThreadLocalGroupByKey();
@@ -125,7 +132,7 @@ public class DistributedCountAttributeAggregator extends AttributeAggregator {
                 long initialValue = Long.parseLong(kvStoreValue);
                 localCounter.set(initialValue);
             } else {
-                kvStoreClient.set(key, "0");
+                writeCounterValue("0");
             }
         } catch (Exception e) {
             log.error("Error initializing from key-value store for key " + key, e);
@@ -134,30 +141,107 @@ public class DistributedCountAttributeAggregator extends AttributeAggregator {
     }
 
     /**
+     * Writes the given value to the key-value store with the remaining TTL of the current window.
+     * Does nothing when {@code storedWindowExpiry} is not yet known or has already passed.
+     *
+     * @param value the value to store for this aggregator's key.
+     */
+    private void writeCounterValue(String value) {
+        long windowExpiry = storedWindowExpiry;
+        if (windowExpiry > 0) {
+            long remainingMillis = windowExpiry - System.currentTimeMillis();
+            if (remainingMillis > 0) {
+                kvStoreClient.setWithExpiry(key, value, remainingMillis);
+            }
+        }
+    }
+
+    /**
      * Synchronize the local counter with the key-value store.
-     * Update the key-value store with the unsynced counter value.
+     * Pending resets (PSETEX "0") are flushed first and retried on failure; then any
+     * accumulated delta is pushed via INCRBY/DECRBY, or the current Redis value is pulled
+     * when there is no local change.
      */
     private void syncWithKVStore() {
         synchronized (kvStoreLock) {
             if (kvStoreClient == null || key == null) {
                 return;
             }
+            if (pendingReset) {
+                try {
+                    writeCounterValue("0");
+                    // Do NOT reset localCounter here — reset() already zeroed it at window boundary.
+                    // Any increments to localCounter since then belong to the new window and are valid.
+                    pendingReset = false; // cleared only on success — failure retried next tick
+                    keyHasTTL = true;
+                } catch (KeyValueStoreException e) {
+                    long currentTimeMillis = System.currentTimeMillis();
+                    if (currentTimeMillis - lastErrorLogTimestamp.get() > ERROR_LOG_INTERVAL_MS) {
+                        log.error("Error resetting counter in key-value store for key " + key, e);
+                        lastErrorLogTimestamp.set(currentTimeMillis);
+                    }
+                }
+                return;
+            }
             long currentUnsyncedCount = unsyncedCounter.getAndSet(0L);
+            if (pendingReset) {
+                // reset() fired between our initial pendingReset check and getAndSet —
+                // discard the captured old-window delta; the next tick will PSETEX 0.
+                return;
+            }
             try {
                 if (currentUnsyncedCount == 0) {
-                    localCounter.set(Long.parseLong(kvStoreClient.get(key)));
-                } else if (currentUnsyncedCount > 0) {
-                    localCounter.set(kvStoreClient.incrementBy(key, currentUnsyncedCount));
+                    String kvStoreValue = kvStoreClient.get(key);
+                    if (kvStoreValue == null) {
+                        writeCounterValue("0");
+                        localCounter.set(0L);
+                    } else if (!pendingReset) {
+                        // skip if reset() fired while waiting for the GET response —
+                        // the returned value is the old-window total and must not overwrite localCounter=0.
+                        localCounter.set(Long.parseLong(kvStoreValue));
+                    }
                 } else {
-                    localCounter.set(kvStoreClient.decrementBy(key, Math.abs(currentUnsyncedCount)));
+                    long kvStoreValue;
+                    if (currentUnsyncedCount > 0) {
+                        kvStoreValue = kvStoreClient.incrementBy(key, currentUnsyncedCount);
+                    } else {
+                        kvStoreValue = kvStoreClient.decrementBy(key, Math.abs(currentUnsyncedCount));
+                    }
+                    // INCRBY/DECRBY never sets a TTL. Stamp one the first time after a gap
+                    // (empty windows) where the key was recreated without a TTL.
+                    if (!keyHasTTL) {
+                        long expiry = storedWindowExpiry;
+                        long remainingMillis = expiry - System.currentTimeMillis();
+                        if (remainingMillis > 0) {
+                            try {
+                                kvStoreClient.expireMillis(key, remainingMillis);
+                                keyHasTTL = true;
+                            } catch (KeyValueStoreException e) {
+                                // Non-fatal: retried on the next sync tick while keyHasTTL is false.
+                                long now = System.currentTimeMillis();
+                                if (now - lastErrorLogTimestamp.get() > ERROR_LOG_INTERVAL_MS) {
+                                    log.warn("Could not set TTL via PEXPIRE for key " + key, e);
+                                    lastErrorLogTimestamp.set(now);
+                                }
+                            }
+                        }
+                    }
+                    if (!pendingReset) {
+                        // guard: reset() can fire while the INCRBY/DECRBY is in flight;
+                        // discard the result to avoid reinstating old-window counts in localCounter.
+                        localCounter.set(kvStoreValue);
+                    }
                 }
-            } catch (KeyValueStoreException e) {
+            } catch (KeyValueStoreException | NumberFormatException e) {
                 long currentTimeMillis = System.currentTimeMillis();
                 if (currentTimeMillis - lastErrorLogTimestamp.get() > ERROR_LOG_INTERVAL_MS) {
                     log.error("Error syncing with key-value store for the key " + key, e);
                     lastErrorLogTimestamp.set(currentTimeMillis);
                 }
-                unsyncedCounter.addAndGet(currentUnsyncedCount);
+                // skip restore if reset() fired after the snapshot — old-window delta must be discarded
+                if (!pendingReset) {
+                    unsyncedCounter.addAndGet(currentUnsyncedCount);
+                }
             }
         }
     }
@@ -177,11 +261,20 @@ public class DistributedCountAttributeAggregator extends AttributeAggregator {
     @Override
     public Object processAdd(Object data) {
         try {
-            localCounter.incrementAndGet();
+            long newCount = localCounter.incrementAndGet();
             if (distributedThrottlingEnabled && kvStoreClient != null && key != null) {
                 unsyncedCounter.incrementAndGet();
+                // Refresh storedWindowExpiry when stale — this happens after one or more empty
+                // windows where reset() was never called (no RESET event → no reset()).
+                if (storedWindowExpiry <= System.currentTimeMillis()) {
+                    Long expiry = ThrottleStreamProcessor.getThreadLocalWindowExpiry();
+                    if (expiry != null && expiry > storedWindowExpiry) {
+                        storedWindowExpiry = expiry;
+                        keyHasTTL = false; // key was created by INCRBY after gap — needs PEXPIRE
+                    }
+                }
             }
-            return localCounter.get();
+            return newCount;
         } catch (Exception e) {
             log.error("Error in processAdd for key " + key, e);
             return localCounter.get();
@@ -190,7 +283,14 @@ public class DistributedCountAttributeAggregator extends AttributeAggregator {
 
     @Override
     public Object processAdd(Object[] data) {
-        return processAdd((Object) data);
+        if (log.isDebugEnabled()) {
+            log.debug("DistributedCountAggregator: processAdd called with data: "
+                    + (data != null && data.length > 0 ? data[0] : null));
+        }
+        if (isResetRequested(data)) {
+            return reset();
+        }
+        return processAdd(data != null && data.length > 0 ? data[0] : null);
     }
 
 
@@ -204,6 +304,9 @@ public class DistributedCountAttributeAggregator extends AttributeAggregator {
      */
     @Override
     public Object processRemove(Object data) {
+        if (log.isDebugEnabled()) {
+            log.debug("DistributedCountAggregator: processRemove called with data: " + data);
+        }
         try {
             localCounter.decrementAndGet();
             if (distributedThrottlingEnabled && kvStoreClient != null && key != null) {
@@ -219,31 +322,32 @@ public class DistributedCountAttributeAggregator extends AttributeAggregator {
 
     @Override
     public Object processRemove(Object[] data) {
-        return processRemove((Object) data);
+        return processRemove(data != null && data.length > 0 ? data[0] : null);
     }
 
 
     /**
-     * Resets the local counter to zero.
-     * If distributed throttling is enabled, also resets the value in the distributed key-value store
-     * and clears any pending unsynced changes.
+     * Resets the local counter to zero and signals the background sync thread to PSETEX "0"
+     * on its next tick. Never blocks on a Redis network call. Transient failures are retried
+     * automatically.
      *
      * @return 0L after reset.
      */
     @Override
     public Object reset() {
-        try {
-            localCounter.set(0L);
-            if (distributedThrottlingEnabled && kvStoreClient != null && key != null) {
-                kvStoreClient.set(key, "0");
-                unsyncedCounter.set(0L); // Clear pending changes
-            }
-            return 0L;
-
-        } catch (KeyValueStoreException e) {
-            log.error("Error resetting counter for key " + key, e);
-            return 0L;
+        if (log.isDebugEnabled()) {
+            log.debug("DistributedCountAggregator: reset called");
         }
+        localCounter.set(0L);
+        if (distributedThrottlingEnabled && kvStoreClient != null && key != null) {
+            Long expiry = ThrottleStreamProcessor.getThreadLocalWindowExpiry();
+            if (expiry != null) {
+                storedWindowExpiry = expiry;
+            }
+            unsyncedCounter.set(0L);
+            pendingReset = true;
+        }
+        return 0L;
     }
 
     @Override
@@ -259,12 +363,18 @@ public class DistributedCountAttributeAggregator extends AttributeAggregator {
      */
     @Override
     public void stop() {
+        if (log.isDebugEnabled()) {
+            log.debug("DistributedCountAggregator: stop called");
+        }
         try {
             // Only remove if key is not null and distributed throttling is enabled
             if (distributedThrottlingEnabled && key != null) {
                 ACTIVE_AGGREGATORS.remove(key);
                 if (kvStoreClient != null) {
-                    syncWithKVStore();
+                    syncWithKVStore(); // best-effort: flush pendingReset (PSETEX 0) if pending
+                    if (!pendingReset) {
+                        syncWithKVStore(); // best-effort: push new-window delta; both may be no-ops if Redis is down
+                    }
                 }
                 // Shutdown scheduler if no active aggregators exist
                 if (ACTIVE_AGGREGATORS.isEmpty()) {
@@ -278,6 +388,9 @@ public class DistributedCountAttributeAggregator extends AttributeAggregator {
 
     @Override
     public Object[] currentState() {
+        if (log.isDebugEnabled()) {
+            log.debug("DistributedCountAggregator: currentState called");
+        }
         if (distributedThrottlingEnabled && kvStoreClient != null && key != null) {
             try {
                 syncWithKVStore();
@@ -290,21 +403,56 @@ public class DistributedCountAttributeAggregator extends AttributeAggregator {
 
     @Override
     public void restoreState(Object[] state) {
+        if (log.isDebugEnabled()) {
+            log.debug("DistributedCountAggregator: restoreState called with state: " + state);
+        }
         Map.Entry<String, Object> stateEntry = (Map.Entry<String, Object>) state[0];
         long restoredValue = (Long) stateEntry.getValue();
 
-        localCounter.set(restoredValue);
-        unsyncedCounter.set(0L);
-
+        // In distributed mode, Redis is authoritative — ignore the stale single-node Siddhi snapshot.
+        // Fall back to 0 on key-absent or Redis error; the sync scheduler recovers the real value once Redis is up.
+        // In non-distributed mode, the Siddhi snapshot is the only state.
+        // Redis GET runs outside the lock to avoid blocking the sync thread during network I/O.
+        long counterToRestore = distributedThrottlingEnabled ? 0L : restoredValue;
+        boolean seedRedis = false;
         if (distributedThrottlingEnabled && kvStoreClient != null && key != null) {
             try {
-                kvStoreClient.set(key, String.valueOf(restoredValue));
+                String kvStoreValue = kvStoreClient.get(key);
+                if (kvStoreValue != null) {
+                    counterToRestore = Long.parseLong(kvStoreValue);
+                } else {
+                    seedRedis = true;
+                }
+            } catch (KeyValueStoreException | NumberFormatException e) {
+                log.error("Error reading from key-value store during restoreState for key "
+                        + key + ". Starting fresh at 0.", e);
+            }
+        }
+
+        // Lock only for the fast in-memory writes — no Redis call inside.
+        synchronized (kvStoreLock) {
+            unsyncedCounter.set(0L);
+            pendingReset = false;
+            localCounter.set(counterToRestore);
+        }
+
+        // Key absent in Redis — attempt to seed with 0; no-op if storedWindowExpiry is not yet known.
+        if (seedRedis) {
+            try {
+                writeCounterValue("0");
             } catch (KeyValueStoreException e) {
-                log.error("Error restoring state to key-value store for key "+ key, e);
+                log.error("Error seeding key-value store with 0 during restoreState for key " + key, e);
             }
         }
     }
 
+    /**
+     * Retrieves the distributed throttle configuration for the API Manager.
+     * Attempts to fetch the configuration from the service reference holder.
+     * If fetching the configuration fails, logs a warning message and returns null.
+     *
+     * @return the {@link DistributedThrottleConfig} instance if successfully loaded, or null if loading fails.
+     */
     private static DistributedThrottleConfig getDistributedThrottleConfig() {
         try {
             return ServiceReferenceHolder.getInstance()
@@ -334,13 +482,17 @@ public class DistributedCountAttributeAggregator extends AttributeAggregator {
             }
             if (kvStoreSyncScheduler == null) {
                 kvStoreSyncScheduler = Executors.newScheduledThreadPool(corePoolSize, r ->
-                        new Thread(r, Thread.currentThread().getName()));
+                        new Thread(r, "apim-distributed-throttle-sync"));
+            }
+            if (masterScheduler == null) {
+                masterScheduler = Executors.newSingleThreadScheduledExecutor(r ->
+                        new Thread(r, "apim-distributed-throttle-master-sync"));
             }
 
             log.debug("Starting key-value store sync scheduler with interval: "
                     + kvStoreSyncIntervalMilliseconds + " ms, pool size: " + corePoolSize);
 
-            masterScheduler.scheduleAtFixedRate(() -> {
+            masterSyncTask = masterScheduler.scheduleAtFixedRate(() -> {
                 try {
                     CompletableFuture<?>[] futures = ACTIVE_AGGREGATORS.values().stream()
                             .map(aggregator -> CompletableFuture.runAsync(() -> {
@@ -373,21 +525,14 @@ public class DistributedCountAttributeAggregator extends AttributeAggregator {
      */
     public static void shutdownScheduler() {
         synchronized (schedulerLock) {
-            if (kvStoreSyncScheduler != null && !kvStoreSyncScheduler.isShutdown()) {
-                log.debug("Shutting down key-value store sync scheduler...");
-                kvStoreSyncScheduler.shutdown();
-                try {
-                    if (!kvStoreSyncScheduler.awaitTermination(5, TimeUnit.SECONDS)) {
-                        log.warn("The key-value store sync scheduler did not terminate in time. Forcing shutdown...");
-                        kvStoreSyncScheduler.shutdownNow();
-                    }
-                } catch (InterruptedException e) {
-                    log.warn("Interrupted while shutting down key-value store sync scheduler. Forcing shutdown...");
-                    kvStoreSyncScheduler.shutdownNow();
-                    Thread.currentThread().interrupt();
-                }
+            if (masterSyncTask != null) {
+                masterSyncTask.cancel(false);
+                masterSyncTask = null;
             }
+            shutdownExecutor(kvStoreSyncScheduler, "key-value store sync scheduler");
             kvStoreSyncScheduler = null;
+            shutdownExecutor(masterScheduler, "master sync scheduler");
+            masterScheduler = null;
             schedulerStarted = false;
 
             // Shutdown the KeyValueStoreManager to close JedisPool
@@ -397,6 +542,34 @@ public class DistributedCountAttributeAggregator extends AttributeAggregator {
                 log.error("Error shutting down KeyValueStoreManager", e);
             }
         }
+    }
+
+    /**
+     * Shuts down the given executor service gracefully, forcing shutdown if it does not
+     * terminate within the timeout.
+     *
+     * @param executor The executor to shut down.
+     * @param name     Name of the executor for logging.
+     */
+    private static void shutdownExecutor(ScheduledExecutorService executor, String name) {
+        if (executor != null && !executor.isShutdown()) {
+            log.debug("Shutting down " + name + "...");
+            executor.shutdown();
+            try {
+                if (!executor.awaitTermination(5, TimeUnit.SECONDS)) {
+                    log.warn("The " + name + " did not terminate in time. Forcing shutdown...");
+                    executor.shutdownNow();
+                }
+            } catch (InterruptedException e) {
+                log.warn("Interrupted while shutting down " + name + ". Forcing shutdown...");
+                executor.shutdownNow();
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+
+    private boolean isResetRequested(Object[] data) {
+        return data != null && data.length > 1 && Boolean.TRUE.equals(data[1]);
     }
 
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.throttling.siddhi.extension/src/main/java/org/wso2/carbon/apimgt/throttling/siddhi/extension/DistributedCountAttributeAggregator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.throttling.siddhi.extension/src/main/java/org/wso2/carbon/apimgt/throttling/siddhi/extension/DistributedCountAttributeAggregator.java
@@ -18,6 +18,7 @@
 package org.wso2.carbon.apimgt.throttling.siddhi.extension;
 
 import java.util.AbstractMap;
+import java.util.Arrays;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.CompletableFuture;
@@ -105,6 +106,10 @@ public class DistributedCountAttributeAggregator extends AttributeAggregator {
         }
         if (distributedThrottlingEnabled && throttleKey != null) {
             this.key = "wso2_throttler:" + throttleKey;
+            Long windowExpiry = ThrottleStreamProcessor.getThreadLocalWindowExpiry();
+            if (windowExpiry != null) {
+                this.storedWindowExpiry = windowExpiry;
+            }
             try {
                 this.kvStoreClient = KeyValueStoreManager.getClient();
                 if (this.kvStoreClient != null) {
@@ -142,18 +147,24 @@ public class DistributedCountAttributeAggregator extends AttributeAggregator {
 
     /**
      * Writes the given value to the key-value store with the remaining TTL of the current window.
-     * Does nothing when {@code storedWindowExpiry} is not yet known or has already passed.
+     * Does nothing when {@code storedWindowExpiry} is not yet known or has already passed —
+     * callers must check the return value rather than assume the write happened.
      *
      * @param value the value to store for this aggregator's key.
+     * @return true if the value was actually written to the key-value store, false if the write
+     *         was skipped because the window expiry was unknown or already in the past.
      */
-    private void writeCounterValue(String value) {
+    private boolean writeCounterValue(String value) {
         long windowExpiry = storedWindowExpiry;
-        if (windowExpiry > 0) {
-            long remainingMillis = windowExpiry - System.currentTimeMillis();
-            if (remainingMillis > 0) {
-                kvStoreClient.setWithExpiry(key, value, remainingMillis);
-            }
+        if (windowExpiry <= 0) {
+            return false;
         }
+        long remainingMillis = windowExpiry - System.currentTimeMillis();
+        if (remainingMillis <= 0) {
+            return false;
+        }
+        kvStoreClient.setWithExpiry(key, value, remainingMillis);
+        return true;
     }
 
     /**
@@ -169,11 +180,14 @@ public class DistributedCountAttributeAggregator extends AttributeAggregator {
             }
             if (pendingReset) {
                 try {
-                    writeCounterValue("0");
                     // Do NOT reset localCounter here — reset() already zeroed it at window boundary.
                     // Any increments to localCounter since then belong to the new window and are valid.
-                    pendingReset = false; // cleared only on success — failure retried next tick
-                    keyHasTTL = true;
+                    if (writeCounterValue("0")) {
+                        pendingReset = false; // cleared only on a confirmed write — retried next tick otherwise
+                        keyHasTTL = true;
+                    } else {
+                        keyHasTTL = false;
+                    }
                 } catch (KeyValueStoreException e) {
                     long currentTimeMillis = System.currentTimeMillis();
                     if (currentTimeMillis - lastErrorLogTimestamp.get() > ERROR_LOG_INTERVAL_MS) {
@@ -184,11 +198,6 @@ public class DistributedCountAttributeAggregator extends AttributeAggregator {
                 return;
             }
             long currentUnsyncedCount = unsyncedCounter.getAndSet(0L);
-            if (pendingReset) {
-                // reset() fired between our initial pendingReset check and getAndSet —
-                // discard the captured old-window delta; the next tick will PSETEX 0.
-                return;
-            }
             try {
                 if (currentUnsyncedCount == 0) {
                     String kvStoreValue = kvStoreClient.get(key);
@@ -301,6 +310,8 @@ public class DistributedCountAttributeAggregator extends AttributeAggregator {
      *
      * @param data The event data to be removed.
      * @return The updated value of the local counter after decrement.
+     * Note: not invoked in practice for throttle plans, since {@link ThrottleStreamProcessor}
+     * never emits EXPIRED events to this selector.
      */
     @Override
     public Object processRemove(Object data) {
@@ -404,7 +415,7 @@ public class DistributedCountAttributeAggregator extends AttributeAggregator {
     @Override
     public void restoreState(Object[] state) {
         if (log.isDebugEnabled()) {
-            log.debug("DistributedCountAggregator: restoreState called with state: " + state);
+            log.debug("DistributedCountAggregator: restoreState called with state: " + Arrays.toString(state));
         }
         Map.Entry<String, Object> stateEntry = (Map.Entry<String, Object>) state[0];
         long restoredValue = (Long) stateEntry.getValue();
@@ -432,8 +443,15 @@ public class DistributedCountAttributeAggregator extends AttributeAggregator {
         // Lock only for the fast in-memory writes — no Redis call inside.
         synchronized (kvStoreLock) {
             unsyncedCounter.set(0L);
-            pendingReset = false;
-            localCounter.set(counterToRestore);
+            // Do NOT clear pendingReset here. If a reset() flagged an unflushed PSETEX 0 and this
+            // restore landed before the sync thread flushed it, dropping the flag would leave the
+            // previous window's total in Redis. Keep it pending (the next sync tick still flushes
+            // it) and seed localCounter to 0 to match what reset() already intended.
+            if (pendingReset) {
+                localCounter.set(0L);
+            } else {
+                localCounter.set(counterToRestore);
+            }
         }
 
         // Key absent in Redis — attempt to seed with 0; no-op if storedWindowExpiry is not yet known.
@@ -568,7 +586,7 @@ public class DistributedCountAttributeAggregator extends AttributeAggregator {
         }
     }
 
-    private boolean isResetRequested(Object[] data) {
+    private static boolean isResetRequested(Object[] data) {
         return data != null && data.length > 1 && Boolean.TRUE.equals(data[1]);
     }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.throttling.siddhi.extension/src/main/java/org/wso2/carbon/apimgt/throttling/siddhi/extension/ThrottleStreamProcessor.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.throttling.siddhi.extension/src/main/java/org/wso2/carbon/apimgt/throttling/siddhi/extension/ThrottleStreamProcessor.java
@@ -47,6 +47,8 @@ import java.util.Map;
 
 public class ThrottleStreamProcessor extends StreamProcessor implements SchedulingProcessor, FindableProcessor {
 
+    private static final ThreadLocal<Long> windowExpiryThreadLocal = new ThreadLocal<>();
+
     private long timeInMilliSeconds;
     private ComplexEventChunk<StreamEvent> expiredEventChunk = new ComplexEventChunk<StreamEvent>(true);
     private Scheduler scheduler;
@@ -130,6 +132,7 @@ public class ThrottleStreamProcessor extends StreamProcessor implements Scheduli
     protected void process(ComplexEventChunk<StreamEvent> streamEventChunk, Processor nextProcessor,
                            StreamEventCloner streamEventCloner, ComplexEventPopulater complexEventPopulater) {
 
+        ComplexEventChunk<StreamEvent> resetEventChunk = null;
         synchronized (this) {
             if (expireEventTime != -1) {
                 if (expireEventTime - timeInMilliSeconds > streamEventChunk.getLast().getTimestamp()) {
@@ -146,13 +149,25 @@ public class ThrottleStreamProcessor extends StreamProcessor implements Scheduli
                 scheduler.notifyAt(expireEventTime);
             }
             long currentTime = executionPlanContext.getTimestampGenerator().currentTime();
-            boolean sendEvents;
+            boolean sendResetEvent;
             if (currentTime >= expireEventTime) {
                 expireEventTime += timeInMilliSeconds;
                 scheduler.notifyAt(expireEventTime);
-                sendEvents = true;
+                sendResetEvent = true;
             } else {
-                sendEvents = false;
+                sendResetEvent = false;
+            }
+
+            if (sendResetEvent) {
+                StreamEvent firstExpiredEvent = expiredEventChunk.getFirst();
+                if (firstExpiredEvent != null) {
+                    StreamEvent resetEvent = streamEventCloner.copyStreamEvent(firstExpiredEvent);
+                    resetEvent.setType(StreamEvent.Type.RESET);
+                    resetEvent.setTimestamp(expireEventTime);
+                    resetEventChunk = new ComplexEventChunk<StreamEvent>(true);
+                    resetEventChunk.add(resetEvent);
+                }
+                expiredEventChunk.clear();
             }
 
             while (streamEventChunk.hasNext()) {
@@ -162,22 +177,32 @@ public class ThrottleStreamProcessor extends StreamProcessor implements Scheduli
                 }
 
                 complexEventPopulater.populateComplexEvent(streamEvent, new Object[]{expireEventTime});
-                StreamEvent clonedStreamEvent = streamEventCloner.copyStreamEvent(streamEvent);
-                clonedStreamEvent.setType(StreamEvent.Type.EXPIRED);
-                clonedStreamEvent.setTimestamp(expireEventTime);
-                expiredEventChunk.add(clonedStreamEvent);
-            }
-            if (sendEvents) {
-                expiredEventChunk.reset();
-                if (expiredEventChunk.getFirst() != null) {
-                    streamEventChunk.add(expiredEventChunk.getFirst());
+                if (expiredEventChunk.getFirst() == null) {
+                    StreamEvent clonedStreamEvent = streamEventCloner.copyStreamEvent(streamEvent);
+                    clonedStreamEvent.setType(StreamEvent.Type.EXPIRED);
+                    clonedStreamEvent.setTimestamp(expireEventTime);
+                    expiredEventChunk.add(clonedStreamEvent);
                 }
-                expiredEventChunk.clear();
             }
+        }
+        if (resetEventChunk != null) {
+            resetEventChunk.setBatch(true);
+            windowExpiryThreadLocal.set(expireEventTime);
+            try {
+                nextProcessor.process(resetEventChunk);
+            } finally {
+                windowExpiryThreadLocal.remove();
+            }
+            resetEventChunk.setBatch(false);
         }
         if (streamEventChunk.getFirst() != null) {
             streamEventChunk.setBatch(true);
-            nextProcessor.process(streamEventChunk);
+            windowExpiryThreadLocal.set(expireEventTime);
+            try {
+                nextProcessor.process(streamEventChunk);
+            } finally {
+                windowExpiryThreadLocal.remove();
+            }
             streamEventChunk.setBatch(false);
         }
     }
@@ -214,6 +239,10 @@ public class ThrottleStreamProcessor extends StreamProcessor implements Scheduli
             Map<String, EventTable> eventTableMap) {
         return OperatorParser.constructOperator(expiredEventChunk, expression, matchingMetaStateHolder,
                 executionPlanContext, variableExpressionExecutors, eventTableMap, queryName);
+    }
+
+    static Long getThreadLocalWindowExpiry() {
+        return windowExpiryThreadLocal.get();
     }
 
     private long addTimeShift(long currentTime) {

--- a/components/apimgt/org.wso2.carbon.apimgt.throttling.siddhi.extension/src/main/java/org/wso2/carbon/apimgt/throttling/siddhi/extension/ThrottleStreamProcessor.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.throttling.siddhi.extension/src/main/java/org/wso2/carbon/apimgt/throttling/siddhi/extension/ThrottleStreamProcessor.java
@@ -133,6 +133,7 @@ public class ThrottleStreamProcessor extends StreamProcessor implements Scheduli
                            StreamEventCloner streamEventCloner, ComplexEventPopulater complexEventPopulater) {
 
         ComplexEventChunk<StreamEvent> resetEventChunk = null;
+        long expireEventTimeSnapshot;
         synchronized (this) {
             if (expireEventTime != -1) {
                 if (expireEventTime - timeInMilliSeconds > streamEventChunk.getLast().getTimestamp()) {
@@ -184,10 +185,11 @@ public class ThrottleStreamProcessor extends StreamProcessor implements Scheduli
                     expiredEventChunk.add(clonedStreamEvent);
                 }
             }
+            expireEventTimeSnapshot = expireEventTime;
         }
         if (resetEventChunk != null) {
             resetEventChunk.setBatch(true);
-            windowExpiryThreadLocal.set(expireEventTime);
+            windowExpiryThreadLocal.set(expireEventTimeSnapshot);
             try {
                 nextProcessor.process(resetEventChunk);
             } finally {
@@ -197,7 +199,7 @@ public class ThrottleStreamProcessor extends StreamProcessor implements Scheduli
         }
         if (streamEventChunk.getFirst() != null) {
             streamEventChunk.setBatch(true);
-            windowExpiryThreadLocal.set(expireEventTime);
+            windowExpiryThreadLocal.set(expireEventTimeSnapshot);
             try {
                 nextProcessor.process(streamEventChunk);
             } finally {

--- a/components/apimgt/org.wso2.carbon.apimgt.throttling.siddhi.extension/src/main/java/org/wso2/carbon/apimgt/throttling/siddhi/extension/util/kvstore/JedisKeyValueStoreClient.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.throttling.siddhi.extension/src/main/java/org/wso2/carbon/apimgt/throttling/siddhi/extension/util/kvstore/JedisKeyValueStoreClient.java
@@ -27,6 +27,7 @@ import org.wso2.carbon.apimgt.throttling.siddhi.extension.internal.ServiceRefere
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisPool;
 import redis.clients.jedis.JedisPoolConfig;
+import redis.clients.jedis.Protocol;
 import redis.clients.jedis.exceptions.JedisException;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -48,6 +49,7 @@ public class JedisKeyValueStoreClient implements KeyValueStoreClient {
     private static volatile char[] password;
     private static volatile int databaseId;
     private static volatile int connectionTimeout;
+    private static volatile int socketTimeout;
     private static volatile boolean sslEnabled;
     private static volatile JedisPoolConfig poolConfig = new JedisPoolConfig();
 
@@ -67,11 +69,15 @@ public class JedisKeyValueStoreClient implements KeyValueStoreClient {
                 user = distributedConfig.getUser();
                 password = distributedConfig.getPassword();
                 databaseId = distributedConfig.getDatabaseId();
-                connectionTimeout = distributedConfig.getConnectionTimeout();
+                connectionTimeout = distributedConfig.getConnectionTimeout() != 0
+                        ? distributedConfig.getConnectionTimeout() : Protocol.DEFAULT_TIMEOUT;
+                socketTimeout = distributedConfig.getSocketTimeout() != 0
+                        ? distributedConfig.getSocketTimeout() : Protocol.DEFAULT_TIMEOUT;
                 sslEnabled = distributedConfig.isSslEnabled();
                 poolConfig.setMaxTotal(distributedConfig.getMaxTotal());
                 poolConfig.setMaxIdle(distributedConfig.getMaxIdle());
                 poolConfig.setMinIdle(distributedConfig.getMinIdle());
+                poolConfig.setMaxWaitMillis(distributedConfig.getMaxWaitMillis());
                 poolConfig.setBlockWhenExhausted(distributedConfig.isBlockWhenExhausted());
                 poolConfig.setTestOnBorrow(distributedConfig.isTestOnBorrow());
                 poolConfig.setTestOnReturn(distributedConfig.isTestOnReturn());
@@ -88,7 +94,10 @@ public class JedisKeyValueStoreClient implements KeyValueStoreClient {
                     user = redisConfig.getUser();
                     password = redisConfig.getPassword();
                     databaseId = redisConfig.getDatabaseId();
-                    connectionTimeout = redisConfig.getConnectionTimeout();
+                    connectionTimeout = redisConfig.getConnectionTimeout() != 0
+                            ? redisConfig.getConnectionTimeout() : Protocol.DEFAULT_TIMEOUT;
+                    socketTimeout = redisConfig.getSocketTimeout() != 0
+                            ? redisConfig.getSocketTimeout() : Protocol.DEFAULT_TIMEOUT;
                     sslEnabled = redisConfig.isSslEnabled();
                     poolConfig.setMaxTotal(redisConfig.getMaxTotal());
                     poolConfig.setMaxIdle(redisConfig.getMaxIdle());
@@ -97,6 +106,7 @@ public class JedisKeyValueStoreClient implements KeyValueStoreClient {
                     poolConfig.setTestOnBorrow(redisConfig.isTestOnBorrow());
                     poolConfig.setTestOnReturn(redisConfig.isTestOnReturn());
                     poolConfig.setTestWhileIdle(redisConfig.isTestWhileIdle());
+                    poolConfig.setMaxWaitMillis(redisConfig.getMaxWaitMillis());
                 }
                 else {
                     log.warn("Unknown config type provided to createPoolConfig. Using default JedisPoolConfig values.");
@@ -115,14 +125,17 @@ public class JedisKeyValueStoreClient implements KeyValueStoreClient {
                     populateKeyValueStoreConfigs();
                     try {
                         if (StringUtils.isNotEmpty(user) && password != null) {
-                            jedisPool = new JedisPool(poolConfig, host, port, connectionTimeout, user,
-                                    String.valueOf(password), databaseId, sslEnabled);
+                            jedisPool = new JedisPool(poolConfig, host, port,
+                                    connectionTimeout, socketTimeout,
+                                    user, String.valueOf(password), databaseId, null, sslEnabled);
                         } else if (password != null) {
-                            jedisPool = new JedisPool(poolConfig, host, port, connectionTimeout,
-                                    String.valueOf(password), databaseId, sslEnabled);
+                            jedisPool = new JedisPool(poolConfig, host, port,
+                                    connectionTimeout, socketTimeout,
+                                    String.valueOf(password), databaseId, null, sslEnabled);
                         } else {
-                            jedisPool = new JedisPool(poolConfig, host, port, connectionTimeout, null,
-                                    databaseId, sslEnabled);
+                            jedisPool = new JedisPool(poolConfig, host, port,
+                                    connectionTimeout, socketTimeout,
+                                    null, databaseId, null, sslEnabled);
                         }
                         return jedisPool;
                     } catch (Exception e) {
@@ -141,17 +154,19 @@ public class JedisKeyValueStoreClient implements KeyValueStoreClient {
                 return pool.getResource();
             } catch (JedisException e) {
                 long currentTimeMillis = System.currentTimeMillis();
-                if (currentTimeMillis - lastErrorLogTimestamp.get() > ERROR_LOG_INTERVAL_MS) {
+                long prev = lastErrorLogTimestamp.get();
+                if (currentTimeMillis - prev > ERROR_LOG_INTERVAL_MS
+                        && lastErrorLogTimestamp.compareAndSet(prev, currentTimeMillis)) {
                     log.error("Failed to get Jedis resource from pool. Check whether the server is running and accessible.", e);
-                    lastErrorLogTimestamp.set(currentTimeMillis);
                 }
                 return null;
             }
         }
         long currentTimeMillis = System.currentTimeMillis();
-        if (currentTimeMillis - lastErrorLogTimestamp.get() > ERROR_LOG_INTERVAL_MS) {
+        long prev = lastErrorLogTimestamp.get();
+        if (currentTimeMillis - prev > ERROR_LOG_INTERVAL_MS
+                && lastErrorLogTimestamp.compareAndSet(prev, currentTimeMillis)) {
             log.error("JedisPool is not initialized. Cannot get Jedis resource.");
-            lastErrorLogTimestamp.set(currentTimeMillis);
         }
         return null;
     }
@@ -260,6 +275,44 @@ public class JedisKeyValueStoreClient implements KeyValueStoreClient {
             return jedis.decrBy(key, decrement);
         } catch (JedisException e) {
             throw new KeyValueStoreException("Error during KeyValue DECREMENT for key: " + key, e);
+        } finally {
+            closeJedis(jedis);
+        }
+    }
+
+    @Override
+    public void setWithExpiry(String key, String value, long ttlMillis) {
+        if (key == null) {
+            throw new KeyValueStoreException("Key cannot be null for PSETEX operation.");
+        }
+        Jedis jedis = null;
+        try {
+            jedis = getJedis();
+            if (jedis == null) {
+                throw new KeyValueStoreException("Failed to get connection from KeyValue pool for PSETEX operation.");
+            }
+            jedis.psetex(key, ttlMillis, value);
+        } catch (JedisException e) {
+            throw new KeyValueStoreException("Error during KeyValue PSETEX for key: " + key, e);
+        } finally {
+            closeJedis(jedis);
+        }
+    }
+
+    @Override
+    public void expireMillis(String key, long ttlMillis) {
+        if (key == null) {
+            throw new KeyValueStoreException("Key cannot be null for PEXPIRE operation.");
+        }
+        Jedis jedis = null;
+        try {
+            jedis = getJedis();
+            if (jedis == null) {
+                throw new KeyValueStoreException("Failed to get connection from KeyValue pool for PEXPIRE operation.");
+            }
+            jedis.pexpire(key, ttlMillis);
+        } catch (JedisException e) {
+            throw new KeyValueStoreException("Error during KeyValue PEXPIRE for key: " + key, e);
         } finally {
             closeJedis(jedis);
         }

--- a/components/apimgt/org.wso2.carbon.apimgt.throttling.siddhi.extension/src/main/java/org/wso2/carbon/apimgt/throttling/siddhi/extension/util/kvstore/JedisKeyValueStoreClient.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.throttling.siddhi.extension/src/main/java/org/wso2/carbon/apimgt/throttling/siddhi/extension/util/kvstore/JedisKeyValueStoreClient.java
@@ -69,9 +69,9 @@ public class JedisKeyValueStoreClient implements KeyValueStoreClient {
                 user = distributedConfig.getUser();
                 password = distributedConfig.getPassword();
                 databaseId = distributedConfig.getDatabaseId();
-                connectionTimeout = distributedConfig.getConnectionTimeout() != 0
+                connectionTimeout = distributedConfig.getConnectionTimeout() > 0
                         ? distributedConfig.getConnectionTimeout() : Protocol.DEFAULT_TIMEOUT;
-                socketTimeout = distributedConfig.getSocketTimeout() != 0
+                socketTimeout = distributedConfig.getSocketTimeout() > 0
                         ? distributedConfig.getSocketTimeout() : Protocol.DEFAULT_TIMEOUT;
                 sslEnabled = distributedConfig.isSslEnabled();
                 poolConfig.setMaxTotal(distributedConfig.getMaxTotal());
@@ -94,9 +94,9 @@ public class JedisKeyValueStoreClient implements KeyValueStoreClient {
                     user = redisConfig.getUser();
                     password = redisConfig.getPassword();
                     databaseId = redisConfig.getDatabaseId();
-                    connectionTimeout = redisConfig.getConnectionTimeout() != 0
+                    connectionTimeout = redisConfig.getConnectionTimeout() > 0
                             ? redisConfig.getConnectionTimeout() : Protocol.DEFAULT_TIMEOUT;
-                    socketTimeout = redisConfig.getSocketTimeout() != 0
+                    socketTimeout = redisConfig.getSocketTimeout() > 0
                             ? redisConfig.getSocketTimeout() : Protocol.DEFAULT_TIMEOUT;
                     sslEnabled = redisConfig.isSslEnabled();
                     poolConfig.setMaxTotal(redisConfig.getMaxTotal());

--- a/components/apimgt/org.wso2.carbon.apimgt.throttling.siddhi.extension/src/main/java/org/wso2/carbon/apimgt/throttling/siddhi/extension/util/kvstore/KeyValueStoreClient.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.throttling.siddhi.extension/src/main/java/org/wso2/carbon/apimgt/throttling/siddhi/extension/util/kvstore/KeyValueStoreClient.java
@@ -63,6 +63,27 @@ public interface KeyValueStoreClient {
     long decrementBy(String key, long decrement);
 
     /**
+     * Sets the string value for the given key with a TTL (time-to-live).
+     * The key is automatically removed from the store after {@code ttlMillis} milliseconds.
+     * This operation is atomic — value and expiry are set in a single command.
+     *
+     * @param key       The key with which the specified value is to be associated.
+     * @param value     The value to be associated with the specified key.
+     * @param ttlMillis The time-to-live in milliseconds after which the key is auto-deleted.
+     */
+    void setWithExpiry(String key, String value, long ttlMillis);
+
+    /**
+     * Sets a TTL on an existing key without changing its value (Redis PEXPIRE).
+     * If the key does not exist this is a no-op. Use this to stamp a TTL on a key
+     * that was created by INCRBY, which never sets an expiry on its own.
+     *
+     * @param key       The key whose expiry is to be set.
+     * @param ttlMillis The time-to-live in milliseconds.
+     */
+    void expireMillis(String key, long ttlMillis);
+
+    /**
      * Deletes the mapping for a key from this store if it is present.
      *
      * @param key The key whose mapping is to be removed from the store.

--- a/components/apimgt/org.wso2.carbon.apimgt.throttling.siddhi.extension/src/test/java/org/wso2/carbon/apimgt/throttling/siddhi/extension/CountAttributeAggregatorWithResetTestCase.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.throttling.siddhi.extension/src/test/java/org/wso2/carbon/apimgt/throttling/siddhi/extension/CountAttributeAggregatorWithResetTestCase.java
@@ -29,6 +29,8 @@ import org.wso2.siddhi.core.query.output.callback.QueryCallback;
 import org.wso2.siddhi.core.stream.input.InputHandler;
 import org.wso2.siddhi.core.util.EventPrinter;
 
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
@@ -200,5 +202,140 @@ public class CountAttributeAggregatorWithResetTestCase {
         Thread.sleep(2000);
         execPlanRunTime.shutdown();
         junit.framework.Assert.assertEquals(1, atomicEventCount.intValue());
+    }
+
+    // -----------------------------------------------------------------------
+    // GROUP BY tests with multiple distinct throttle keys sharing the reset flag column —
+    // the tests above only ever exercise a single "symbol"/"APIM" key at a time. The tests
+    // below confirm the reset flag on throttler:count(price, reset) is properly SCOPED to
+    // only the key whose own event carried the flag, and doesn't disturb sibling keys
+    // sharing the same query/window.
+    // -----------------------------------------------------------------------
+
+    /**
+     * The admin-triggered reset-flag mechanism (throttler:count(messageID, resetFlag), the
+     * 2-arg form used by app.xml) must be properly SCOPED to only the key whose event
+     * actually carried the reset flag. Resetting "App1_ResourceA" must not touch
+     * "App1_ResourceB" or "App2_ResourceA"'s independently-accumulated counts.
+     */
+    @Test
+    public void adminFlagResetOnlyAffectsTargetedKey_otherAppsAndApisUntouched() throws InterruptedException {
+        SiddhiManager siddhiManager = new SiddhiManager();
+        String query = "" +
+                "define stream cseEventStream (throttleKey string, messageID string, reset bool);" +
+                "@info(name = 'query1') " +
+                "from cseEventStream#throttler:timeBatch(10000) " +
+                "select throttleKey, throttler:count(messageID, reset) as cnt, expiryTimeStamp " +
+                "group by throttleKey " +
+                "insert all events into outputStream;";
+
+        ExecutionPlanRuntime execPlanRunTime = siddhiManager.createExecutionPlanRuntime(query);
+        Map<String, Long> lastCountPerKey = new ConcurrentHashMap<>();
+        execPlanRunTime.addCallback("query1", new QueryCallback() {
+            @Override
+            public void receive(long timeStamp, Event[] inEvents, Event[] removeEvents) {
+                EventPrinter.print(timeStamp, inEvents, removeEvents);
+                if (inEvents != null) {
+                    for (Event e : inEvents) {
+                        lastCountPerKey.put((String) e.getData(0), (Long) e.getData(1));
+                    }
+                }
+            }
+        });
+        execPlanRunTime.start();
+        InputHandler inputHandler = execPlanRunTime.getInputHandler("cseEventStream");
+
+        // All three keys accumulate to 3.
+        String[] keys = {"App1_ResourceA", "App1_ResourceB", "App2_ResourceA"};
+        for (String key : keys) {
+            for (int i = 1; i <= 3; i++) {
+                inputHandler.send(new Object[]{key, key + "-msg" + i, false});
+            }
+        }
+        junit.framework.Assert.assertEquals(Long.valueOf(3L), lastCountPerKey.get("App1_ResourceA"));
+        junit.framework.Assert.assertEquals(Long.valueOf(3L), lastCountPerKey.get("App1_ResourceB"));
+        junit.framework.Assert.assertEquals(Long.valueOf(3L), lastCountPerKey.get("App2_ResourceA"));
+
+        // Admin resets ONLY "App1_ResourceA".
+        inputHandler.send(new Object[]{"App1_ResourceA", "admin-reset-msg", true});
+        // A follow-up real request for the reset key should now start counting from 0 -> 1.
+        inputHandler.send(new Object[]{"App1_ResourceA", "post-reset-msg", false});
+
+        execPlanRunTime.shutdown();
+
+        junit.framework.Assert.assertEquals("The targeted key should reflect the reset (0) then one new "
+                + "increment (1)", Long.valueOf(1L), lastCountPerKey.get("App1_ResourceA"));
+        junit.framework.Assert.assertEquals("A different resource under the SAME app must be untouched",
+                Long.valueOf(3L), lastCountPerKey.get("App1_ResourceB"));
+        junit.framework.Assert.assertEquals("A different app entirely must be untouched",
+                Long.valueOf(3L), lastCountPerKey.get("App2_ResourceA"));
+    }
+
+    /**
+     * Admin-triggered flag reset on one key in the middle of a window, followed later by the
+     * natural window-boundary rollover — confirms the two mechanisms compose correctly: the
+     * admin reset takes effect immediately and scoped to its own key, the later rollover
+     * still correctly resets every key (including ones untouched by the admin reset), and
+     * neither corrupts the other.
+     */
+    @Test
+    public void adminFlagResetMidWindow_thenNaturalBoundaryLater_bothApplyCorrectly() throws InterruptedException {
+        SiddhiManager siddhiManager = new SiddhiManager();
+        String query = "" +
+                "define stream cseEventStream (throttleKey string, messageID string, reset bool);" +
+                "@info(name = 'query1') " +
+                "from cseEventStream#throttler:timeBatch(3000) " +
+                "select throttleKey, throttler:count(messageID, reset) as cnt, expiryTimeStamp " +
+                "group by throttleKey " +
+                "insert all events into outputStream;";
+
+        ExecutionPlanRuntime execPlanRunTime = siddhiManager.createExecutionPlanRuntime(query);
+        Map<String, Long> lastCountPerKey = new ConcurrentHashMap<>();
+        execPlanRunTime.addCallback("query1", new QueryCallback() {
+            @Override
+            public void receive(long timeStamp, Event[] inEvents, Event[] removeEvents) {
+                EventPrinter.print(timeStamp, inEvents, removeEvents);
+                if (inEvents != null) {
+                    for (Event e : inEvents) {
+                        lastCountPerKey.put((String) e.getData(0), (Long) e.getData(1));
+                    }
+                }
+            }
+        });
+        execPlanRunTime.start();
+        InputHandler inputHandler = execPlanRunTime.getInputHandler("cseEventStream");
+
+        // Both keys accumulate to 4 mid-window.
+        for (int i = 0; i < 4; i++) {
+            inputHandler.send(new Object[]{"AppM", "m-" + i, false});
+        }
+        for (int i = 0; i < 4; i++) {
+            inputHandler.send(new Object[]{"AppN", "n-" + i, false});
+        }
+        junit.framework.Assert.assertEquals(Long.valueOf(4L), lastCountPerKey.get("AppM"));
+        junit.framework.Assert.assertEquals(Long.valueOf(4L), lastCountPerKey.get("AppN"));
+
+        // Admin resets ONLY AppM, mid-window, well before the natural 3s boundary.
+        inputHandler.send(new Object[]{"AppM", "admin-reset", true});
+        inputHandler.send(new Object[]{"AppM", "post-admin-reset", false});
+        junit.framework.Assert.assertEquals("AppM should be at 1 right after its own admin reset + one "
+                + "new event", Long.valueOf(1L), lastCountPerKey.get("AppM"));
+        junit.framework.Assert.assertEquals("AppN must be untouched by AppM's admin reset",
+                Long.valueOf(4L), lastCountPerKey.get("AppN"));
+
+        // Let the natural window boundary fire.
+        Thread.sleep(3500);
+
+        // Fresh window: both keys must start at 1, regardless of the mid-window admin reset
+        // history — AppM from its post-admin-reset baseline of 1, AppN from its pre-boundary
+        // baseline of 4, both reset by the SAME rollover.
+        inputHandler.send(new Object[]{"AppM", "new-window", false});
+        inputHandler.send(new Object[]{"AppN", "new-window", false});
+        execPlanRunTime.shutdown();
+
+        junit.framework.Assert.assertEquals("AppM should be fresh at 1 in the new window",
+                Long.valueOf(1L), lastCountPerKey.get("AppM"));
+        junit.framework.Assert.assertEquals("AppN should be fresh at 1 in the new window too",
+                Long.valueOf(1L), lastCountPerKey.get("AppN"));
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.throttling.siddhi.extension/src/test/java/org/wso2/carbon/apimgt/throttling/siddhi/extension/DistributedCountAggregatorTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.throttling.siddhi.extension/src/test/java/org/wso2/carbon/apimgt/throttling/siddhi/extension/DistributedCountAggregatorTest.java
@@ -1,0 +1,740 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.apimgt.throttling.siddhi.extension;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.wso2.carbon.apimgt.impl.dto.DistributedThrottleConfig;
+import org.wso2.carbon.apimgt.throttling.siddhi.extension.util.kvstore.KeyValueStoreClient;
+import org.wso2.carbon.apimgt.throttling.siddhi.extension.util.kvstore.KeyValueStoreException;
+import org.wso2.carbon.apimgt.throttling.siddhi.extension.util.kvstore.KeyValueStoreManager;
+
+import java.lang.reflect.Field;
+import java.util.AbstractMap;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Unit tests for DistributedCountAttributeAggregator's Redis interaction logic.
+ *
+ * Dependencies: JUnit 4, siddhi-core, apimgt.impl (already in test scope).
+ * No Mockito or other mocking frameworks are used.
+ *
+ * Test strategy: reflection is used to inject a fake KeyValueStoreClient and to read
+ * private state fields after operations, bypassing the OSGi ServiceReferenceHolder so
+ * tests run outside a Carbon container.
+ */
+public class DistributedCountAggregatorTest {
+
+    // -----------------------------------------------------------------------
+    // Fake in-memory KeyValueStoreClient — records calls for assertion
+    // -----------------------------------------------------------------------
+
+    private static class InMemoryKeyValueStoreClient implements KeyValueStoreClient {
+
+        final ConcurrentHashMap<String, String> store = new ConcurrentHashMap<>();
+        final AtomicInteger setWithExpiryCount = new AtomicInteger();
+        final AtomicInteger expireMillisCount = new AtomicInteger();
+        final AtomicInteger incrementByCount = new AtomicInteger();
+        volatile String lastSetWithExpiryValue;
+        volatile long lastSetWithExpiryTTL = -1L;
+        volatile long lastExpireMillisTTL = -1L;
+
+        @Override
+        public void setWithExpiry(String key, String value, long ttlMillis) {
+            store.put(key, value);
+            lastSetWithExpiryValue = value;
+            lastSetWithExpiryTTL = ttlMillis;
+            setWithExpiryCount.incrementAndGet();
+        }
+
+        @Override
+        public void expireMillis(String key, long ttlMillis) {
+            lastExpireMillisTTL = ttlMillis;
+            expireMillisCount.incrementAndGet();
+        }
+
+        @Override
+        public long incrementBy(String key, long increment) {
+            String result = store.merge(key, String.valueOf(increment),
+                    (existing, delta) -> String.valueOf(Long.parseLong(existing) + Long.parseLong(delta)));
+            incrementByCount.incrementAndGet();
+            return Long.parseLong(result);
+        }
+
+        @Override
+        public long decrementBy(String key, long decrement) {
+            String result = store.merge(key, String.valueOf(-decrement),
+                    (existing, delta) -> String.valueOf(Long.parseLong(existing) + Long.parseLong(delta)));
+            return Long.parseLong(result);
+        }
+
+        @Override
+        public String get(String key) {
+            return store.get(key);
+        }
+
+        @Override
+        public void set(String key, String value) {
+            store.put(key, value);
+        }
+
+        @Override
+        public void delete(String key) {
+            store.remove(key);
+        }
+
+        @Override
+        public void disconnect() {
+            store.clear();
+        }
+    }
+
+    /** Throws on every setWithExpiry call — simulates a Redis PSETEX failure. */
+    private static class FailingOnWriteKeyValueStoreClient extends InMemoryKeyValueStoreClient {
+        @Override
+        public void setWithExpiry(String key, String value, long ttlMillis) {
+            throw new KeyValueStoreException("Simulated PSETEX failure");
+        }
+    }
+
+    /** Throws on every incrementBy call — simulates a Redis INCRBY failure. */
+    private static class FailingOnIncrByKeyValueStoreClient extends InMemoryKeyValueStoreClient {
+        @Override
+        public long incrementBy(String key, long increment) {
+            throw new KeyValueStoreException("Simulated INCRBY failure");
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Reflection helpers
+    // -----------------------------------------------------------------------
+
+    private static void setStaticField(Class<?> clazz, String name, Object value) throws Exception {
+        Field f = clazz.getDeclaredField(name);
+        f.setAccessible(true);
+        f.set(null, value);
+    }
+
+    private static Object getStaticField(Class<?> clazz, String name) throws Exception {
+        Field f = clazz.getDeclaredField(name);
+        f.setAccessible(true);
+        return f.get(null);
+    }
+
+    private static void setInstanceField(Object obj, String name, Object value) throws Exception {
+        Field f = obj.getClass().getDeclaredField(name);
+        f.setAccessible(true);
+        f.set(obj, value);
+    }
+
+    private static Object getInstanceField(Object obj, String name) throws Exception {
+        Field f = obj.getClass().getDeclaredField(name);
+        f.setAccessible(true);
+        return f.get(obj);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static ThreadLocal<Long> getWindowExpiryThreadLocal() throws Exception {
+        Field f = ThrottleStreamProcessor.class.getDeclaredField("windowExpiryThreadLocal");
+        f.setAccessible(true);
+        return (ThreadLocal<Long>) f.get(null);
+    }
+
+    // -----------------------------------------------------------------------
+    // Setup / teardown
+    // -----------------------------------------------------------------------
+
+    private InMemoryKeyValueStoreClient fakeClient;
+
+    @Before
+    public void setUp() throws Exception {
+        fakeClient = new InMemoryKeyValueStoreClient();
+
+        // Build a minimal config so init() does not attempt ServiceReferenceHolder lookup.
+        DistributedThrottleConfig config = new DistributedThrottleConfig();
+        config.setEnabled(true);
+        config.setSyncInterval(10);
+        config.setCorePoolSize(2);
+
+        // Inject static state on DCAA: config + flags.
+        setStaticField(DistributedCountAttributeAggregator.class, "DISTRIBUTED_THROTTLE_CONFIG", config);
+        setStaticField(DistributedCountAttributeAggregator.class, "distributedThrottlingEnabled", true);
+        setStaticField(DistributedCountAttributeAggregator.class, "kvStoreSyncIntervalMilliseconds", 10);
+        setStaticField(DistributedCountAttributeAggregator.class, "corePoolSize", 2);
+        // Keep schedulerStarted=true so the background scheduler is never launched during tests.
+        setStaticField(DistributedCountAttributeAggregator.class, "schedulerStarted", true);
+
+        // Inject the fake client into KeyValueStoreManager so any getClient() call returns it.
+        setStaticField(KeyValueStoreManager.class, "clientInstance", fakeClient);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        // Reset all static state between tests.
+        setStaticField(DistributedCountAttributeAggregator.class, "DISTRIBUTED_THROTTLE_CONFIG", null);
+        setStaticField(DistributedCountAttributeAggregator.class, "distributedThrottlingEnabled", false);
+        setStaticField(DistributedCountAttributeAggregator.class, "schedulerStarted", false);
+
+        @SuppressWarnings("unchecked")
+        ConcurrentHashMap<String, DistributedCountAttributeAggregator> active =
+                (ConcurrentHashMap<String, DistributedCountAttributeAggregator>)
+                        getStaticField(DistributedCountAttributeAggregator.class, "ACTIVE_AGGREGATORS");
+        active.clear();
+
+        setStaticField(KeyValueStoreManager.class, "clientInstance", null);
+
+        // Remove any stale ThreadLocal value left by a test.
+        getWindowExpiryThreadLocal().remove();
+    }
+
+    /**
+     * Creates a DCAA instance with all necessary fields injected via reflection.
+     * init() is bypassed — the background scheduler is not started.
+     */
+    private DistributedCountAttributeAggregator createAggregator(String throttleKey) throws Exception {
+        DistributedCountAttributeAggregator aggregator = new DistributedCountAttributeAggregator();
+        setInstanceField(aggregator, "key", "wso2_throttler:" + throttleKey);
+        setInstanceField(aggregator, "kvStoreClient", fakeClient);
+        return aggregator;
+    }
+
+    /**
+     * Sets the windowExpiryThreadLocal on the calling thread.
+     * Must be paired with a removeWindowExpiryThreadLocal() call to avoid leaking state.
+     */
+    private void setWindowExpiryThreadLocal(long expiryMillis) throws Exception {
+        getWindowExpiryThreadLocal().set(expiryMillis);
+    }
+
+    private void removeWindowExpiryThreadLocal() throws Exception {
+        getWindowExpiryThreadLocal().remove();
+    }
+
+    // -----------------------------------------------------------------------
+    // Tests
+    // -----------------------------------------------------------------------
+
+    /**
+     * reset() must set pendingReset=true non-blockingly; the subsequent syncWithKVStore()
+     * (triggered via currentState()) must issue a PSETEX "0" call and clear the flag.
+     */
+    @Test
+    public void pendingResetIsSetByResetAndClearedAfterSync() throws Exception {
+        DistributedCountAttributeAggregator aggregator = createAggregator("testKey1");
+        long futureExpiry = System.currentTimeMillis() + 60_000L;
+        setWindowExpiryThreadLocal(futureExpiry);
+        try {
+            aggregator.reset();
+        } finally {
+            removeWindowExpiryThreadLocal();
+        }
+
+        boolean pendingResetAfterReset = (boolean) getInstanceField(aggregator, "pendingReset");
+        Assert.assertTrue("pendingReset must be true immediately after reset()", pendingResetAfterReset);
+
+        aggregator.currentState(); // triggers syncWithKVStore()
+
+        boolean pendingResetAfterSync = (boolean) getInstanceField(aggregator, "pendingReset");
+        Assert.assertFalse("pendingReset must be cleared after syncWithKVStore() succeeds", pendingResetAfterSync);
+
+        Assert.assertEquals("setWithExpiry must be called exactly once for the PSETEX 0",
+                1, fakeClient.setWithExpiryCount.get());
+        Assert.assertEquals("PSETEX value must be 0 to reset the window count",
+                "0", fakeClient.lastSetWithExpiryValue);
+        Assert.assertTrue("PSETEX TTL must be positive (remaining window time)",
+                fakeClient.lastSetWithExpiryTTL > 0);
+    }
+
+    /**
+     * After processAdd() detects a stale storedWindowExpiry (empty-window gap scenario),
+     * keyHasTTL is set to false. The subsequent syncWithKVStore() must call PEXPIRE exactly
+     * once. A second syncWithKVStore() must not call PEXPIRE again because keyHasTTL=true.
+     */
+    @Test
+    public void expireMillisCalledOncePerWindowAfterGap() throws Exception {
+        DistributedCountAttributeAggregator aggregator = createAggregator("testKey2");
+
+        // storedWindowExpiry starts at 0L (class default) — simulates a post-gap state.
+        // Set ThreadLocal to a future expiry so processAdd() can refresh storedWindowExpiry.
+        long futureExpiry = System.currentTimeMillis() + 60_000L;
+        setWindowExpiryThreadLocal(futureExpiry);
+        try {
+            aggregator.processAdd((Object) null);
+        } finally {
+            removeWindowExpiryThreadLocal();
+        }
+
+        // First sync: INCRBY fires; keyHasTTL=false so PEXPIRE is also called.
+        aggregator.currentState();
+        Assert.assertEquals("PEXPIRE must be called once after detecting a gap",
+                1, fakeClient.expireMillisCount.get());
+        Assert.assertTrue("PEXPIRE TTL must be positive", fakeClient.lastExpireMillisTTL > 0);
+
+        // Second sync: keyHasTTL is now true — no additional PEXPIRE.
+        aggregator.currentState();
+        Assert.assertEquals("PEXPIRE must not be called again when keyHasTTL is already true",
+                1, fakeClient.expireMillisCount.get());
+    }
+
+    /**
+     * When storedWindowExpiry is in the past (stale — as happens after empty windows),
+     * processAdd() must refresh it from the ThreadLocal and mark keyHasTTL=false.
+     */
+    @Test
+    public void storedWindowExpiryRefreshedFromThreadLocalWhenStale() throws Exception {
+        DistributedCountAttributeAggregator aggregator = createAggregator("testKey3");
+
+        // Simulate a stale storedWindowExpiry (default 0L is already in the past).
+        long futureExpiry = System.currentTimeMillis() + 30_000L;
+        setWindowExpiryThreadLocal(futureExpiry);
+        try {
+            aggregator.processAdd((Object) null);
+        } finally {
+            removeWindowExpiryThreadLocal();
+        }
+
+        long stored = (long) getInstanceField(aggregator, "storedWindowExpiry");
+        Assert.assertEquals("storedWindowExpiry must be refreshed to the ThreadLocal value",
+                futureExpiry, stored);
+
+        boolean keyHasTTL = (boolean) getInstanceField(aggregator, "keyHasTTL");
+        Assert.assertFalse("keyHasTTL must be false after storedWindowExpiry is refreshed (key needs PEXPIRE)",
+                keyHasTTL);
+    }
+
+    /**
+     * Multiple processAdd() calls must accumulate in unsyncedCounter. syncWithKVStore()
+     * (via currentState()) must flush the full delta in a single INCRBY and zero
+     * unsyncedCounter afterwards.
+     */
+    @Test
+    public void accumulatedDeltaFlushedViaIncrementBy() throws Exception {
+        DistributedCountAttributeAggregator aggregator = createAggregator("testKey4");
+
+        // Give a valid future expiry so the TTL path doesn't interfere.
+        long futureExpiry = System.currentTimeMillis() + 60_000L;
+        setInstanceField(aggregator, "storedWindowExpiry", futureExpiry);
+        setInstanceField(aggregator, "keyHasTTL", true);
+
+        aggregator.processAdd((Object) null);
+        aggregator.processAdd((Object) null);
+        aggregator.processAdd((Object) null);
+
+        AtomicLong unsynced = (AtomicLong) getInstanceField(aggregator, "unsyncedCounter");
+        Assert.assertEquals("unsyncedCounter must hold all 3 increments before sync", 3L, unsynced.get());
+
+        aggregator.currentState(); // triggers syncWithKVStore()
+
+        Assert.assertEquals("incrementBy must be called exactly once to flush the batch delta",
+                1, fakeClient.incrementByCount.get());
+        Assert.assertEquals("Redis value after INCRBY must equal 3",
+                "3", fakeClient.store.get("wso2_throttler:testKey4"));
+        Assert.assertEquals("unsyncedCounter must be zero after a successful sync", 0L, unsynced.get());
+    }
+
+    /**
+     * reset() must zero both localCounter and unsyncedCounter immediately (non-blocking)
+     * and set pendingReset=true. No Redis call should occur during reset() itself.
+     */
+    @Test
+    public void resetZerosCountersImmediatelyWithoutBlockingOnRedis() throws Exception {
+        DistributedCountAttributeAggregator aggregator = createAggregator("testKey5");
+
+        long futureExpiry = System.currentTimeMillis() + 60_000L;
+        setInstanceField(aggregator, "storedWindowExpiry", futureExpiry);
+        setInstanceField(aggregator, "keyHasTTL", true);
+
+        aggregator.processAdd((Object) null);
+        aggregator.processAdd((Object) null);
+        aggregator.processAdd((Object) null);
+        aggregator.processAdd((Object) null);
+        aggregator.processAdd((Object) null);
+
+        AtomicLong local = (AtomicLong) getInstanceField(aggregator, "localCounter");
+        AtomicLong unsynced = (AtomicLong) getInstanceField(aggregator, "unsyncedCounter");
+        Assert.assertEquals("localCounter must be 5 before reset", 5L, local.get());
+        Assert.assertEquals("unsyncedCounter must be 5 before reset", 5L, unsynced.get());
+
+        setWindowExpiryThreadLocal(futureExpiry);
+        try {
+            Object result = aggregator.reset();
+            Assert.assertEquals("reset() must return 0L", 0L, result);
+        } finally {
+            removeWindowExpiryThreadLocal();
+        }
+
+        Assert.assertEquals("localCounter must be 0 immediately after reset()", 0L, local.get());
+        Assert.assertEquals("unsyncedCounter must be 0 immediately after reset()", 0L, unsynced.get());
+        Assert.assertTrue("pendingReset must be true after reset()",
+                (boolean) getInstanceField(aggregator, "pendingReset"));
+
+        // No Redis calls must have been made by reset() itself.
+        Assert.assertEquals("reset() must not call setWithExpiry — that is the sync thread's job",
+                0, fakeClient.setWithExpiryCount.get());
+        Assert.assertEquals("reset() must not call expireMillis",
+                0, fakeClient.expireMillisCount.get());
+        Assert.assertEquals("reset() must not call incrementBy",
+                0, fakeClient.incrementByCount.get());
+    }
+
+    /**
+     * storedWindowExpiry must not be updated when the ThreadLocal value is not newer than
+     * the current storedWindowExpiry (prevents regression to an older window's boundary).
+     */
+    @Test
+    public void storedWindowExpiryNotOverwrittenWithOlderValue() throws Exception {
+        DistributedCountAttributeAggregator aggregator = createAggregator("testKey6");
+
+        long futureExpiry = System.currentTimeMillis() + 60_000L;
+        setInstanceField(aggregator, "storedWindowExpiry", futureExpiry);
+        setInstanceField(aggregator, "keyHasTTL", true);
+
+        // storedWindowExpiry is in the future, so processAdd() should NOT refresh it.
+        long olderExpiry = System.currentTimeMillis() + 1_000L; // older than current
+        setWindowExpiryThreadLocal(olderExpiry);
+        try {
+            aggregator.processAdd((Object) null);
+        } finally {
+            removeWindowExpiryThreadLocal();
+        }
+
+        long stored = (long) getInstanceField(aggregator, "storedWindowExpiry");
+        Assert.assertEquals("storedWindowExpiry must not be overwritten with a value from the past",
+                futureExpiry, stored);
+        Assert.assertTrue("keyHasTTL must remain true when storedWindowExpiry was not refreshed",
+                (boolean) getInstanceField(aggregator, "keyHasTTL"));
+    }
+
+    /**
+     * writeCounterValue() must be a no-op when storedWindowExpiry is 0 (not yet known).
+     * Concretely: reset() called before any window expiry is known — the subsequent
+     * syncWithKVStore() must clear pendingReset without issuing a PSETEX.
+     */
+    @Test
+    public void writeCounterValueIsNoOpWhenStoredWindowExpiryIsZero() throws Exception {
+        DistributedCountAttributeAggregator aggregator = createAggregator("testKey7");
+        // storedWindowExpiry stays 0 (default) — no ThreadLocal set before reset()
+        aggregator.reset();
+
+        boolean pendingResetAfterReset = (boolean) getInstanceField(aggregator, "pendingReset");
+        Assert.assertTrue("pendingReset must be true after reset()", pendingResetAfterReset);
+
+        aggregator.currentState(); // triggers syncWithKVStore() → pendingReset path → writeCounterValue no-op
+
+        Assert.assertEquals("PSETEX must not be called when storedWindowExpiry is 0",
+                0, fakeClient.setWithExpiryCount.get());
+        Assert.assertFalse("pendingReset must still be cleared even when writeCounterValue is a no-op",
+                (boolean) getInstanceField(aggregator, "pendingReset"));
+    }
+
+    /**
+     * writeCounterValue() must be a no-op when the window has already expired
+     * (storedWindowExpiry is in the past). No PSETEX must be sent in this case.
+     */
+    @Test
+    public void writeCounterValueIsNoOpWhenWindowHasExpired() throws Exception {
+        DistributedCountAttributeAggregator aggregator = createAggregator("testKey8");
+        // Simulate a storedWindowExpiry that is already in the past.
+        setInstanceField(aggregator, "storedWindowExpiry", System.currentTimeMillis() - 5_000L);
+        setInstanceField(aggregator, "pendingReset", true);
+
+        aggregator.currentState(); // triggers syncWithKVStore() → pendingReset path → remainingMillis <= 0 → no-op
+
+        Assert.assertEquals("PSETEX must not be called when the window has already expired",
+                0, fakeClient.setWithExpiryCount.get());
+        Assert.assertFalse("pendingReset must be cleared regardless of whether PSETEX was sent",
+                (boolean) getInstanceField(aggregator, "pendingReset"));
+    }
+
+    /**
+     * When the Redis PSETEX call for a pendingReset throws, pendingReset must remain true
+     * so the next sync tick retries. The flag must never be cleared on failure.
+     */
+    @Test
+    public void pendingResetNotClearedWhenSetWithExpiryThrows() throws Exception {
+        FailingOnWriteKeyValueStoreClient failingClient = new FailingOnWriteKeyValueStoreClient();
+        DistributedCountAttributeAggregator aggregator = createAggregator("testKey9");
+        setInstanceField(aggregator, "kvStoreClient", failingClient);
+
+        long futureExpiry = System.currentTimeMillis() + 60_000L;
+        setWindowExpiryThreadLocal(futureExpiry);
+        try {
+            aggregator.reset();
+        } finally {
+            removeWindowExpiryThreadLocal();
+        }
+
+        // First sync attempt: PSETEX throws → pendingReset stays true.
+        aggregator.currentState();
+        Assert.assertTrue("pendingReset must remain true when PSETEX fails",
+                (boolean) getInstanceField(aggregator, "pendingReset"));
+
+        // Second sync attempt: still failing → still true.
+        aggregator.currentState();
+        Assert.assertTrue("pendingReset must remain true on repeated PSETEX failures",
+                (boolean) getInstanceField(aggregator, "pendingReset"));
+    }
+
+    /**
+     * When the Redis INCRBY call throws and no pendingReset is set, the captured delta
+     * must be restored into unsyncedCounter so it is not silently lost.
+     */
+    @Test
+    public void deltaRestoredToUnsyncedCounterOnIncrementByFailure() throws Exception {
+        FailingOnIncrByKeyValueStoreClient failingClient = new FailingOnIncrByKeyValueStoreClient();
+        DistributedCountAttributeAggregator aggregator = createAggregator("testKey10");
+        setInstanceField(aggregator, "kvStoreClient", failingClient);
+
+        long futureExpiry = System.currentTimeMillis() + 60_000L;
+        setInstanceField(aggregator, "storedWindowExpiry", futureExpiry);
+        setInstanceField(aggregator, "keyHasTTL", true);
+
+        aggregator.processAdd((Object) null);
+        aggregator.processAdd((Object) null);
+        aggregator.processAdd((Object) null);
+
+        AtomicLong unsynced = (AtomicLong) getInstanceField(aggregator, "unsyncedCounter");
+        Assert.assertEquals("unsyncedCounter must be 3 before sync", 3L, unsynced.get());
+
+        aggregator.currentState(); // INCRBY throws → delta restored
+
+        Assert.assertEquals("unsyncedCounter must be restored to 3 after a failed INCRBY",
+                3L, unsynced.get());
+    }
+
+    /**
+     * When unsyncedCounter is 0 and the Redis key already exists (written by another TM),
+     * syncWithKVStore() must pull the current value via GET and update localCounter.
+     */
+    @Test
+    public void localCounterSyncedFromRedisGetWhenNoLocalDelta() throws Exception {
+        DistributedCountAttributeAggregator aggregator = createAggregator("testKey11");
+        setInstanceField(aggregator, "storedWindowExpiry", System.currentTimeMillis() + 60_000L);
+        setInstanceField(aggregator, "keyHasTTL", true);
+        fakeClient.store.put("wso2_throttler:testKey11", "50");
+
+        // No processAdd() calls — unsyncedCounter=0 → GET path.
+        aggregator.currentState();
+
+        AtomicLong local = (AtomicLong) getInstanceField(aggregator, "localCounter");
+        Assert.assertEquals("localCounter must be set to the Redis GET value from another TM",
+                50L, local.get());
+    }
+
+    /**
+     * When unsyncedCounter is 0 and the Redis key is absent, syncWithKVStore() must call
+     * writeCounterValue("0") (PSETEX "0") to initialize the key and set localCounter to 0.
+     */
+    @Test
+    public void localCounterSetToZeroAndRedisSeededWhenKeyAbsent() throws Exception {
+        DistributedCountAttributeAggregator aggregator = createAggregator("testKey12");
+        long futureExpiry = System.currentTimeMillis() + 60_000L;
+        setInstanceField(aggregator, "storedWindowExpiry", futureExpiry);
+        setInstanceField(aggregator, "keyHasTTL", true);
+        // Store is empty — no key exists.
+
+        aggregator.currentState(); // GET returns null → writeCounterValue("0") + localCounter=0
+
+        AtomicLong local = (AtomicLong) getInstanceField(aggregator, "localCounter");
+        Assert.assertEquals("localCounter must be 0 when Redis key is absent", 0L, local.get());
+        Assert.assertEquals("PSETEX must be called once to seed Redis with 0 when key is absent",
+                1, fakeClient.setWithExpiryCount.get());
+        Assert.assertEquals("seeded Redis value must be 0", "0", fakeClient.lastSetWithExpiryValue);
+    }
+
+    /**
+     * stop() must execute two syncWithKVStore() calls: first flushes pendingReset via PSETEX "0",
+     * second pushes the accumulated new-window delta via INCRBY.
+     */
+    @Test
+    public void stopFlushesResetThenDeltaInTwoSyncs() throws Exception {
+        DistributedCountAttributeAggregator aggregator = createAggregator("testKey13");
+        long futureExpiry = System.currentTimeMillis() + 60_000L;
+        setWindowExpiryThreadLocal(futureExpiry);
+        try {
+            aggregator.reset(); // pendingReset=true, storedWindowExpiry=futureExpiry, unsyncedCounter=0
+        } finally {
+            removeWindowExpiryThreadLocal();
+        }
+        // Simulate two new-window increments arriving after the reset.
+        setInstanceField(aggregator, "keyHasTTL", true);
+        aggregator.processAdd((Object) null);
+        aggregator.processAdd((Object) null); // unsyncedCounter=2
+
+        aggregator.stop();
+
+        Assert.assertEquals("stop() must issue exactly one PSETEX for the pendingReset",
+                1, fakeClient.setWithExpiryCount.get());
+        Assert.assertEquals("PSETEX value must be 0 to reset the window counter",
+                "0", fakeClient.lastSetWithExpiryValue);
+        Assert.assertEquals("stop() must issue exactly one INCRBY for the new-window delta",
+                1, fakeClient.incrementByCount.get());
+    }
+
+    /**
+     * restoreState() must load localCounter from Redis in distributed mode, ignoring the
+     * stale single-node Siddhi snapshot value. Redis is the authoritative source.
+     */
+    @Test
+    public void restoreStateUsesRedisValueInDistributedMode() throws Exception {
+        DistributedCountAttributeAggregator aggregator = createAggregator("testKey14");
+        fakeClient.store.put("wso2_throttler:testKey14", "100");
+
+        Object[] state = new Object[]{new AbstractMap.SimpleEntry<String, Object>("Value", 5L)};
+        aggregator.restoreState(state);
+
+        AtomicLong local = (AtomicLong) getInstanceField(aggregator, "localCounter");
+        Assert.assertEquals("localCounter must reflect the Redis value, not the Siddhi snapshot",
+                100L, local.get());
+    }
+
+    /**
+     * restoreState() must clear pendingReset inside the lock so that the sync thread does not
+     * issue a stale PSETEX "0" after state has been freshly restored from Redis.
+     */
+    @Test
+    public void restoreStateClearsPendingReset() throws Exception {
+        DistributedCountAttributeAggregator aggregator = createAggregator("testKey15");
+        setInstanceField(aggregator, "pendingReset", true);
+
+        Object[] state = new Object[]{new AbstractMap.SimpleEntry<String, Object>("Value", 3L)};
+        aggregator.restoreState(state);
+
+        Assert.assertFalse("restoreState() must clear pendingReset to prevent stale PSETEX retries",
+                (boolean) getInstanceField(aggregator, "pendingReset"));
+    }
+
+    /**
+     * In non-distributed mode restoreState() must use the Siddhi snapshot value because
+     * there is no Redis to consult.
+     */
+    @Test
+    public void restoreStateInNonDistributedModeUsesSiddhiSnapshot() throws Exception {
+        // Temporarily disable distributed throttling for this test.
+        setStaticField(DistributedCountAttributeAggregator.class, "distributedThrottlingEnabled", false);
+
+        DistributedCountAttributeAggregator aggregator = createAggregator("testKey16");
+        Object[] state = new Object[]{new AbstractMap.SimpleEntry<String, Object>("Value", 7L)};
+        aggregator.restoreState(state);
+
+        AtomicLong local = (AtomicLong) getInstanceField(aggregator, "localCounter");
+        Assert.assertEquals("In non-distributed mode localCounter must come from the Siddhi snapshot",
+                7L, local.get());
+        Assert.assertEquals("No Redis calls must be made in non-distributed mode",
+                0, fakeClient.setWithExpiryCount.get());
+    }
+
+    /**
+     * After a successful PSETEX in the pendingReset path, keyHasTTL must be set to true
+     * so that subsequent INCRBY calls do not redundantly issue another PEXPIRE.
+     */
+    @Test
+    public void keyHasTTLSetTrueAfterSuccessfulPSetexInResetPath() throws Exception {
+        DistributedCountAttributeAggregator aggregator = createAggregator("testKey17");
+        long futureExpiry = System.currentTimeMillis() + 60_000L;
+        setWindowExpiryThreadLocal(futureExpiry);
+        try {
+            aggregator.reset();
+        } finally {
+            removeWindowExpiryThreadLocal();
+        }
+
+        Assert.assertFalse("keyHasTTL must be false before the first sync after reset()",
+                (boolean) getInstanceField(aggregator, "keyHasTTL"));
+
+        aggregator.currentState(); // pendingReset → PSETEX → keyHasTTL = true
+
+        Assert.assertTrue("keyHasTTL must be true after a successful PSETEX in the pendingReset path",
+                (boolean) getInstanceField(aggregator, "keyHasTTL"));
+    }
+
+    /**
+     * processRemove() must decrement both localCounter and unsyncedCounter when distributed
+     * throttling is enabled. The net delta must reflect the subtraction correctly.
+     */
+    @Test
+    public void processRemoveDecrementsUnsyncedCounter() throws Exception {
+        DistributedCountAttributeAggregator aggregator = createAggregator("testKey18");
+        long futureExpiry = System.currentTimeMillis() + 60_000L;
+        setInstanceField(aggregator, "storedWindowExpiry", futureExpiry);
+        setInstanceField(aggregator, "keyHasTTL", true);
+
+        aggregator.processAdd((Object) null);
+        aggregator.processAdd((Object) null);
+        aggregator.processAdd((Object) null); // localCounter=3, unsyncedCounter=3
+
+        aggregator.processRemove((Object) null); // localCounter=2, unsyncedCounter=2
+
+        AtomicLong local = (AtomicLong) getInstanceField(aggregator, "localCounter");
+        AtomicLong unsynced = (AtomicLong) getInstanceField(aggregator, "unsyncedCounter");
+        Assert.assertEquals("localCounter must be 2 after three adds and one remove", 2L, local.get());
+        Assert.assertEquals("unsyncedCounter must be 2 so only the net delta is pushed to Redis",
+                2L, unsynced.get());
+    }
+
+    /**
+     * When reset() is called without a ThreadLocal value (no current window boundary known),
+     * storedWindowExpiry must remain unchanged so a stale or zero value is not introduced.
+     */
+    @Test
+    public void resetWithNullThreadLocalDoesNotChangeStoredWindowExpiry() throws Exception {
+        DistributedCountAttributeAggregator aggregator = createAggregator("testKey19");
+        long knownExpiry = System.currentTimeMillis() + 60_000L;
+        setInstanceField(aggregator, "storedWindowExpiry", knownExpiry);
+
+        // ThreadLocal is null (not set) — reset() must leave storedWindowExpiry alone.
+        aggregator.reset();
+
+        long stored = (long) getInstanceField(aggregator, "storedWindowExpiry");
+        Assert.assertEquals("storedWindowExpiry must not change when ThreadLocal is null during reset()",
+                knownExpiry, stored);
+        Assert.assertTrue("pendingReset must still be set even when ThreadLocal is absent",
+                (boolean) getInstanceField(aggregator, "pendingReset"));
+    }
+
+    /**
+     * The TTL passed to PEXPIRE after INCRBY must closely match the remaining window time
+     * (storedWindowExpiry - currentTimeMillis). Verifies the TTL is wired correctly, not
+     * hard-coded or calculated from a stale snapshot.
+     */
+    @Test
+    public void pexpireTtlMatchesRemainingWindowTime() throws Exception {
+        DistributedCountAttributeAggregator aggregator = createAggregator("testKey20");
+        long windowDurationMs = 30_000L;
+        long futureExpiry = System.currentTimeMillis() + windowDurationMs;
+        setInstanceField(aggregator, "storedWindowExpiry", futureExpiry);
+        setInstanceField(aggregator, "keyHasTTL", false); // forces PEXPIRE after INCRBY
+
+        aggregator.processAdd((Object) null);
+        aggregator.currentState(); // INCRBY + PEXPIRE
+
+        Assert.assertEquals("PEXPIRE must be called exactly once after the first INCRBY in a new window",
+                1, fakeClient.expireMillisCount.get());
+        long ttlApplied = fakeClient.lastExpireMillisTTL;
+        Assert.assertTrue("PEXPIRE TTL must be positive (remaining window time)",
+                ttlApplied > 0);
+        Assert.assertTrue("PEXPIRE TTL must not exceed the original window duration",
+                ttlApplied <= windowDurationMs);
+        Assert.assertTrue("PEXPIRE TTL must be within 2 seconds of the remaining window time",
+                ttlApplied >= windowDurationMs - 2_000L);
+    }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.throttling.siddhi.extension/src/test/java/org/wso2/carbon/apimgt/throttling/siddhi/extension/DistributedCountAggregatorTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.throttling.siddhi.extension/src/test/java/org/wso2/carbon/apimgt/throttling/siddhi/extension/DistributedCountAggregatorTest.java
@@ -25,10 +25,20 @@ import org.wso2.carbon.apimgt.impl.dto.DistributedThrottleConfig;
 import org.wso2.carbon.apimgt.throttling.siddhi.extension.util.kvstore.KeyValueStoreClient;
 import org.wso2.carbon.apimgt.throttling.siddhi.extension.util.kvstore.KeyValueStoreException;
 import org.wso2.carbon.apimgt.throttling.siddhi.extension.util.kvstore.KeyValueStoreManager;
+import org.wso2.siddhi.core.ExecutionPlanRuntime;
+import org.wso2.siddhi.core.SiddhiManager;
+import org.wso2.siddhi.core.event.Event;
+import org.wso2.siddhi.core.query.output.callback.QueryCallback;
+import org.wso2.siddhi.core.stream.input.InputHandler;
 
 import java.lang.reflect.Field;
 import java.util.AbstractMap;
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -121,6 +131,92 @@ public class DistributedCountAggregatorTest {
         @Override
         public long incrementBy(String key, long increment) {
             throw new KeyValueStoreException("Simulated INCRBY failure");
+        }
+    }
+
+    /** Fails setWithExpiry only for keys containing the given substring — simulates one
+     *  node/shard of a Redis-backed store being unavailable while others are healthy. */
+    private static class PartiallyFailingKeyValueStoreClient extends InMemoryKeyValueStoreClient {
+        private final String failingKeySubstring;
+        volatile int failureCount = 0;
+
+        PartiallyFailingKeyValueStoreClient(String failingKeySubstring) {
+            this.failingKeySubstring = failingKeySubstring;
+        }
+
+        @Override
+        public void setWithExpiry(String key, String value, long ttlMillis) {
+            if (key.contains(failingKeySubstring)) {
+                failureCount++;
+                throw new KeyValueStoreException("Simulated PSETEX failure for " + key);
+            }
+            super.setWithExpiry(key, value, ttlMillis);
+        }
+    }
+
+    /** Throws on every get call — simulates a Redis GET failure (as opposed to a
+     *  successful GET that simply returns null for an absent key). */
+    private static class FailingOnGetKeyValueStoreClient extends InMemoryKeyValueStoreClient {
+        @Override
+        public String get(String key) {
+            throw new KeyValueStoreException("Simulated GET failure");
+        }
+    }
+
+    /** Blocks inside incrementBy until released — used to deterministically land a
+     *  reset() call in the middle of an in-flight syncWithKVStore() INCRBY, without relying
+     *  on timing. */
+    private static class BlockingOnIncrByKeyValueStoreClient extends InMemoryKeyValueStoreClient {
+        final CountDownLatch enteredIncrBy = new CountDownLatch(1);
+        final CountDownLatch releaseIncrBy = new CountDownLatch(1);
+
+        @Override
+        public long incrementBy(String key, long increment) {
+            enteredIncrBy.countDown();
+            try {
+                releaseIncrBy.await(5, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            return super.incrementBy(key, increment);
+        }
+    }
+
+    /** Blocks inside get() until released — used to deterministically land a reset() call in
+     *  the middle of an in-flight syncWithKVStore() GET (the zero-delta path), without relying
+     *  on timing. */
+    private static class BlockingOnGetKeyValueStoreClient extends InMemoryKeyValueStoreClient {
+        final CountDownLatch enteredGet = new CountDownLatch(1);
+        final CountDownLatch releaseGet = new CountDownLatch(1);
+
+        @Override
+        public String get(String key) {
+            enteredGet.countDown();
+            try {
+                releaseGet.await(5, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            return super.get(key);
+        }
+    }
+
+    /** Blocks inside incrementBy until released, then throws — used to deterministically land
+     *  a reset() call in the middle of an INCRBY that goes on to FAIL, so the two can be
+     *  combined without relying on timing. */
+    private static class BlockingThenFailingOnIncrByKeyValueStoreClient extends InMemoryKeyValueStoreClient {
+        final CountDownLatch enteredIncrBy = new CountDownLatch(1);
+        final CountDownLatch releaseIncrBy = new CountDownLatch(1);
+
+        @Override
+        public long incrementBy(String key, long increment) {
+            enteredIncrBy.countDown();
+            try {
+                releaseIncrBy.await(5, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            throw new KeyValueStoreException("Simulated INCRBY failure after reset raced in");
         }
     }
 
@@ -466,6 +562,30 @@ public class DistributedCountAggregatorTest {
     }
 
     /**
+     * The remainingMillis > 0 boundary check in writeCounterValue() must not be some
+     * hard-coded/rounded threshold that only works for the large (tens-of-seconds) windows
+     * used elsewhere in this file — a SHORT but still genuinely positive remaining window
+     * must still fire the PSETEX. Uses a 2-second margin (comfortably clear of test-execution
+     * jitter) rather than a millisecond-scale value, which would risk flipping negative before
+     * the assertion runs and turning a real bug into an indistinguishable false failure.
+     */
+    @Test
+    public void writeCounterValueFiresWhenRemainingTimeIsShortButPositive() throws Exception {
+        DistributedCountAttributeAggregator aggregator = createAggregator("testKey27");
+        setInstanceField(aggregator, "pendingReset", true);
+        long shortRemainingMs = 2000L;
+        setInstanceField(aggregator, "storedWindowExpiry", System.currentTimeMillis() + shortRemainingMs);
+
+        aggregator.currentState();
+
+        Assert.assertEquals("PSETEX must still fire when the remaining window time is short "
+                + "but positive", 1, fakeClient.setWithExpiryCount.get());
+        Assert.assertTrue("The TTL sent must be positive and no larger than the short window "
+                + "itself — got: " + fakeClient.lastSetWithExpiryTTL,
+                fakeClient.lastSetWithExpiryTTL > 0 && fakeClient.lastSetWithExpiryTTL <= shortRemainingMs);
+    }
+
+    /**
      * When the Redis PSETEX call for a pendingReset throws, pendingReset must remain true
      * so the next sync tick retries. The flag must never be cleared on failure.
      */
@@ -492,6 +612,135 @@ public class DistributedCountAggregatorTest {
         aggregator.currentState();
         Assert.assertTrue("pendingReset must remain true on repeated PSETEX failures",
                 (boolean) getInstanceField(aggregator, "pendingReset"));
+    }
+
+    /**
+     * If reset() fires on another thread WHILE a syncWithKVStore() INCRBY for the OLD window's
+     * delta is still in flight, the stale INCRBY result must not be allowed to overwrite the
+     * fresh post-reset state. Uses a blocking fake client + latches to land the race
+     * deterministically instead of relying on sleep-based timing.
+     */
+    @Test
+    public void resetDuringInFlightIncrByDiscardsTheStaleResult() throws Exception {
+        BlockingOnIncrByKeyValueStoreClient blockingClient = new BlockingOnIncrByKeyValueStoreClient();
+        DistributedCountAttributeAggregator aggregator = createAggregator("testKey21");
+        setInstanceField(aggregator, "kvStoreClient", blockingClient);
+
+        long futureExpiry = System.currentTimeMillis() + 60_000L;
+        setInstanceField(aggregator, "storedWindowExpiry", futureExpiry);
+        setInstanceField(aggregator, "keyHasTTL", true);
+
+        aggregator.processAdd((Object) null);
+        aggregator.processAdd((Object) null); // unsyncedCounter=2 — this is the OLD window's delta.
+
+        Thread syncThread = new Thread(aggregator::currentState);
+        syncThread.start();
+        Assert.assertTrue("Sync thread must have entered incrementBy within the timeout",
+                blockingClient.enteredIncrBy.await(5, TimeUnit.SECONDS));
+
+        // reset() fires from the "main" thread WHILE the old-window INCRBY is still blocked —
+        // mirrors the window-boundary RESET broadcast racing an in-progress periodic sync tick.
+        setWindowExpiryThreadLocal(futureExpiry + 60_000L);
+        try {
+            aggregator.reset();
+        } finally {
+            removeWindowExpiryThreadLocal();
+        }
+
+        blockingClient.releaseIncrBy.countDown();
+        syncThread.join(5000);
+        Assert.assertFalse("Sync thread must have completed", syncThread.isAlive());
+
+        AtomicLong local = (AtomicLong) getInstanceField(aggregator, "localCounter");
+        AtomicLong unsynced = (AtomicLong) getInstanceField(aggregator, "unsyncedCounter");
+        Assert.assertEquals("localCounter must be 0 from reset(), not overwritten by the "
+                + "stale in-flight INCRBY result", 0L, local.get());
+        Assert.assertEquals("unsyncedCounter must be 0 (reset()'s own zeroing), not reinstated "
+                + "with the old-window delta", 0L, unsynced.get());
+        Assert.assertTrue("pendingReset must be true — reset() fired after this sync had "
+                        + "already captured its (now-stale) delta snapshot, so a later sync "
+                        + "tick is still needed to flush the PSETEX 0",
+                (boolean) getInstanceField(aggregator, "pendingReset"));
+    }
+
+    /**
+     * The same race as above, but for the zero-delta GET path: if reset() fires WHILE a
+     * syncWithKVStore() GET is in flight (another TM's value for this key), the stale GET
+     * result must not be allowed to overwrite the fresh post-reset localCounter=0.
+     */
+    @Test
+    public void resetDuringInFlightGetDiscardsTheStaleResult() throws Exception {
+        BlockingOnGetKeyValueStoreClient blockingClient = new BlockingOnGetKeyValueStoreClient();
+        DistributedCountAttributeAggregator aggregator = createAggregator("testKey24");
+        setInstanceField(aggregator, "kvStoreClient", blockingClient);
+
+        long futureExpiry = System.currentTimeMillis() + 60_000L;
+        setInstanceField(aggregator, "storedWindowExpiry", futureExpiry);
+        setInstanceField(aggregator, "keyHasTTL", true);
+        blockingClient.store.put("wso2_throttler:testKey24", "77"); // stale value from another TM
+
+        // No local delta (unsyncedCounter=0) — currentState() takes the GET branch.
+        Thread syncThread = new Thread(aggregator::currentState);
+        syncThread.start();
+        Assert.assertTrue("Sync thread must have entered get() within the timeout",
+                blockingClient.enteredGet.await(5, TimeUnit.SECONDS));
+
+        // reset() fires from the "main" thread WHILE the GET is still blocked.
+        setWindowExpiryThreadLocal(futureExpiry + 60_000L);
+        try {
+            aggregator.reset();
+        } finally {
+            removeWindowExpiryThreadLocal();
+        }
+
+        blockingClient.releaseGet.countDown();
+        syncThread.join(5000);
+        Assert.assertFalse("Sync thread must have completed", syncThread.isAlive());
+
+        AtomicLong local = (AtomicLong) getInstanceField(aggregator, "localCounter");
+        Assert.assertEquals("localCounter must be 0 from reset(), not overwritten by the "
+                + "stale in-flight GET result (77)", 0L, local.get());
+    }
+
+    /**
+     * If reset() fires WHILE an old-window INCRBY is in flight AND that INCRBY goes on to
+     * FAIL, the failed call's delta must NOT be restored into unsyncedCounter — reset() has
+     * already superseded it, so restoring it would reinstate a stale amount on top of a
+     * counter that is supposed to start the new window at 0.
+     */
+    @Test
+    public void resetDuringInFlightFailingIncrByDoesNotRestoreStaleDelta() throws Exception {
+        BlockingThenFailingOnIncrByKeyValueStoreClient client = new BlockingThenFailingOnIncrByKeyValueStoreClient();
+        DistributedCountAttributeAggregator aggregator = createAggregator("testKey25");
+        setInstanceField(aggregator, "kvStoreClient", client);
+
+        long futureExpiry = System.currentTimeMillis() + 60_000L;
+        setInstanceField(aggregator, "storedWindowExpiry", futureExpiry);
+        setInstanceField(aggregator, "keyHasTTL", true);
+
+        aggregator.processAdd((Object) null);
+        aggregator.processAdd((Object) null); // unsyncedCounter=2 — the OLD window's delta.
+
+        Thread syncThread = new Thread(aggregator::currentState);
+        syncThread.start();
+        Assert.assertTrue("Sync thread must have entered incrementBy within the timeout",
+                client.enteredIncrBy.await(5, TimeUnit.SECONDS));
+
+        setWindowExpiryThreadLocal(futureExpiry + 60_000L);
+        try {
+            aggregator.reset(); // unsyncedCounter -> 0, pendingReset=true
+        } finally {
+            removeWindowExpiryThreadLocal();
+        }
+
+        client.releaseIncrBy.countDown(); // incrementBy now throws
+        syncThread.join(5000);
+        Assert.assertFalse("Sync thread must have completed", syncThread.isAlive());
+
+        AtomicLong unsynced = (AtomicLong) getInstanceField(aggregator, "unsyncedCounter");
+        Assert.assertEquals("unsyncedCounter must stay 0 from reset() — the failed INCRBY's "
+                + "old-window delta (2) must not be restored on top of it, since reset() "
+                + "already superseded it", 0L, unsynced.get());
     }
 
     /**
@@ -591,6 +840,38 @@ public class DistributedCountAggregatorTest {
     }
 
     /**
+     * stop()'s second sync (the new-window delta push) is only attempted "if (!pendingReset)"
+     * after the first sync — i.e. only if the PSETEX reset-flush actually succeeded. When that
+     * first flush FAILS, stop() must skip the delta sync entirely rather than push a delta on
+     * top of a reset that never actually completed in Redis.
+     */
+    @Test
+    public void stopSkipsTheDeltaSyncWhenTheResetFlushFails() throws Exception {
+        FailingOnWriteKeyValueStoreClient failingClient = new FailingOnWriteKeyValueStoreClient();
+        DistributedCountAttributeAggregator aggregator = createAggregator("testKey26");
+        setInstanceField(aggregator, "kvStoreClient", failingClient);
+
+        long futureExpiry = System.currentTimeMillis() + 60_000L;
+        setWindowExpiryThreadLocal(futureExpiry);
+        try {
+            aggregator.reset(); // pendingReset=true; the PSETEX will fail via failingClient
+        } finally {
+            removeWindowExpiryThreadLocal();
+        }
+        setInstanceField(aggregator, "keyHasTTL", true);
+        aggregator.processAdd((Object) null);
+        aggregator.processAdd((Object) null); // unsyncedCounter=2, new-window delta
+
+        aggregator.stop();
+
+        Assert.assertTrue("pendingReset must remain true since the PSETEX flush failed",
+                (boolean) getInstanceField(aggregator, "pendingReset"));
+        Assert.assertEquals("stop() must skip the delta sync entirely when the reset flush "
+                + "failed — incrementBy must never be called",
+                0, failingClient.incrementByCount.get());
+    }
+
+    /**
      * restoreState() must load localCounter from Redis in distributed mode, ignoring the
      * stale single-node Siddhi snapshot value. Redis is the authoritative source.
      */
@@ -641,6 +922,61 @@ public class DistributedCountAggregatorTest {
                 7L, local.get());
         Assert.assertEquals("No Redis calls must be made in non-distributed mode",
                 0, fakeClient.setWithExpiryCount.get());
+    }
+
+    /**
+     * When the Redis GET during restoreState() throws (as opposed to succeeding and simply
+     * returning null for an absent key), counterToRestore must fall back to 0 rather than the
+     * stale single-node Siddhi snapshot, and no PSETEX seed must be attempted — a thrown GET
+     * is not the same as a confirmed-absent key.
+     *
+     * storedWindowExpiry must be set to a future value here, exactly like the sibling
+     * "key is absent" test below — otherwise writeCounterValue()'s own no-op guard
+     * (storedWindowExpiry == 0) would silently swallow a PSETEX call regardless of whether
+     * this code incorrectly treated a thrown GET the same as a confirmed-absent key,
+     * making the "no PSETEX" assertion pass even if that exact regression were present.
+     */
+    @Test
+    public void restoreStateFallsBackToZeroWhenRedisGetThrows() throws Exception {
+        FailingOnGetKeyValueStoreClient failingClient = new FailingOnGetKeyValueStoreClient();
+        DistributedCountAttributeAggregator aggregator = createAggregator("testKey22");
+        setInstanceField(aggregator, "kvStoreClient", failingClient);
+        long futureExpiry = System.currentTimeMillis() + 60_000L;
+        setInstanceField(aggregator, "storedWindowExpiry", futureExpiry);
+
+        Object[] state = new Object[]{new AbstractMap.SimpleEntry<String, Object>("Value", 42L)};
+        aggregator.restoreState(state);
+
+        AtomicLong local = (AtomicLong) getInstanceField(aggregator, "localCounter");
+        Assert.assertEquals("localCounter must fall back to 0 (not the stale Siddhi snapshot "
+                + "of 42) when the Redis GET itself throws", 0L, local.get());
+        Assert.assertEquals("A thrown GET must not be treated as a confirmed-absent key, so no "
+                + "PSETEX seed should be attempted", 0, failingClient.setWithExpiryCount.get());
+    }
+
+    /**
+     * When the Redis key is genuinely absent (GET returns null, no exception) and the window
+     * boundary is already known, restoreState() must actually issue a PSETEX "0" to seed Redis
+     * — not just skip touching localCounter. writeCounterValue()'s own no-op guard (tested
+     * elsewhere via storedWindowExpiry=0) must not mask whether this call site is reached.
+     */
+    @Test
+    public void restoreStateSeedsRedisWithZeroWhenKeyIsAbsent() throws Exception {
+        DistributedCountAttributeAggregator aggregator = createAggregator("testKey23");
+        long futureExpiry = System.currentTimeMillis() + 60_000L;
+        setInstanceField(aggregator, "storedWindowExpiry", futureExpiry);
+        // fakeClient's store has no entry for "wso2_throttler:testKey23" — key is absent.
+
+        Object[] state = new Object[]{new AbstractMap.SimpleEntry<String, Object>("Value", 9L)};
+        aggregator.restoreState(state);
+
+        AtomicLong local = (AtomicLong) getInstanceField(aggregator, "localCounter");
+        Assert.assertEquals("localCounter must be 0 (not the stale Siddhi snapshot of 9) when "
+                + "the Redis key is absent", 0L, local.get());
+        Assert.assertEquals("restoreState() must seed Redis with a real PSETEX 0 when the key "
+                + "is absent and the window boundary is already known",
+                1, fakeClient.setWithExpiryCount.get());
+        Assert.assertEquals("0", fakeClient.lastSetWithExpiryValue);
     }
 
     /**
@@ -736,5 +1072,580 @@ public class DistributedCountAggregatorTest {
                 ttlApplied <= windowDurationMs);
         Assert.assertTrue("PEXPIRE TTL must be within 2 seconds of the remaining window time",
                 ttlApplied >= windowDurationMs - 2_000L);
+    }
+
+    // -----------------------------------------------------------------------
+    // Multi-key, full-Siddhi-query tests.
+    //
+    // Everything above drives a single, manually-constructed aggregator instance directly
+    // via reflection — the right harness for pinning down syncWithKVStore/reset/restoreState
+    // mechanics precisely. The tests below instead run a real #throttler:timeBatch(...)
+    // group-by query through SiddhiManager, because the thing under test here is how
+    // MULTIPLE per-key aggregator clones (one per distinct application/API resource
+    // sharing a policy, the normal production shape) behave together — something a single
+    // manually-built instance can't exercise. setUp()/tearDown() above already wire
+    // distributedThrottlingEnabled=true and a shared fakeClient; each test below only
+    // overrides schedulerStarted=false so the real periodic sync scheduler actually runs
+    // (setUp() keeps it artificially off for the single-instance tests, which drive syncs
+    // manually instead).
+    // -----------------------------------------------------------------------
+
+    /**
+     * The RESET broadcast (GroupByAggregationAttributeExecutor's special handling of
+     * StreamEvent.Type.RESET, which resets every key in its aggregatorMap regardless of
+     * which one the boundary placeholder represents) must zero EVERY key's Redis-backed
+     * value on a window rollover, not just one — confirmed here for three keys spanning
+     * two different applications and two resources under the same application.
+     */
+    @Test
+    public void resetBroadcastZeroesEveryKeyInRedisBackedStore_multipleAppsAndResources() throws Exception {
+        setStaticField(DistributedCountAttributeAggregator.class, "schedulerStarted", false);
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+        String query = "" +
+                "define stream cseEventStream (throttleKey string, messageID string);" +
+                "@info(name = 'q1') " +
+                "from cseEventStream#throttler:timeBatch(3000) " +
+                "select throttleKey, throttler:distributedCount(messageID) as cnt, expiryTimeStamp " +
+                "group by throttleKey " +
+                "insert all events into outputStream;";
+
+        ExecutionPlanRuntime runtime = siddhiManager.createExecutionPlanRuntime(query);
+        runtime.start();
+        InputHandler in = runtime.getInputHandler("cseEventStream");
+
+        String[] keys = {"App1_ResourceA", "App2_ResourceA", "App2_ResourceB"};
+        for (String key : keys) {
+            for (int i = 1; i <= 5; i++) {
+                in.send(new Object[]{key, key + "-msg" + i});
+            }
+        }
+        Thread.sleep(3200); // cross the 3s window boundary
+
+        // The Redis-backed flush is asynchronous (a background scheduler tick, independent
+        // of the calling thread), so poll for the expected end-state rather than relying on
+        // a single fixed sleep. Siddhi's own group-by key generator also appends its own
+        // delimiter (observed: "::") to the constructed key, so match by prefix.
+        long deadline = System.currentTimeMillis() + 8000;
+        boolean allKeysReset = false;
+        while (System.currentTimeMillis() < deadline) {
+            allKeysReset = true;
+            for (String key : keys) {
+                String expectedPrefix = "wso2_throttler:" + key;
+                boolean found = fakeClient.store.entrySet().stream()
+                        .anyMatch(e -> e.getKey().startsWith(expectedPrefix) && "0".equals(e.getValue()));
+                if (!found) {
+                    allKeysReset = false;
+                    break;
+                }
+            }
+            if (allKeysReset) {
+                break;
+            }
+            Thread.sleep(100);
+        }
+        runtime.shutdown();
+
+        Assert.assertTrue("Expected every key to be reset to 0 in the Redis-backed store "
+                + "within the poll window — final store contents: " + fakeClient.store, allKeysReset);
+    }
+
+    /**
+     * A Redis write failure for ONE key during the broadcast reset must not prevent a
+     * DIFFERENT, healthy key's reset from succeeding — each per-key aggregator clone's
+     * pendingReset/retry state is independent.
+     */
+    @Test
+    public void redisFailureOnOneKeyDoesNotPreventAHealthyKeyFromResetting() throws Exception {
+        setStaticField(DistributedCountAttributeAggregator.class, "schedulerStarted", false);
+        PartiallyFailingKeyValueStoreClient failingClient = new PartiallyFailingKeyValueStoreClient("Failing");
+        setStaticField(KeyValueStoreManager.class, "clientInstance", failingClient);
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+        String query = "" +
+                "define stream cseEventStream (throttleKey string, messageID string);" +
+                "@info(name = 'q1') " +
+                "from cseEventStream#throttler:timeBatch(3000) " +
+                "select throttleKey, throttler:distributedCount(messageID) as cnt, expiryTimeStamp " +
+                "group by throttleKey " +
+                "insert all events into outputStream;";
+
+        ExecutionPlanRuntime runtime = siddhiManager.createExecutionPlanRuntime(query);
+        runtime.start();
+        InputHandler in = runtime.getInputHandler("cseEventStream");
+
+        for (int i = 0; i < 5; i++) {
+            in.send(new Object[]{"Failing_App", "f-" + i});
+        }
+        for (int i = 0; i < 5; i++) {
+            in.send(new Object[]{"Healthy_App", "h-" + i});
+        }
+        Thread.sleep(3200);
+
+        long deadline = System.currentTimeMillis() + 8000;
+        boolean healthyReset = false;
+        while (System.currentTimeMillis() < deadline) {
+            healthyReset = failingClient.store.entrySet().stream()
+                    .anyMatch(e -> e.getKey().contains("Healthy_App") && "0".equals(e.getValue()));
+            if (healthyReset) {
+                break;
+            }
+            Thread.sleep(100);
+        }
+        runtime.shutdown();
+
+        Assert.assertTrue("Healthy_App should have reset to 0 despite Failing_App's writes "
+                + "throwing — final store: " + failingClient.store, healthyReset);
+        Assert.assertTrue("The failing key's writes should have been attempted (and failed) "
+                + "at least once, confirming the failure path was actually exercised",
+                failingClient.failureCount > 0);
+        boolean failingKeyFalselyShowsReset = failingClient.store.entrySet().stream()
+                .anyMatch(e -> e.getKey().contains("Failing_App") && "0".equals(e.getValue()));
+        Assert.assertFalse("Failing_App's key must NOT show 0, since every write for it "
+                + "was made to fail", failingKeyFalselyShowsReset);
+    }
+
+    /**
+     * The admin-triggered reset flag for distributedCount (app.xml's actual form:
+     * throttler:distributedCount(messageID, resetFlag)) — confirms resetting one key leaves
+     * other apps/resources untouched, in BOTH the query output and the Redis-backed store.
+     */
+    @Test
+    public void adminFlagResetForDistributedCountOnlyAffectsTargetedKey() throws Exception {
+        setStaticField(DistributedCountAttributeAggregator.class, "schedulerStarted", false);
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+        String query = "" +
+                "define stream cseEventStream (throttleKey string, messageID string, reset bool);" +
+                "@info(name = 'q1') " +
+                "from cseEventStream#throttler:timeBatch(10000) " +
+                "select throttleKey, throttler:distributedCount(messageID, reset) as cnt, expiryTimeStamp " +
+                "group by throttleKey " +
+                "insert all events into outputStream;";
+
+        ExecutionPlanRuntime runtime = siddhiManager.createExecutionPlanRuntime(query);
+        Map<String, Long> lastCountPerKey = new ConcurrentHashMap<>();
+        runtime.addCallback("q1", new QueryCallback() {
+            @Override
+            public void receive(long timeStamp, Event[] inEvents, Event[] removeEvents) {
+                if (inEvents != null) {
+                    for (Event e : inEvents) {
+                        lastCountPerKey.put((String) e.getData(0), (Long) e.getData(1));
+                    }
+                }
+            }
+        });
+        try {
+            runtime.start();
+            InputHandler in = runtime.getInputHandler("cseEventStream");
+
+            String[] keys = {"App1_ResourceA", "App1_ResourceB", "App2_ResourceA"};
+            for (String key : keys) {
+                for (int i = 0; i < 3; i++) {
+                    in.send(new Object[]{key, key + "-" + i, false});
+                }
+            }
+            Assert.assertEquals(Long.valueOf(3L), lastCountPerKey.get("App1_ResourceA"));
+            Assert.assertEquals(Long.valueOf(3L), lastCountPerKey.get("App1_ResourceB"));
+            Assert.assertEquals(Long.valueOf(3L), lastCountPerKey.get("App2_ResourceA"));
+
+            // Admin resets ONLY App1_ResourceA via the 2-arg distributedCount reset flag.
+            in.send(new Object[]{"App1_ResourceA", "admin-reset", true});
+            in.send(new Object[]{"App1_ResourceA", "post-reset", false});
+
+            // Poll for the expected steady-state — checking untouched keys for merely "not 0"
+            // is unreliable, since a key's very first write is itself a "0" seed
+            // (initializeFromKVStore) before its own accumulated delta syncs up.
+            long deadline = System.currentTimeMillis() + 5000;
+            String targetValue = null;
+            String otherAValue = null;
+            String otherBValue = null;
+            while (System.currentTimeMillis() < deadline) {
+                targetValue = redisValueContaining("App1_ResourceA");
+                otherAValue = redisValueContaining("App1_ResourceB");
+                otherBValue = redisValueContaining("App2_ResourceA");
+                if ("1".equals(targetValue) && "3".equals(otherAValue) && "3".equals(otherBValue)) {
+                    break;
+                }
+                Thread.sleep(50);
+            }
+
+            Assert.assertEquals("Targeted key should read 1 (reset then one new increment) in query output",
+                    Long.valueOf(1L), lastCountPerKey.get("App1_ResourceA"));
+            Assert.assertEquals("A different resource under the same app must be untouched",
+                    Long.valueOf(3L), lastCountPerKey.get("App1_ResourceB"));
+            Assert.assertEquals("A different app entirely must be untouched",
+                    Long.valueOf(3L), lastCountPerKey.get("App2_ResourceA"));
+            Assert.assertEquals("Redis-backed value for the targeted key should reflect the "
+                    + "reset (0) plus one new increment (1)", "1", targetValue);
+            Assert.assertEquals("Redis-backed value for the untouched sibling resource should "
+                    + "reach its true accumulated value, proving it was never reset", "3", otherAValue);
+            Assert.assertEquals("Redis-backed value for the untouched other app should reach "
+                    + "its true accumulated value, proving it was never reset", "3", otherBValue);
+        } finally {
+            runtime.shutdown();
+        }
+    }
+
+    private String redisValueContaining(String keySubstring) {
+        return fakeClient.store.entrySet().stream()
+                .filter(e -> e.getKey().contains(keySubstring))
+                .map(Map.Entry::getValue)
+                .findFirst().orElse(null);
+    }
+
+    /**
+     * distributedCount() with distributed throttling explicitly disabled (the default when
+     * Redis isn't configured at all) must behave exactly like plain count() — a correct
+     * pure-local counter — across multiple keys and multiple window rollovers.
+     */
+    @Test
+    public void distributedCountWithDistributionDisabledBehavesAsLocalCounter_multipleKeys() throws Exception {
+        setStaticField(DistributedCountAttributeAggregator.class, "distributedThrottlingEnabled", false);
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+        String query = "" +
+                "define stream cseEventStream (throttleKey string, messageID string);" +
+                "@info(name = 'q1') " +
+                "from cseEventStream#throttler:timeBatch(3000) " +
+                "select throttleKey, throttler:distributedCount(messageID) as cnt, expiryTimeStamp " +
+                "group by throttleKey " +
+                "insert all events into outputStream;";
+
+        ExecutionPlanRuntime runtime = siddhiManager.createExecutionPlanRuntime(query);
+        Map<String, Long> lastCountPerKey = new ConcurrentHashMap<>();
+        runtime.addCallback("q1", new QueryCallback() {
+            @Override
+            public void receive(long timeStamp, Event[] inEvents, Event[] removeEvents) {
+                if (inEvents != null) {
+                    for (Event e : inEvents) {
+                        lastCountPerKey.put((String) e.getData(0), (Long) e.getData(1));
+                    }
+                }
+            }
+        });
+        runtime.start();
+        InputHandler in = runtime.getInputHandler("cseEventStream");
+
+        String[] keys = {"App1", "App2", "App3"};
+        for (int k = 0; k < keys.length; k++) {
+            for (int i = 0; i <= k + 3; i++) {
+                in.send(new Object[]{keys[k], keys[k] + "-w1-" + i});
+            }
+        }
+        Assert.assertEquals(Long.valueOf(4L), lastCountPerKey.get("App1"));
+        Assert.assertEquals(Long.valueOf(5L), lastCountPerKey.get("App2"));
+        Assert.assertEquals(Long.valueOf(6L), lastCountPerKey.get("App3"));
+
+        Thread.sleep(3500); // cross the boundary
+
+        for (String key : keys) {
+            in.send(new Object[]{key, key + "-w2"});
+        }
+        runtime.shutdown();
+
+        Assert.assertEquals("App1 should reset correctly in local-only mode", Long.valueOf(1L),
+                lastCountPerKey.get("App1"));
+        Assert.assertEquals("App2 should reset correctly in local-only mode", Long.valueOf(1L),
+                lastCountPerKey.get("App2"));
+        Assert.assertEquals("App3 should reset correctly in local-only mode", Long.valueOf(1L),
+                lastCountPerKey.get("App3"));
+    }
+
+    /**
+     * shutdownScheduler()'s masterSyncTask.cancel() must actually cancel the scheduled
+     * periodic task (not just null out the field) — confirmed via the returned
+     * ScheduledFuture's own cancellation state, and that both executor fields are nulled.
+     */
+    @Test
+    public void shutdownSchedulerCancelsTheMasterSyncTask() throws Exception {
+        setStaticField(DistributedCountAttributeAggregator.class, "schedulerStarted", false);
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+        String query = "" +
+                "define stream cseEventStream (throttleKey string, messageID string);" +
+                "@info(name = 'q1') " +
+                "from cseEventStream#throttler:timeBatch(3000) " +
+                "select throttleKey, throttler:distributedCount(messageID) as cnt, expiryTimeStamp " +
+                "group by throttleKey " +
+                "insert all events into outputStream;";
+
+        ExecutionPlanRuntime runtime = siddhiManager.createExecutionPlanRuntime(query);
+        try {
+            runtime.start();
+            InputHandler in = runtime.getInputHandler("cseEventStream");
+            in.send(new Object[]{"AppX", "msg1"});
+
+            long deadline = System.currentTimeMillis() + 2000;
+            boolean started = false;
+            while (System.currentTimeMillis() < deadline) {
+                started = (boolean) getStaticField(DistributedCountAttributeAggregator.class, "schedulerStarted");
+                if (started) {
+                    break;
+                }
+                Thread.sleep(20);
+            }
+            Assert.assertTrue("Scheduler should have started after the first distributed-mode event", started);
+
+            ScheduledFuture<?> taskBeforeShutdown =
+                    (ScheduledFuture<?>) getStaticField(DistributedCountAttributeAggregator.class, "masterSyncTask");
+            Assert.assertTrue("masterSyncTask should be a live, non-cancelled task before shutdown",
+                    taskBeforeShutdown != null && !taskBeforeShutdown.isCancelled());
+
+            DistributedCountAttributeAggregator.shutdownScheduler();
+
+            Assert.assertTrue("masterSyncTask should be cancelled after shutdownScheduler()",
+                    taskBeforeShutdown.isCancelled());
+            Assert.assertNull("masterScheduler field should be nulled out after shutdown",
+                    getStaticField(DistributedCountAttributeAggregator.class, "masterScheduler"));
+            Assert.assertNull("kvStoreSyncScheduler field should be nulled out after shutdown",
+                    (ScheduledExecutorService) getStaticField(DistributedCountAttributeAggregator.class,
+                            "kvStoreSyncScheduler"));
+        } finally {
+            runtime.shutdown();
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // windowExpiryThreadLocal correctness.
+    //
+    // Every test above that touches storedWindowExpiry sets windowExpiryThreadLocal manually
+    // via the test's own reflection helper, simulating what ThrottleStreamProcessor does. The
+    // tests below instead run real queries and inspect the ACTUAL live aggregator instance(s)
+    // (via ACTIVE_AGGREGATORS) to confirm ThrottleStreamProcessor itself sets the ThreadLocal
+    // to the correct value during real processing, and that the aggregator side genuinely
+    // consumes it correctly — not just that the simulated wiring in earlier tests behaves.
+    // -----------------------------------------------------------------------
+
+    /**
+     * ThrottleStreamProcessor propagates the window boundary to attribute aggregators through
+     * TWO independent paths: the "expiryTimeStamp" column (via complexEventPopulater, visible
+     * to the SELECT clause) and the windowExpiryThreadLocal (visible only to aggregators like
+     * this one). Both are set from the same expireEventTime in the same process() call, so they
+     * must always agree. Cross-checking them against each other — rather than each in
+     * isolation — is what actually proves the ThreadLocal carries the real window boundary and
+     * not some unrelated or stale value.
+     */
+    @Test
+    public void storedWindowExpiryMatchesQueryOutputExpiryTimeStampColumn() throws Exception {
+        setStaticField(DistributedCountAttributeAggregator.class, "schedulerStarted", false);
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+        String query = "" +
+                "define stream cseEventStream (throttleKey string, messageID string);" +
+                "@info(name = 'q1') " +
+                "from cseEventStream#throttler:timeBatch(3000) " +
+                "select throttleKey, throttler:distributedCount(messageID) as cnt, expiryTimeStamp " +
+                "group by throttleKey " +
+                "insert all events into outputStream;";
+
+        ExecutionPlanRuntime runtime = siddhiManager.createExecutionPlanRuntime(query);
+        AtomicLong lastExpiryTimeStampColumn = new AtomicLong(-1L);
+        runtime.addCallback("q1", new QueryCallback() {
+            @Override
+            public void receive(long timeStamp, Event[] inEvents, Event[] removeEvents) {
+                if (inEvents != null) {
+                    for (Event e : inEvents) {
+                        lastExpiryTimeStampColumn.set((Long) e.getData(2));
+                    }
+                }
+            }
+        });
+        try {
+            runtime.start();
+            InputHandler in = runtime.getInputHandler("cseEventStream");
+            in.send(new Object[]{"App1", "m1"});
+
+            Assert.assertTrue("expiryTimeStamp column must have been populated to a real future "
+                    + "timestamp", lastExpiryTimeStampColumn.get() > System.currentTimeMillis());
+
+            @SuppressWarnings("unchecked")
+            ConcurrentHashMap<String, DistributedCountAttributeAggregator> active =
+                    (ConcurrentHashMap<String, DistributedCountAttributeAggregator>)
+                            getStaticField(DistributedCountAttributeAggregator.class, "ACTIVE_AGGREGATORS");
+            DistributedCountAttributeAggregator liveAggregator = active.values().stream().findFirst()
+                    .orElseThrow(() -> new AssertionError("Expected exactly one live aggregator for App1"));
+            long storedWindowExpiry = (long) getInstanceField(liveAggregator, "storedWindowExpiry");
+
+            Assert.assertEquals("The window expiry the aggregator captured internally via the "
+                    + "ThreadLocal must exactly match the expiryTimeStamp column the SAME window "
+                    + "populates for the query's own output", lastExpiryTimeStampColumn.get(), storedWindowExpiry);
+        } finally {
+            runtime.shutdown();
+        }
+    }
+
+    /**
+     * windowExpiryThreadLocal is set ONCE per process() invocation and the whole streamEventChunk
+     * (every key's event in this batch) is processed while it holds that single value. Confirms
+     * multiple DIFFERENT group-by keys sharing the same window all capture the IDENTICAL expiry
+     * — not per-key-different by some indexing or ordering mistake.
+     */
+    @Test
+    public void allKeysInSameWindowSeeIdenticalWindowExpiryThroughThreadLocal() throws Exception {
+        setStaticField(DistributedCountAttributeAggregator.class, "schedulerStarted", false);
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+        String query = "" +
+                "define stream cseEventStream (throttleKey string, messageID string);" +
+                "@info(name = 'q1') " +
+                "from cseEventStream#throttler:timeBatch(3000) " +
+                "select throttleKey, throttler:distributedCount(messageID) as cnt, expiryTimeStamp " +
+                "group by throttleKey " +
+                "insert all events into outputStream;";
+
+        ExecutionPlanRuntime runtime = siddhiManager.createExecutionPlanRuntime(query);
+        try {
+            runtime.start();
+            InputHandler in = runtime.getInputHandler("cseEventStream");
+
+            String[] keys = {"App1_ResourceA", "App2_ResourceA", "App2_ResourceB"};
+            for (String key : keys) {
+                in.send(new Object[]{key, key + "-m1"});
+            }
+
+            @SuppressWarnings("unchecked")
+            ConcurrentHashMap<String, DistributedCountAttributeAggregator> active =
+                    (ConcurrentHashMap<String, DistributedCountAttributeAggregator>)
+                            getStaticField(DistributedCountAttributeAggregator.class, "ACTIVE_AGGREGATORS");
+            Assert.assertEquals("Expected exactly 3 live aggregator clones, one per key", 3, active.size());
+
+            long[] expiries = new long[3];
+            int i = 0;
+            for (DistributedCountAttributeAggregator agg : active.values()) {
+                expiries[i++] = (long) getInstanceField(agg, "storedWindowExpiry");
+            }
+
+            Assert.assertTrue("The shared window expiry must be a real future timestamp, not the "
+                    + "0L default", expiries[0] > System.currentTimeMillis());
+            Assert.assertEquals("All keys sharing the same window must have captured the identical "
+                    + "expiry via the ThreadLocal", expiries[0], expiries[1]);
+            Assert.assertEquals("All keys sharing the same window must have captured the identical "
+                    + "expiry via the ThreadLocal", expiries[0], expiries[2]);
+        } finally {
+            runtime.shutdown();
+        }
+    }
+
+    /**
+     * Confirms windowExpiryThreadLocal is refreshed to the NEW window's boundary on every
+     * rollover — not stuck on the first window's value forever, and not merely incrementing by
+     * accident. Checked directly against the live aggregator's storedWindowExpiry across three
+     * consecutive windows.
+     */
+    @Test
+    public void storedWindowExpiryAdvancesToTheNewWindowOnEachRollover() throws Exception {
+        setStaticField(DistributedCountAttributeAggregator.class, "schedulerStarted", false);
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+        String query = "" +
+                "define stream cseEventStream (throttleKey string, messageID string);" +
+                "@info(name = 'q1') " +
+                "from cseEventStream#throttler:timeBatch(3000) " +
+                "select throttleKey, throttler:distributedCount(messageID) as cnt, expiryTimeStamp " +
+                "group by throttleKey " +
+                "insert all events into outputStream;";
+
+        ExecutionPlanRuntime runtime = siddhiManager.createExecutionPlanRuntime(query);
+        runtime.start();
+        InputHandler in = runtime.getInputHandler("cseEventStream");
+
+        in.send(new Object[]{"App1", "w1-m1"});
+
+        @SuppressWarnings("unchecked")
+        ConcurrentHashMap<String, DistributedCountAttributeAggregator> active =
+                (ConcurrentHashMap<String, DistributedCountAttributeAggregator>)
+                        getStaticField(DistributedCountAttributeAggregator.class, "ACTIVE_AGGREGATORS");
+        DistributedCountAttributeAggregator liveAggregator = active.values().stream().findFirst()
+                .orElseThrow(() -> new AssertionError("Expected a live aggregator for App1"));
+        long window1Expiry = (long) getInstanceField(liveAggregator, "storedWindowExpiry");
+
+        Thread.sleep(3500); // cross boundary 1 -> 2
+
+        in.send(new Object[]{"App1", "w2-m1"});
+        long window2Expiry = (long) getInstanceField(liveAggregator, "storedWindowExpiry");
+
+        Thread.sleep(3500); // cross boundary 2 -> 3
+
+        in.send(new Object[]{"App1", "w3-m1"});
+        long window3Expiry = (long) getInstanceField(liveAggregator, "storedWindowExpiry");
+
+        runtime.shutdown();
+
+        Assert.assertTrue("Window 2's expiry must be strictly later than window 1's — "
+                        + "storedWindowExpiry must not be stuck on the first window's value",
+                window2Expiry > window1Expiry);
+        Assert.assertTrue("Window 3's expiry must be strictly later than window 2's",
+                window3Expiry > window2Expiry);
+        Assert.assertTrue("Consecutive window expiries should be spaced ~3000ms apart — got: "
+                        + (window2Expiry - window1Expiry),
+                Math.abs((window2Expiry - window1Expiry) - 3000L) <= 1000L);
+        Assert.assertTrue("Consecutive window expiries should be spaced ~3000ms apart — got: "
+                        + (window3Expiry - window2Expiry),
+                Math.abs((window3Expiry - window2Expiry) - 3000L) <= 1000L);
+    }
+
+    /**
+     * Confirms each consecutive window-boundary reset stamps a FRESH PSETEX TTL matching ITS
+     * OWN window's remaining time — not a stale value carried over from an earlier rollover.
+     * Runs through a real multi-rollover query rather than the single-instance reflection
+     * harness used by the other writeCounterValue/TTL tests above.
+     */
+    @Test
+    public void consecutiveResetsEachGetFreshTTLMatchingTheirOwnWindow() throws Exception {
+        setStaticField(DistributedCountAttributeAggregator.class, "schedulerStarted", false);
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+        String query = "" +
+                "define stream cseEventStream (throttleKey string, messageID string);" +
+                "@info(name = 'q1') " +
+                "from cseEventStream#throttler:timeBatch(3000) " +
+                "select throttleKey, throttler:distributedCount(messageID) as cnt, expiryTimeStamp " +
+                "group by throttleKey " +
+                "insert all events into outputStream;";
+
+        ExecutionPlanRuntime runtime = siddhiManager.createExecutionPlanRuntime(query);
+        try {
+            runtime.start();
+            InputHandler in = runtime.getInputHandler("cseEventStream");
+
+            in.send(new Object[]{"App1", "w1-m1"});
+            Thread.sleep(3200); // cross boundary 1 -> RESET broadcast fires
+
+            long deadline1 = System.currentTimeMillis() + 5000;
+            long ttlAfterFirstReset = -1;
+            while (System.currentTimeMillis() < deadline1) {
+                if (fakeClient.setWithExpiryCount.get() >= 1) {
+                    ttlAfterFirstReset = fakeClient.lastSetWithExpiryTTL;
+                    break;
+                }
+                Thread.sleep(50);
+            }
+            Assert.assertTrue("Expected the first PSETEX reset to have fired", ttlAfterFirstReset > 0);
+            Assert.assertTrue("First reset's TTL should be close to the 3000ms window duration — got: "
+                    + ttlAfterFirstReset, ttlAfterFirstReset > 0 && ttlAfterFirstReset <= 3000L);
+
+            int countBeforeSecondReset = fakeClient.setWithExpiryCount.get();
+            in.send(new Object[]{"App1", "w2-m1"});
+            Thread.sleep(3200); // cross boundary 2 -> a SECOND, independent RESET broadcast
+
+            long deadline2 = System.currentTimeMillis() + 5000;
+            long ttlAfterSecondReset = -1;
+            while (System.currentTimeMillis() < deadline2) {
+                if (fakeClient.setWithExpiryCount.get() > countBeforeSecondReset) {
+                    ttlAfterSecondReset = fakeClient.lastSetWithExpiryTTL;
+                    break;
+                }
+                Thread.sleep(50);
+            }
+
+            Assert.assertTrue("Expected the SECOND PSETEX reset to have fired independently",
+                    ttlAfterSecondReset > 0);
+            Assert.assertTrue("Second reset's TTL should ALSO be close to the fresh 3000ms window, "
+                    + "not a stale carried-over value — got: " + ttlAfterSecondReset,
+                    ttlAfterSecondReset > 0 && ttlAfterSecondReset <= 3000L);
+        } finally {
+            runtime.shutdown();
+        }
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.throttling.siddhi.extension/src/test/java/org/wso2/carbon/apimgt/throttling/siddhi/extension/DistributedCountAggregatorTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.throttling.siddhi.extension/src/test/java/org/wso2/carbon/apimgt/throttling/siddhi/extension/DistributedCountAggregatorTest.java
@@ -385,7 +385,9 @@ public class DistributedCountAggregatorTest {
                 1, fakeClient.expireMillisCount.get());
         Assert.assertTrue("PEXPIRE TTL must be positive", fakeClient.lastExpireMillisTTL > 0);
 
-        // Second sync: keyHasTTL is now true — no additional PEXPIRE.
+        // Second sync: another delta forces the INCRBY branch again, but keyHasTTL is now
+        // true — no additional PEXPIRE.
+        aggregator.processAdd((Object) null);
         aggregator.currentState();
         Assert.assertEquals("PEXPIRE must not be called again when keyHasTTL is already true",
                 1, fakeClient.expireMillisCount.get());

--- a/components/apimgt/org.wso2.carbon.apimgt.throttling.siddhi.extension/src/test/java/org/wso2/carbon/apimgt/throttling/siddhi/extension/DistributedCountAggregatorTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.throttling.siddhi.extension/src/test/java/org/wso2/carbon/apimgt/throttling/siddhi/extension/DistributedCountAggregatorTest.java
@@ -285,6 +285,10 @@ public class DistributedCountAggregatorTest {
 
     @After
     public void tearDown() throws Exception {
+        // Stop any scheduler started by the Siddhi-based tests so its periodic task cannot
+        // sync aggregators belonging to a later test.
+        DistributedCountAttributeAggregator.shutdownScheduler();
+
         // Reset all static state between tests.
         setStaticField(DistributedCountAttributeAggregator.class, "DISTRIBUTED_THROTTLE_CONFIG", null);
         setStaticField(DistributedCountAttributeAggregator.class, "distributedThrottlingEnabled", false);
@@ -525,7 +529,9 @@ public class DistributedCountAggregatorTest {
     /**
      * writeCounterValue() must be a no-op when storedWindowExpiry is 0 (not yet known).
      * Concretely: reset() called before any window expiry is known — the subsequent
-     * syncWithKVStore() must clear pendingReset without issuing a PSETEX.
+     * syncWithKVStore() must NOT issue a PSETEX, and since nothing was actually written,
+     * pendingReset must stay true so a later tick (once the expiry is known) retries the flush
+     * instead of silently losing the reset.
      */
     @Test
     public void writeCounterValueIsNoOpWhenStoredWindowExpiryIsZero() throws Exception {
@@ -540,13 +546,14 @@ public class DistributedCountAggregatorTest {
 
         Assert.assertEquals("PSETEX must not be called when storedWindowExpiry is 0",
                 0, fakeClient.setWithExpiryCount.get());
-        Assert.assertFalse("pendingReset must still be cleared even when writeCounterValue is a no-op",
+        Assert.assertTrue("pendingReset must remain true since nothing was actually written to Redis",
                 (boolean) getInstanceField(aggregator, "pendingReset"));
     }
 
     /**
      * writeCounterValue() must be a no-op when the window has already expired
-     * (storedWindowExpiry is in the past). No PSETEX must be sent in this case.
+     * (storedWindowExpiry is in the past). No PSETEX must be sent in this case, and since the
+     * reset was never actually flushed, pendingReset must stay true so the next tick retries it.
      */
     @Test
     public void writeCounterValueIsNoOpWhenWindowHasExpired() throws Exception {
@@ -559,7 +566,7 @@ public class DistributedCountAggregatorTest {
 
         Assert.assertEquals("PSETEX must not be called when the window has already expired",
                 0, fakeClient.setWithExpiryCount.get());
-        Assert.assertFalse("pendingReset must be cleared regardless of whether PSETEX was sent",
+        Assert.assertTrue("pendingReset must remain true since the write never actually happened",
                 (boolean) getInstanceField(aggregator, "pendingReset"));
     }
 
@@ -891,18 +898,20 @@ public class DistributedCountAggregatorTest {
     }
 
     /**
-     * restoreState() must clear pendingReset inside the lock so that the sync thread does not
-     * issue a stale PSETEX "0" after state has been freshly restored from Redis.
+     * restoreState() must NOT clear an unflushed pendingReset. Dropping it would leave the
+     * previous window's stale total sitting in Redis forever, since nothing would ever issue
+     * the pending PSETEX "0" afterwards. The flag must survive the restore so the next sync
+     * tick still flushes it.
      */
     @Test
-    public void restoreStateClearsPendingReset() throws Exception {
+    public void restoreStateDoesNotClearPendingReset() throws Exception {
         DistributedCountAttributeAggregator aggregator = createAggregator("testKey15");
         setInstanceField(aggregator, "pendingReset", true);
 
         Object[] state = new Object[]{new AbstractMap.SimpleEntry<String, Object>("Value", 3L)};
         aggregator.restoreState(state);
 
-        Assert.assertFalse("restoreState() must clear pendingReset to prevent stale PSETEX retries",
+        Assert.assertTrue("restoreState() must preserve an unflushed pendingReset, not drop it",
                 (boolean) getInstanceField(aggregator, "pendingReset"));
     }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.throttling.siddhi.extension/src/test/java/org/wso2/carbon/apimgt/throttling/siddhi/extension/ThrottleTimeBatchWindowTestCase.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.throttling.siddhi.extension/src/test/java/org/wso2/carbon/apimgt/throttling/siddhi/extension/ThrottleTimeBatchWindowTestCase.java
@@ -29,6 +29,11 @@ import org.wso2.siddhi.core.query.output.callback.QueryCallback;
 import org.wso2.siddhi.core.stream.input.InputHandler;
 import org.wso2.siddhi.core.util.EventPrinter;
 
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.TimeUnit;
+
 public class ThrottleTimeBatchWindowTestCase {
     private static final Log log = LogFactory.getLog(ThrottleTimeBatchWindowTestCase.class);
     private int inEventCount;
@@ -86,7 +91,7 @@ public class ThrottleTimeBatchWindowTestCase {
         inputHandler.send(new Object[]{"WSO2", 60.5f, 1});
         Thread.sleep(6000);
         Assert.assertEquals(4, inEventCount);
-        Assert.assertEquals(2, removeEventCount);
+        Assert.assertEquals(0, removeEventCount);
         Assert.assertTrue(eventArrived);
         executionPlanRuntime.shutdown();
 
@@ -129,12 +134,133 @@ public class ThrottleTimeBatchWindowTestCase {
         inputHandler.send(new Object[]{"WSO2", 60.5f, 1});
         Thread.sleep(10000);
         Assert.assertEquals(2, inEventCount);
-        Assert.assertEquals(0.0d, lastRemoveEvent.getData()[1]);
+        Assert.assertNull(lastRemoveEvent);
         Assert.assertTrue(eventArrived);
         executionPlanRuntime.shutdown();
 
     }
 
+
+    @Test
+    public void throttleTimeWindowBatchShouldResetAggregatesOnWindowExpiry() throws InterruptedException {
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String requestStream = "" +
+                "define stream RequestStream (throttleKey string, messageSize long);";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from RequestStream#throttler:timeBatch(2 sec , 0) " +
+                "select throttleKey, count(throttleKey) as requestCount, sum(messageSize) as bandwidth, " +
+                "expiryTimeStamp group by throttleKey " +
+                "insert all events into outputStream ;";
+
+        ExecutionPlanRuntime executionPlanRuntime = siddhiManager.createExecutionPlanRuntime(requestStream + query);
+        List<Event> currentEvents = new CopyOnWriteArrayList<>();
+        CountDownLatch firstWindowEventsArrived = new CountDownLatch(2);
+        CountDownLatch postExpiryEventArrived = new CountDownLatch(1);
+
+        executionPlanRuntime.addCallback("query1", new QueryCallback() {
+            @Override
+            public void receive(long timeStamp, Event[] inEvents, Event[] removeEvents) {
+                EventPrinter.print(timeStamp, inEvents, removeEvents);
+                if (inEvents != null) {
+                    for (Event event : inEvents) {
+                        currentEvents.add(event);
+                        if (currentEvents.size() <= 2) {
+                            firstWindowEventsArrived.countDown();
+                        } else {
+                            postExpiryEventArrived.countDown();
+                        }
+                    }
+                }
+                eventArrived = true;
+            }
+        });
+
+        try {
+            InputHandler inputHandler = executionPlanRuntime.getInputHandler("RequestStream");
+            executionPlanRuntime.start();
+            inputHandler.send(new Object[]{"app1", 100L});
+            inputHandler.send(new Object[]{"app1", 200L});
+            Assert.assertTrue("Timed out waiting for first window events",
+                    firstWindowEventsArrived.await(5, TimeUnit.SECONDS));
+
+            long expiryTime = (Long) currentEvents.get(1).getData()[3];
+            long waitTime = expiryTime - System.currentTimeMillis() + 500;
+            if (waitTime > 0) {
+                Thread.sleep(waitTime);
+            }
+
+            inputHandler.send(new Object[]{"app1", 50L});
+            Assert.assertTrue("Timed out waiting for post-expiry event",
+                    postExpiryEventArrived.await(5, TimeUnit.SECONDS));
+
+            Event firstEventAfterReset = currentEvents.get(currentEvents.size() - 1);
+            Assert.assertEquals("app1", firstEventAfterReset.getData()[0]);
+            Assert.assertEquals(1L, firstEventAfterReset.getData()[1]);
+            Assert.assertEquals(50L, firstEventAfterReset.getData()[2]);
+            Assert.assertTrue(eventArrived);
+        } finally {
+            executionPlanRuntime.shutdown();
+        }
+    }
+
+    /**
+     * Verifies that getThreadLocalWindowExpiry() returns null when called outside of a
+     * ThrottleStreamProcessor dispatch — the ThreadLocal must never leak across event batches.
+     */
+    @Test
+    public void getThreadLocalWindowExpiryIsNullOutsideProcessing() {
+        Assert.assertNull(
+                "ThreadLocal window expiry must be null outside of ThrottleStreamProcessor.process()",
+                ThrottleStreamProcessor.getThreadLocalWindowExpiry());
+    }
+
+    /**
+     * Verifies that all events belonging to the same time-batch window share an identical
+     * expiryTimeStamp. The window boundary is fixed once the first event arrives, so every
+     * subsequent event in the same batch must carry the same expiry value.
+     */
+    @Test
+    public void windowExpiryTimestampIsConsistentForAllEventsInSameBatch() throws InterruptedException {
+        SiddhiManager siddhiManager = new SiddhiManager();
+        String requestStream = "define stream RequestStream (throttleKey string, messageSize long);";
+        String query = "@info(name = 'query1') " +
+                "from RequestStream#throttler:timeBatch(2 sec , 0) " +
+                "select throttleKey, count(throttleKey) as requestCount, expiryTimeStamp " +
+                "group by throttleKey " +
+                "insert all events into outputStream;";
+
+        ExecutionPlanRuntime runtime = siddhiManager.createExecutionPlanRuntime(requestStream + query);
+        List<Long> expiryTimestamps = new CopyOnWriteArrayList<>();
+        CountDownLatch eventsArrived = new CountDownLatch(3);
+
+        runtime.addCallback("query1", new QueryCallback() {
+            @Override
+            public void receive(long timeStamp, Event[] inEvents, Event[] removeEvents) {
+                if (inEvents != null) {
+                    for (Event e : inEvents) {
+                        expiryTimestamps.add((Long) e.getData()[2]);
+                        eventsArrived.countDown();
+                    }
+                }
+            }
+        });
+
+        try {
+            InputHandler inputHandler = runtime.getInputHandler("RequestStream");
+            runtime.start();
+            inputHandler.send(new Object[]{"key1", 100L});
+            inputHandler.send(new Object[]{"key2", 200L});
+            inputHandler.send(new Object[]{"key3", 300L});
+            Assert.assertTrue("Timed out waiting for events", eventsArrived.await(6, TimeUnit.SECONDS));
+            Assert.assertEquals("All events in the same window must have the same expiryTimeStamp",
+                    1, expiryTimestamps.stream().distinct().count());
+        } finally {
+            runtime.shutdown();
+        }
+    }
 
     @Test
     public void throttleTimeWindowBatchTest3() throws InterruptedException {

--- a/components/apimgt/org.wso2.carbon.apimgt.throttling.siddhi.extension/src/test/java/org/wso2/carbon/apimgt/throttling/siddhi/extension/ThrottleTimeBatchWindowTestCase.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.throttling.siddhi.extension/src/test/java/org/wso2/carbon/apimgt/throttling/siddhi/extension/ThrottleTimeBatchWindowTestCase.java
@@ -30,6 +30,8 @@ import org.wso2.siddhi.core.stream.input.InputHandler;
 import org.wso2.siddhi.core.util.EventPrinter;
 
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
@@ -306,5 +308,392 @@ public class ThrottleTimeBatchWindowTestCase {
 
     }
 
+    // -----------------------------------------------------------------------
+    // GROUP BY tests with multiple distinct throttle keys — i.e. multiple applications
+    // and/or multiple API resources sharing one policy query, the normal production shape.
+    // The tests above only ever exercise a single key per window; the ones below confirm
+    // the window-boundary reset and expiry-notification behavior generalizes correctly
+    // across several keys at once, including consecutive rollovers and an idle window.
+    // -----------------------------------------------------------------------
+
+    /**
+     * Multiple applications AND multiple APIs/resources within one of those applications,
+     * all sharing a single policy query. Every key exceeds the limit in window 1. Window 2
+     * sends exactly one fresh request per key; if the window-boundary reset only zeroed one
+     * key instead of every key sharing the query, the un-reset keys would show an inflated
+     * count in window 2 instead of 1.
+     */
+    @Test
+    public void resetBroadcastZeroesEveryKey_multipleAppsAndMultipleApisPerApp() throws InterruptedException {
+        SiddhiManager siddhiManager = new SiddhiManager();
+        String query = "" +
+                "define stream cseEventStream (throttleKey string, messageID string);" +
+                "@info(name = 'q1') " +
+                "from cseEventStream#throttler:timeBatch(3000) " +
+                "select throttleKey, count(messageID) as cnt, expiryTimeStamp " +
+                "group by throttleKey " +
+                "insert all events into outputStream;";
+
+        ExecutionPlanRuntime runtime = siddhiManager.createExecutionPlanRuntime(query);
+        Map<String, Long> lastCountPerKey = new ConcurrentHashMap<>();
+        runtime.addCallback("q1", new QueryCallback() {
+            @Override
+            public void receive(long timeStamp, Event[] inEvents, Event[] removeEvents) {
+                if (inEvents != null) {
+                    for (Event e : inEvents) {
+                        lastCountPerKey.put((String) e.getData(0), (Long) e.getData(1));
+                    }
+                }
+            }
+        });
+        runtime.start();
+        InputHandler in = runtime.getInputHandler("cseEventStream");
+
+        // Two applications, and two distinct API resources within "App1" — mirrors a
+        // resource-level throttleKey shape (appId + resourceKey combined).
+        String[] keys = {"App1_ResourceA", "App1_ResourceB", "App2_ResourceA"};
+        int limit = 3;
+        for (String key : keys) {
+            for (int i = 1; i <= limit + 2; i++) {
+                in.send(new Object[]{key, key + "-msg" + i});
+            }
+        }
+        Thread.sleep(4000); // cross the 3s boundary
+
+        // Window 2: exactly one fresh request per key.
+        for (String key : keys) {
+            in.send(new Object[]{key, key + "-window2-msg1"});
+        }
+        Thread.sleep(500);
+        runtime.shutdown();
+
+        for (String key : keys) {
+            Assert.assertEquals("Key " + key + " should show count=1 in window 2 if the reset "
+                            + "truly zeroed it — a higher value means it carried over from window 1",
+                    Long.valueOf(1L), lastCountPerKey.get(key));
+        }
+    }
+
+    /**
+     * ThrottleStreamProcessor captures only the FIRST event of the window (whichever key it
+     * happens to belong to) as the RESET placeholder — it has no concept of "throttleKey" at
+     * all, since group-by routing happens downstream of it. The placeholder's own identity is
+     * then irrelevant: GroupByAggregationAttributeExecutor's RESET handling broadcasts to every
+     * key in its map regardless of what data the placeholder itself carries.
+     *
+     * This test proves that directly: the identical 3-key scenario is run twice, with the send
+     * order swapped so a DIFFERENT key becomes the captured placeholder each time (Siddhi
+     * captures strictly by arrival order, so whichever key is sent first is guaranteed to be
+     * the one captured). If the reset's correctness depended on which specific key's data ended
+     * up as the placeholder, swapping the order would change the outcome for at least one key.
+     * It must not — every key must reset identically in both runs.
+     */
+    @Test
+    public void resetBroadcastOutcomeIsIndependentOfWhichKeyBecomesTheCapturedPlaceholder()
+            throws InterruptedException {
+        Map<String, Long> resultsWhenAppFirst = runMultiKeyResetScenario(
+                new String[]{"AppFirst", "AppMiddle", "AppLast"});
+        Map<String, Long> resultsWhenLastFirst = runMultiKeyResetScenario(
+                new String[]{"AppLast", "AppMiddle", "AppFirst"});
+
+        for (String key : new String[]{"AppFirst", "AppMiddle", "AppLast"}) {
+            Assert.assertEquals("Key " + key + " must reset correctly when it was NOT the "
+                            + "captured placeholder (AppFirst was sent first, so AppFirst was "
+                            + "captured this run) — got: " + resultsWhenAppFirst,
+                    Long.valueOf(1L), resultsWhenAppFirst.get(key));
+            Assert.assertEquals("Key " + key + " must reset IDENTICALLY when a DIFFERENT key "
+                            + "(AppLast) was the captured placeholder instead — got: "
+                            + resultsWhenLastFirst,
+                    Long.valueOf(1L), resultsWhenLastFirst.get(key));
+        }
+    }
+
+    /**
+     * Runs the same 3-key, single-window, over-the-limit-then-reset scenario used throughout
+     * this file, but sends the keys in the given order — the first key in {@code sendOrder} is
+     * guaranteed to be the one ThrottleStreamProcessor captures as its RESET placeholder for
+     * this window, since capture is strictly first-arrival, not key-based.
+     */
+    private Map<String, Long> runMultiKeyResetScenario(String[] sendOrder) throws InterruptedException {
+        SiddhiManager siddhiManager = new SiddhiManager();
+        String query = "" +
+                "define stream cseEventStream (throttleKey string, messageID string);" +
+                "@info(name = 'q1') " +
+                "from cseEventStream#throttler:timeBatch(3000) " +
+                "select throttleKey, count(messageID) as cnt, expiryTimeStamp " +
+                "group by throttleKey " +
+                "insert all events into outputStream;";
+
+        ExecutionPlanRuntime runtime = siddhiManager.createExecutionPlanRuntime(query);
+        Map<String, Long> lastCountPerKey = new ConcurrentHashMap<>();
+        runtime.addCallback("q1", new QueryCallback() {
+            @Override
+            public void receive(long timeStamp, Event[] inEvents, Event[] removeEvents) {
+                if (inEvents != null) {
+                    for (Event e : inEvents) {
+                        lastCountPerKey.put((String) e.getData(0), (Long) e.getData(1));
+                    }
+                }
+            }
+        });
+        runtime.start();
+        InputHandler in = runtime.getInputHandler("cseEventStream");
+
+        for (String key : sendOrder) {
+            for (int i = 1; i <= 4; i++) {
+                in.send(new Object[]{key, key + "-msg" + i});
+            }
+        }
+        Thread.sleep(4000); // cross the 3s boundary
+
+        for (String key : sendOrder) {
+            in.send(new Object[]{key, key + "-window2-msg1"});
+        }
+        Thread.sleep(500);
+        runtime.shutdown();
+
+        return lastCountPerKey;
+    }
+
+    /**
+     * Explicit "multiple APIs under one application" scenario using resource-level-shaped
+     * keys (mirroring str:concat(resourceKey,'_default') from throttle_policy_template_
+     * resource_default.xml): one application calling two different API resources, each with
+     * its own independent limit and its own independent reset — confirms no cross-resource
+     * contamination when both are reset by the same window boundary.
+     */
+    @Test
+    public void multipleApiResourcesUnderSameApplication_independentCountingAndReset() throws InterruptedException {
+        SiddhiManager siddhiManager = new SiddhiManager();
+        String query = "" +
+                "define stream cseEventStream (throttleKey string, messageID string);" +
+                "@info(name = 'q1') " +
+                "from cseEventStream#throttler:timeBatch(3000) " +
+                "select throttleKey, count(messageID) as cnt, expiryTimeStamp " +
+                "group by throttleKey " +
+                "insert all events into outputStream;";
+
+        ExecutionPlanRuntime runtime = siddhiManager.createExecutionPlanRuntime(query);
+        Map<String, Long> lastCountPerKey = new ConcurrentHashMap<>();
+        runtime.addCallback("q1", new QueryCallback() {
+            @Override
+            public void receive(long timeStamp, Event[] inEvents, Event[] removeEvents) {
+                if (inEvents != null) {
+                    for (Event e : inEvents) {
+                        lastCountPerKey.put((String) e.getData(0), (Long) e.getData(1));
+                    }
+                }
+            }
+        });
+        try {
+            runtime.start();
+            InputHandler in = runtime.getInputHandler("cseEventStream");
+
+            String getPetKey = "api123_GET_/pet_default";
+            String postPetKey = "api123_POST_/pet_default";
+
+            // GET is hit twice, POST is hit five times — independent volumes on the same app's API.
+            in.send(new Object[]{getPetKey, "get-1"});
+            in.send(new Object[]{getPetKey, "get-2"});
+            for (int i = 1; i <= 5; i++) {
+                in.send(new Object[]{postPetKey, "post-" + i});
+            }
+            Assert.assertEquals(Long.valueOf(2L), lastCountPerKey.get(getPetKey));
+            Assert.assertEquals(Long.valueOf(5L), lastCountPerKey.get(postPetKey));
+
+            Thread.sleep(4000); // cross the boundary
+            in.send(new Object[]{getPetKey, "get-window2-1"});
+            in.send(new Object[]{postPetKey, "post-window2-1"});
+            Thread.sleep(500);
+
+            Assert.assertEquals("GET resource should start fresh at 1 in window 2, not 3 (2+1 carried over)",
+                    Long.valueOf(1L), lastCountPerKey.get(getPetKey));
+            Assert.assertEquals("POST resource should start fresh at 1 in window 2, not 6 (5+1 carried over)",
+                    Long.valueOf(1L), lastCountPerKey.get(postPetKey));
+        } finally {
+            runtime.shutdown();
+        }
+    }
+
+    /**
+     * Three consecutive windows, three keys. Verifies the window-boundary reset correctly
+     * zeroes every key on EVERY rollover, not just the first — a mechanism that only worked
+     * once would be a much narrower bug than one that never worked, so this is worth
+     * confirming explicitly rather than assuming window 1->2 behavior generalizes.
+     */
+    @Test
+    public void multipleConsecutiveWindows_allKeysResetOnEveryRollover() throws InterruptedException {
+        SiddhiManager siddhiManager = new SiddhiManager();
+        String query = "" +
+                "define stream cseEventStream (throttleKey string, messageID string);" +
+                "@info(name = 'q1') " +
+                "from cseEventStream#throttler:timeBatch(3000) " +
+                "select throttleKey, count(messageID) as cnt, expiryTimeStamp " +
+                "group by throttleKey " +
+                "insert all events into outputStream;";
+
+        ExecutionPlanRuntime runtime = siddhiManager.createExecutionPlanRuntime(query);
+        Map<String, Long> lastCountPerKey = new ConcurrentHashMap<>();
+        runtime.addCallback("q1", new QueryCallback() {
+            @Override
+            public void receive(long timeStamp, Event[] inEvents, Event[] removeEvents) {
+                if (inEvents != null) {
+                    for (Event e : inEvents) {
+                        lastCountPerKey.put((String) e.getData(0), (Long) e.getData(1));
+                    }
+                }
+            }
+        });
+        try {
+            runtime.start();
+            InputHandler in = runtime.getInputHandler("cseEventStream");
+            String[] keys = {"AppA", "AppB", "AppC"};
+
+            // Window 1: heavy traffic (3, 4, 5 requests respectively).
+            for (int k = 0; k < keys.length; k++) {
+                for (int i = 0; i <= k + 2; i++) {
+                    in.send(new Object[]{keys[k], keys[k] + "-w1-" + i});
+                }
+            }
+            Thread.sleep(4000); // 1000ms margin past the 3000ms boundary, consistent with the rest of this file
+
+            // Window 2: exactly one request per key — must read back as 1, not accumulated.
+            for (String key : keys) {
+                in.send(new Object[]{key, key + "-w2"});
+            }
+            Assert.assertEquals(Long.valueOf(1L), lastCountPerKey.get("AppA"));
+            Assert.assertEquals(Long.valueOf(1L), lastCountPerKey.get("AppB"));
+            Assert.assertEquals(Long.valueOf(1L), lastCountPerKey.get("AppC"));
+            Thread.sleep(4000);
+
+            // Window 3: exactly one request per key again — must STILL read back as 1, proving
+            // the second rollover reset correctly too, not just the first.
+            for (String key : keys) {
+                in.send(new Object[]{key, key + "-w3"});
+            }
+
+            Assert.assertEquals("AppA should reset correctly on the SECOND rollover too",
+                    Long.valueOf(1L), lastCountPerKey.get("AppA"));
+            Assert.assertEquals("AppB should reset correctly on the SECOND rollover too",
+                    Long.valueOf(1L), lastCountPerKey.get("AppB"));
+            Assert.assertEquals("AppC should reset correctly on the SECOND rollover too",
+                    Long.valueOf(1L), lastCountPerKey.get("AppC"));
+        } finally {
+            runtime.shutdown();
+        }
+    }
+
+    /**
+     * An idle window with zero traffic sandwiched between two active windows. Confirms this
+     * self-corrects the moment traffic resumes — the next active window's own boundary reset
+     * (triggered by ITS traffic) still zeroes everything correctly, with no stale carryover
+     * from the window before the gap.
+     */
+    @Test
+    public void idleWindowInTheMiddle_selfCorrectsOnceTrafficResumes() throws InterruptedException {
+        SiddhiManager siddhiManager = new SiddhiManager();
+        String query = "" +
+                "define stream cseEventStream (throttleKey string, messageID string);" +
+                "@info(name = 'q1') " +
+                "from cseEventStream#throttler:timeBatch(3000) " +
+                "select throttleKey, count(messageID) as cnt, expiryTimeStamp " +
+                "group by throttleKey " +
+                "insert all events into outputStream;";
+
+        ExecutionPlanRuntime runtime = siddhiManager.createExecutionPlanRuntime(query);
+        Map<String, Long> lastCountPerKey = new ConcurrentHashMap<>();
+        runtime.addCallback("q1", new QueryCallback() {
+            @Override
+            public void receive(long timeStamp, Event[] inEvents, Event[] removeEvents) {
+                if (inEvents != null) {
+                    for (Event e : inEvents) {
+                        lastCountPerKey.put((String) e.getData(0), (Long) e.getData(1));
+                    }
+                }
+            }
+        });
+        try {
+            runtime.start();
+            InputHandler in = runtime.getInputHandler("cseEventStream");
+
+            // Window 1: traffic for AppX and AppY.
+            for (int i = 0; i < 4; i++) {
+                in.send(new Object[]{"AppX", "w1-" + i});
+            }
+            for (int i = 0; i < 2; i++) {
+                in.send(new Object[]{"AppY", "w1-" + i});
+            }
+            Assert.assertEquals(Long.valueOf(4L), lastCountPerKey.get("AppX"));
+            Assert.assertEquals(Long.valueOf(2L), lastCountPerKey.get("AppY"));
+
+            // Window 2: completely idle — no traffic from anyone. Sleep through two full
+            // window lengths so window 2 elapses with zero events.
+            Thread.sleep(7000);
+
+            // Window 3 (or later): traffic resumes. Both keys must start fresh at 1, not
+            // carry over their window-1 accumulated values (4 and 2 respectively).
+            in.send(new Object[]{"AppX", "resumed"});
+            in.send(new Object[]{"AppY", "resumed"});
+
+            Assert.assertEquals("AppX must not carry over its pre-idle-gap count", Long.valueOf(1L),
+                    lastCountPerKey.get("AppX"));
+            Assert.assertEquals("AppY must not carry over its pre-idle-gap count", Long.valueOf(1L),
+                    lastCountPerKey.get("AppY"));
+        } finally {
+            runtime.shutdown();
+        }
+    }
+
+    /**
+     * Mirrors throttle_policy_template_resource.xml's shape: an extra "evaluatedConditions"
+     * column alongside throttleKey/count/expiryTimeStamp, and resource-level-style keys
+     * (resourceKey + "_" + condition). Confirms the extra column doesn't interfere with
+     * multi-key reset correctness.
+     */
+    @Test
+    public void resourceLevelStyleQueryWithExtraColumn_multiKeyResetStillCorrect() throws InterruptedException {
+        SiddhiManager siddhiManager = new SiddhiManager();
+        String query = "" +
+                "define stream cseEventStream (throttleKey string, messageID string, evaluatedConditions string);" +
+                "@info(name = 'q1') " +
+                "from cseEventStream#throttler:timeBatch(3000) " +
+                "select throttleKey, count(messageID) as cnt, expiryTimeStamp, evaluatedConditions " +
+                "group by throttleKey " +
+                "insert all events into outputStream;";
+
+        ExecutionPlanRuntime runtime = siddhiManager.createExecutionPlanRuntime(query);
+        Map<String, Long> lastCountPerKey = new ConcurrentHashMap<>();
+        runtime.addCallback("q1", new QueryCallback() {
+            @Override
+            public void receive(long timeStamp, Event[] inEvents, Event[] removeEvents) {
+                if (inEvents != null) {
+                    for (Event e : inEvents) {
+                        lastCountPerKey.put((String) e.getData(0), (Long) e.getData(1));
+                    }
+                }
+            }
+        });
+        runtime.start();
+        InputHandler in = runtime.getInputHandler("cseEventStream");
+
+        String key1 = "resourceA_GET_condition1";
+        String key2 = "resourceA_POST_condition2";
+        for (int i = 0; i < 6; i++) {
+            in.send(new Object[]{key1, key1 + "-" + i, "W10="});
+        }
+        for (int i = 0; i < 3; i++) {
+            in.send(new Object[]{key2, key2 + "-" + i, "W10="});
+        }
+        Thread.sleep(4000); // 1000ms margin past the 3000ms boundary, consistent with the rest of this file
+
+        in.send(new Object[]{key1, "after", "W10="});
+        in.send(new Object[]{key2, "after", "W10="});
+        runtime.shutdown();
+
+        Assert.assertEquals("Resource/condition key 1 should reset correctly despite the extra column",
+                Long.valueOf(1L), lastCountPerKey.get(key1));
+        Assert.assertEquals("Resource/condition key 2 should reset correctly despite the extra column",
+                Long.valueOf(1L), lastCountPerKey.get(key2));
+    }
 
 }

--- a/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/templates/repository/conf/api-manager.xml.j2
+++ b/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/templates/repository/conf/api-manager.xml.j2
@@ -1366,6 +1366,9 @@
                 {% if apim.distributed_throttling.keyvalue_store.connection_timeout is defined %}
                 <ConnectionTimeout>{{apim.distributed_throttling.keyvalue_store.connection_timeout}}</ConnectionTimeout>
                 {% endif %}
+                {% if apim.distributed_throttling.keyvalue_store.socket_timeout is defined %}
+                <SocketTimeout>{{apim.distributed_throttling.keyvalue_store.socket_timeout}}</SocketTimeout>
+                {% endif %}
                 {% if apim.distributed_throttling.keyvalue_store.ssl is defined %}
                 <IsSslEnabled>{{apim.distributed_throttling.keyvalue_store.ssl}}</IsSslEnabled>
                 {% endif %}
@@ -1389,6 +1392,9 @@
                 {% endif %}
                 {% if apim.distributed_throttling.keyvalue_store.time_between_eviction_runs_millis is defined %}
                 <TimeBetweenEvictionRunsMillis>{{apim.distributed_throttling.keyvalue_store.time_between_eviction_runs_millis}}</TimeBetweenEvictionRunsMillis>
+                {% endif %}
+                {% if apim.distributed_throttling.keyvalue_store.max_wait_millis is defined %}
+                <MaxWaitMillis>{{apim.distributed_throttling.keyvalue_store.max_wait_millis}}</MaxWaitMillis>
                 {% endif %}
             </KeyValueStoreOptions>
             {% endif %}


### PR DESCRIPTION
## Purpose

Address incorrect throttling decisions in distributed deployments caused by non-atomic counter resets during time window expiry. Previously, window resets were executed via sequential decrement (`processRemove`) operations, exposing intermediate counter states to other Traffic Managers during KV store synchronization. This resulted in inconsistent reads and temporary over-allowance of requests.

## Goals

- Ensure atomic reset of distributed counters at window boundaries
- Eliminate intermediate state visibility across Traffic Managers  
- Improve consistency of throttling decisions in distributed environments
- Prevent sync thread hangs under slow/unresponsive Redis instances

---

## Change 1 — Add SocketTimeout and MaxWaitMillis config for distributed throttle Redis pool

### Problem
`JedisPool` was initialized with only a `connectionTimeout`, leaving socket reads and pool-borrow waits unbounded. Under a slow or unresponsive Redis instance, this caused sync threads to hang indefinitely, blocking throttling operations.

### Solution
- Added **`SocketTimeout`** config option to cap socket read/write operations
- Added **`MaxWaitMillis`** config option to limit pool connection wait time
- Wired both through `APIConstants`, `APIManagerConfiguration`, `DistributedThrottleConfig`, and `JedisKeyValueStoreClient`
- **SocketTimeout** defaults to `Protocol.DEFAULT_TIMEOUT` (2000ms) when not configured
- **MaxWaitMillis** defaults to **3000ms** for throttling operations, ensuring bounded waits

### Configuration

**deployment.toml**
```toml
[apim.distributed_throttling.keyvalue_store]
socket_timeout = 2000     # caps socket read/write time (ms)
max_wait_millis = 3000    # max wait for a pool connection (ms)
```

---

## Change 2 — Introduce async pendingReset and TTL-aware Redis keys for distributed throttle reset

### Problem
The previous `reset()` implementation had multiple race conditions:

1. **Blocking Reset**: Made a synchronous Redis `SET key 0` call on the Siddhi event thread, blocking the throttle pipeline at every window boundary
2. **Old-Window Delta Race**: After `reset()` wrote `0` to Redis, in-flight sync operations could race back and overwrite with old window counts
3. **Stale Keys**: Crashed nodes left counters in Redis without expiry, causing incorrect counts when the node restarted
4. **Sequential Decrements**: Window resets via `processRemove` exposed intermediate states to concurrent sync operations

### Solution

#### Non-Blocking Async Reset
- `reset()` now sets `pendingReset = true` flag and returns immediately (no blocking Redis call)
- Background sync thread detects `pendingReset` and flushes via `PSETEX key 0 <remaining-ttl>`
- Automatic retry on failure ensures eventual consistency
- Siddhi event thread never blocks on Redis I/O

#### Race Condition Guards
- **Double-check pattern**: After `unsyncedCounter.getAndSet(0)`, verify `pendingReset` again
- If `reset()` fired concurrently, discard the captured old-window delta
- Prevents old counts from overwriting the reset value

#### TTL-Aware Keys
- All Redis keys now carry a window TTL matching the time-window duration
- Implemented via `PSETEX` for resets and `PEXPIRE` for incremental updates
- Stale keys auto-expire if nodes crash mid-window
- `ThrottleStreamProcessor` propagates window expiry timestamp via `ThreadLocal`
- Aggregators refresh `storedWindowExpiry` from ThreadLocal to handle gaps (empty windows)

#### Key-Value Store Interface Extensions
- Added `setWithExpiry(key, value, ttlMillis)` → Redis `PSETEX`
- Added `expireMillis(key, ttlMillis)` → Redis `PEXPIRE`
- Integrated into `JedisKeyValueStoreClient` implementation

---

## Related Issue
- https://github.com/wso2/api-manager/issues/4744

