### PR TITLE
Fix AWS Lambda secret key decryption check

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -2970,7 +2970,6 @@ public final class APIConstants {
 
     // AWS Lambda: Constants for aws lambda
     public static final String AWS_SECRET_KEY = "AWS_SECRET_KEY";
-    public static final int AWS_ENCRYPTED_SECRET_KEY_LENGTH = 620;
     public static final int AWS_DEFAULT_CONNECTION_TIMEOUT = 50000;
     public static final String AMZN_ACCESS_KEY = "amznAccessKey";
     public static final String AMZN_SECRET_KEY = "amznSecretKey";

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/restapi/publisher/ApisApiServiceImplUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/restapi/publisher/ApisApiServiceImplUtils.java
@@ -312,8 +312,8 @@ public class ApisApiServiceImplUtils {
         if (log.isDebugEnabled()) {
             log.debug("Using user given stored credentials");
         }
-        if (secretKey.length() == APIConstants.AWS_ENCRYPTED_SECRET_KEY_LENGTH) {
-            CryptoUtil cryptoUtil = CryptoUtil.getDefaultCryptoUtil();
+        CryptoUtil cryptoUtil = CryptoUtil.getDefaultCryptoUtil();
+        if (cryptoUtil.base64DecodeAndIsSelfContainedCipherText(secretKey)) {
             secretKey = new String(cryptoUtil.base64DecodeAndDecrypt(secretKey),
                     StandardCharsets.UTF_8);
         }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/restapi/publisher/ApisApiServiceImplUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/restapi/publisher/ApisApiServiceImplUtils.java
@@ -313,7 +313,15 @@ public class ApisApiServiceImplUtils {
             log.debug("Using user given stored credentials");
         }
         CryptoUtil cryptoUtil = CryptoUtil.getDefaultCryptoUtil();
-        if (cryptoUtil.base64DecodeAndIsSelfContainedCipherText(secretKey)) {
+        boolean isEncryptedSecretKey = false;
+        try {
+            isEncryptedSecretKey = cryptoUtil.base64DecodeAndIsSelfContainedCipherText(secretKey);
+        } catch (CryptoException e) {
+            if (log.isDebugEnabled()) {
+                log.debug("AWS secret key is not a self-contained cipher text; using stored value as-is.", e);
+            }
+        }
+        if (isEncryptedSecretKey) {
             secretKey = new String(cryptoUtil.base64DecodeAndDecrypt(secretKey),
                     StandardCharsets.UTF_8);
         }


### PR DESCRIPTION
## Problem

The encrypted secret key was detected using a hardcoded length check (`AWS_ENCRYPTED_SECRET_KEY_LENGTH = 620`), which is unreliable — ciphertext length varies by algorithm and encoding.

## Fix

Replaced the length check with `CryptoUtil.base64DecodeAndIsSelfContainedCipherText(secretKey)`, which correctly identifies encrypted values regardless of length. The now-unused `AWS_ENCRYPTED_SECRET_KEY_LENGTH` constant has also been removed.

## Related PR
- https://github.com/wso2/api-manager/issues/5029