### PR TITLE
Bump aws-core version to 2.30.22.wso2v3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2331,7 +2331,7 @@
         <import.package.version.commons.io>[2.4.0,3.0.0)</import.package.version.commons.io>
         <import.package.version.commons.codec>[1.14.0,3.0.0)</import.package.version.commons.codec>
 
-        <org.wso2.orbit.com.amazonaws.version>2.30.22.wso2v2</org.wso2.orbit.com.amazonaws.version>
+        <org.wso2.orbit.com.amazonaws.version>2.30.22.wso2v3</org.wso2.orbit.com.amazonaws.version>
         <org.wso2.orbit.com.amazonaws.version.range>[2.20, 2.50]</org.wso2.orbit.com.amazonaws.version.range>
 
         <zipkin.version>2.27.1</zipkin.version>


### PR DESCRIPTION
### Purpose

Upgrades the `org.wso2.orbit.com.amazonaws` (aws-core) orbit bundle version in the root `pom.xml` from `2.30.22.wso2v2` to `2.30.22.wso2v3`.

### Why

The `2.30.22.wso2v2` orbit bundle embedded the AWS SDK `retries` module but did not export its packages, so `software.amazon.awssdk.retries.*` classes were not visible to other OSGi bundles at runtime. The `2.30.22.wso2v3` release ([wso2/orbit#1371](https://github.com/wso2/orbit/pull/1371)) fixes this by:

- Adding `software.amazon.awssdk.retries.*` to the bundle's `Export-Package` list, making the AWS SDK retry strategy classes resolvable by consuming bundles.

### Changes

- Updated `org.wso2.orbit.com.amazonaws.version` from `2.30.22.wso2v2` to `2.30.22.wso2v3` in the root `pom.xml`.

## Related Issue
- https://github.com/wso2/api-manager/issues/5029