### PR TITLE
Allow POST /apis to add versions to already-registered exact-case names

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/APIManager.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/APIManager.java
@@ -182,6 +182,27 @@ public interface APIManager {
     boolean isApiNameWithDifferentCaseExist(String apiName, String organization) throws APIManagementException;
 
     /**
+     * Checks whether an API with the given name in the exact same letter case is already registered under
+     * the given organization. Complements {@link #isApiNameWithDifferentCaseExist(String, String)}: this
+     * returns true only when the stored name matches character-for-character (no case fold), so callers
+     * can distinguish "introducing a new case-variant" from "acting on an already-registered exact name".
+     *
+     * <p>Declared as a {@code default} method to keep this a source/binary-compatible addition for any
+     * external classes implementing {@link APIManager}. The default returns {@code false}, which
+     * preserves the stricter pre-existing behaviour of the create-time case-variant check when a legacy
+     * implementation does not override it. The stock implementation in {@code AbstractAPIManager}
+     * overrides this to delegate to the DAO.</p>
+     *
+     * @param apiName      A String representing an API name
+     * @param organization Organization
+     * @return true if an exact-case match already exists, false otherwise
+     * @throws APIManagementException if failed to check the exact-case api name availability
+     */
+    default boolean isApiNameExistExactCase(String apiName, String organization) throws APIManagementException {
+        return false;
+    }
+
+    /**
      * Returns a set of API versions for the given provider and API name
      *
      * @param providerName name of the provider (common)

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/AbstractAPIManager.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/AbstractAPIManager.java
@@ -664,6 +664,15 @@ public abstract class AbstractAPIManager implements APIManager {
         return apiMgtDAO.isApiNameWithDifferentCaseExist(apiName, tenantName, organization);
     }
 
+    public boolean isApiNameExistExactCase(String apiName, String organization) throws APIManagementException {
+
+        String tenantName = MultitenantConstants.SUPER_TENANT_DOMAIN_NAME;
+        if (tenantDomain != null && !MultitenantConstants.SUPER_TENANT_DOMAIN_NAME.equals(tenantDomain)) {
+            tenantName = tenantDomain;
+        }
+        return apiMgtDAO.isApiNameExistExactCase(apiName, tenantName, organization);
+    }
+
     public void addSubscriber(String username, String groupingId) throws APIManagementException {
         addSubscriber(username, groupingId, null);
     }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/ApiMgtDAO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/ApiMgtDAO.java
@@ -11774,6 +11774,50 @@ public class ApiMgtDAO {
     }
 
     /**
+     * Check whether an API with the given name in the exact same letter case already exists under the given
+     * tenant. Useful for distinguishing "the caller's name is a new letter-case variant of an existing name"
+     * from "the caller's name matches an existing row exactly" without depending on the database collation.
+     *
+     * @param apiName      candidate api name
+     * @param tenantDomain tenant domain name
+     * @param organization organization identifier
+     * @return true if a row with exact-case matching API_NAME already exists in this tenant/org
+     * @throws APIManagementException If failed to check exact-case api name availability
+     */
+    public boolean isApiNameExistExactCase(String apiName, String tenantDomain, String organization)
+            throws APIManagementException {
+
+        String contextParam = "/t/";
+        String query = SQLConstants.GET_API_NAME_DIFF_CASE_NOT_MATCHING_CONTEXT_SQL;
+        if (!MultitenantConstants.SUPER_TENANT_DOMAIN_NAME.equals(tenantDomain)) {
+            query = SQLConstants.GET_API_NAME_DIFF_CASE_MATCHING_CONTEXT_SQL;
+            contextParam += tenantDomain + '/';
+        }
+
+        // The SQL fetches rows whose name matches case-insensitively; the exact-case
+        // decision is made in Java via String.equals so this check is independent of the
+        // database collation (mirrors isApiNameWithDifferentCaseExist but returns true
+        // for the opposite condition: exact-case match found).
+        try (Connection connection = APIMgtDBUtil.getConnection();
+             PreparedStatement prepStmt = connection.prepareStatement(query)) {
+            prepStmt.setString(1, apiName);
+            prepStmt.setString(2, contextParam + '%');
+            prepStmt.setString(3, organization);
+            try (ResultSet resultSet = prepStmt.executeQuery()) {
+                while (resultSet.next()) {
+                    String storedName = resultSet.getString("API_NAME");
+                    if (storedName != null && storedName.equals(apiName)) {
+                        return true;
+                    }
+                }
+            }
+        } catch (SQLException e) {
+            handleException("Failed to check exact-case api name availability : " + apiName, e);
+        }
+        return false;
+    }
+
+    /**
      * Check whether the given scope key is already assigned locally to another API which are different from the given
      * API or its versioned APIs under given tenant.
      *

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/dao/test/APIMgtDAOTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/dao/test/APIMgtDAOTest.java
@@ -869,6 +869,101 @@ public class APIMgtDAOTest {
         }
     }
 
+    /**
+     * Regression coverage for the exact-case existence helper used by the create-API
+     * front-door check to distinguish "introducing a new case-variant" from "operating
+     * on an already-registered exact name" independently of DB collation.
+     */
+    @Test
+    public void testIsApiNameExistExactCase() throws Exception {
+        String apiName = "IsApiNameExactCaseTestApi";
+        String org = "isApiNameExactCaseTestOrg";
+
+        APIIdentifier apiId = new APIIdentifier(apiName, apiName, "1.0.0");
+        API api = new API(apiId);
+        api.setContext("/" + apiName);
+        api.setContextTemplate("/" + apiName + "/{version}");
+        api.setUUID(UUID.randomUUID().toString());
+        api.setVersionTimestamp(String.valueOf(System.currentTimeMillis()));
+        apiMgtDAO.addAPI(api, -1234, org);
+
+        try {
+            // Exact-case input matches the stored name -- must return true.
+            assertTrue("exact-case name should be detected",
+                    apiMgtDAO.isApiNameExistExactCase(
+                            apiName, MultitenantConstants.SUPER_TENANT_DOMAIN_NAME, org));
+
+            // Uppercase variant does NOT match the stored mixed-case name -- must return false.
+            assertFalse("case-variant name should NOT be reported as exact-case",
+                    apiMgtDAO.isApiNameExistExactCase(
+                            apiName.toUpperCase(), MultitenantConstants.SUPER_TENANT_DOMAIN_NAME, org));
+
+            // Lowercase variant does NOT match the stored mixed-case name -- must return false.
+            assertFalse("case-variant name should NOT be reported as exact-case",
+                    apiMgtDAO.isApiNameExistExactCase(
+                            apiName.toLowerCase(), MultitenantConstants.SUPER_TENANT_DOMAIN_NAME, org));
+
+            // Completely different name -- must return false.
+            assertFalse("unrelated name should NOT be reported as exact-case",
+                    apiMgtDAO.isApiNameExistExactCase(
+                            "SomethingCompletelyDifferent", MultitenantConstants.SUPER_TENANT_DOMAIN_NAME, org));
+
+            // Different organization scope -- exact match in a different org must NOT be found.
+            assertFalse("exact-case in a different org should NOT match",
+                    apiMgtDAO.isApiNameExistExactCase(
+                            apiName, MultitenantConstants.SUPER_TENANT_DOMAIN_NAME, "aDifferentOrg"));
+        } finally {
+            apiMgtDAO.deleteAPI(api.getUuid());
+        }
+    }
+
+    /**
+     * Covers the tenant-domain branch of {@link ApiMgtDAO#isApiNameExistExactCase(String, String, String)}
+     * which selects {@code GET_API_NAME_DIFF_CASE_MATCHING_CONTEXT_SQL} and binds {@code /t/<tenant>/%}
+     * as the context filter. The super-tenant test above exercises the sibling
+     * {@code GET_API_NAME_DIFF_CASE_NOT_MATCHING_CONTEXT_SQL} branch, so between the two, both SQL
+     * constants added by this fix are exercised.
+     */
+    @Test
+    public void testIsApiNameExistExactCase_TenantDomain() throws Exception {
+        String apiName = "IsApiNameExactCaseTenantApi";
+        String tenantDomain = "isapinameexactcase.test";
+        String org = "isApiNameExactCaseTenantOrg";
+        String tenantPrefixedContext = "/t/" + tenantDomain + "/" + apiName;
+
+        APIIdentifier apiId = new APIIdentifier(apiName, apiName, "1.0.0");
+        API api = new API(apiId);
+        api.setContext(tenantPrefixedContext);
+        api.setContextTemplate(tenantPrefixedContext + "/{version}");
+        api.setUUID(UUID.randomUUID().toString());
+        api.setVersionTimestamp(String.valueOf(System.currentTimeMillis()));
+        apiMgtDAO.addAPI(api, 1, org);
+
+        try {
+            // Exact-case name in this tenant's context prefix -- must return true.
+            assertTrue("exact-case name in tenant scope should be detected",
+                    apiMgtDAO.isApiNameExistExactCase(apiName, tenantDomain, org));
+
+            // Case-variant in same tenant scope -- must return false.
+            assertFalse("case-variant in tenant scope should NOT be reported as exact-case",
+                    apiMgtDAO.isApiNameExistExactCase(apiName.toUpperCase(), tenantDomain, org));
+
+            // Same name but queried under a DIFFERENT tenant domain -- must return false,
+            // because the tenant-branch query filters CONTEXT LIKE '/t/<queried-tenant>/%'
+            // and this row's context is stored under a different tenant prefix.
+            assertFalse("exact-case in a different tenant should NOT match",
+                    apiMgtDAO.isApiNameExistExactCase(apiName, "different.tenant", org));
+
+            // Same name but queried under SUPER tenant -- must return false, because the
+            // super-tenant branch uses CONTEXT NOT LIKE '/t/%' and this row IS under /t/.
+            assertFalse("exact-case in a tenant should NOT match when queried from super tenant",
+                    apiMgtDAO.isApiNameExistExactCase(apiName,
+                            MultitenantConstants.SUPER_TENANT_DOMAIN_NAME, org));
+        } finally {
+            apiMgtDAO.deleteAPI(api.getUuid());
+        }
+    }
+
     @Test
     public void testGetAPIGatewayVendorByUUID() throws Exception {
         APIIdentifier apiId = new APIIdentifier("getAPIGatewayVendorByApiUUID",

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/PublisherCommonUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/PublisherCommonUtils.java
@@ -2892,7 +2892,16 @@ public class PublisherCommonUtils {
                             apiDtoTypeWrapper.getVersion()));
         }
 
-        if (apiProvider.isApiNameWithDifferentCaseExist(apiDtoTypeWrapper.getName(), organization)) {
+        // Block only when this create would INTRODUCE a new case-variant. If an exact-case
+        // name already exists in the tenant, the request is either a duplicate (caught later
+        // in this same method by the version-uniqueness check via
+        // getApiVersionsMatchingApiNameAndOrganization, then by the duplicate-context check,
+        // and ultimately by the AM_API (API_PROVIDER, API_NAME, API_VERSION, ORGANIZATION)
+        // unique constraint) or a legitimate new-version path -- either way, the existing
+        // case-variant sibling (if any) is a pre-existing legacy state that predates this
+        // check, so blocking here would be over-strict.
+        if (apiProvider.isApiNameWithDifferentCaseExist(apiDtoTypeWrapper.getName(), organization)
+                && !apiProvider.isApiNameExistExactCase(apiDtoTypeWrapper.getName(), organization)) {
             throw new APIManagementException(
                     "API with name " + apiDtoTypeWrapper.getName() + " already exists.",
                     ExceptionCodes.from(ExceptionCodes.API_NAME_ALREADY_EXISTS, apiDtoTypeWrapper.getName()));


### PR DESCRIPTION
## Summary

Follow-up refinement to PR #13898 (merged). The front-door check added there rejects `POST /apis` too eagerly when the tenant already contains legacy case-variant sibling APIs (e.g. `testAPI` v1.0 and `TestAPI` v2.0, created before the fix on a case-insensitive DB collation): adding `testAPI` v3.0 was blocked as a "case-variant already exists," even though the create does not introduce any NEW case-variant — the sibling is pre-existing legacy state.

## Refinement

Block only when the create would INTRODUCE a new case-variant, i.e. `isApiNameWithDifferentCaseExist(name) && !isApiNameExistExactCase(name)`. Adding a version to an already-registered exact-case name is allowed; creating a new letter-case variant is still rejected.

## Scenario matrix

| Tenant state | User creates | Before this refinement | After |
|---|---|---|---|
| `testAPI` v1.0 only | `testAPI` v3.0 | allow | allow |
| `testAPI` v1.0 only | `TestAPI` v1.0 | block | block |
| `testAPI` v1.0 + `TestAPI` v2.0 (legacy) | `testAPI` v3.0 | block (over-strict) | **allow** |
| `testAPI` v1.0 + `TestAPI` v2.0 (legacy) | `TESTAPI` v3.0 | block | block |

Duplicate name+version pairs continue to be caught by the existing version-uniqueness check at `PublisherCommonUtils` (`getApiVersionsMatchingApiNameAndOrganization` + `equalsIgnoreCase`).

## Changes

- New DAO method `isApiNameExistExactCase(apiName, tenantDomain, organization)` — mirrors `isApiNameWithDifferentCaseExist` but inverts the Java-side filter to `storedName.equals(apiName)`; reuses the two SQL constants added in PR #13898.
- Exposed through `APIManager.isApiNameExistExactCase(name, org)` and `AbstractAPIManager.isApiNameExistExactCase(...)`.
- `PublisherCommonUtils` `POST /apis` check now combines both.
- Added `APIMgtDAOTest#testIsApiNameExistExactCase` covering exact-case match / uppercase variant / lowercase variant / unrelated name / different org.
- Typeahead callers (`ApisApiServiceImpl.validateAPI`, `McpServersApiServiceImpl`) are unchanged — their UI-warning semantics still want to flag case-variants.

## Test plan

- [x] `mvn test -Dtest=APIMgtDAOTest#testIsApiNameExistExactCase` passes (Java 21).
- [x] Impl module compiles (Java 21).
- [x] `PublisherCommonUtils` compiles (Java 21).
- [x] Manual: create `testAPI` v1.0, then `TestAPI` v2.0 via direct DB insert (or on CI collation), then `POST /apis` `testAPI` v3.0 — should now succeed.

Related: wso2/api-manager#5107.