### PR TITLE
Fix jwt claim array validator 5126

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/mediators/ClaimBasedResourceAccessValidationMediator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/mediators/ClaimBasedResourceAccessValidationMediator.java
@@ -30,6 +30,10 @@ import org.wso2.carbon.apimgt.gateway.handlers.Utils;
 import org.wso2.carbon.apimgt.gateway.handlers.security.APISecurityConstants;
 import org.wso2.carbon.apimgt.gateway.handlers.security.APISecurityException;
 
+import java.lang.reflect.Array;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -55,56 +59,77 @@ public class ClaimBasedResourceAccessValidationMediator extends AbstractMediator
     @Override
     public boolean mediate(MessageContext messageContext) {
 
-        String claimValueSentInToken;
-        Map<String, String> jwtTokenClaims = (Map<String, String>) messageContext
-                .getProperty(APIMgtGatewayConstants.JWT_CLAIMS);
-
-        claimValueSentInToken = jwtTokenClaims.get(accessVerificationClaim);
-
         try {
-            if (StringUtils.isBlank(claimValueSentInToken)) {
+            Map<String, Object> jwtTokenClaims = (Map<String, Object>) messageContext
+                    .getProperty(APIMgtGatewayConstants.JWT_CLAIMS);
+            Object claimValueSentInToken = jwtTokenClaims == null ? null : jwtTokenClaims.get(accessVerificationClaim);
+            List<String> tokenClaimValues = getClaimValues(claimValueSentInToken);
+
+            if (tokenClaimValues.isEmpty()) {
                 log.error("The configured resource access validation claim is " + "not present in the token.");
                 throw new APISecurityException(APISecurityConstants.API_AUTH_ACCESS_TOKEN_CLAIMS_INVALID,
                                                APISecurityConstants.API_AUTH_ACCESS_TOKEN_CLAIMS_INVALID_MESSAGE,
                                                String.format("Token doesn't contain the " + "claim \"%s\"",
                                                              accessVerificationClaim));
-            } else {
-                if (StringUtils.isNotBlank(accessVerificationClaimValueRegex)) {
-                    log.debug("A regex is provided, hence, validating the claim values using the provided regex.");
-                    Pattern pattern = Pattern.compile(accessVerificationClaimValueRegex);
-                    Matcher configuredClaimValueMatcher = pattern.matcher(accessVerificationClaimValue);
-                    Matcher tokenSentClaimValueMatcher = pattern.matcher(claimValueSentInToken);
-
-                    if ((configuredClaimValueMatcher.matches() && tokenSentClaimValueMatcher.matches())
-                            || shouldAllowValidation) {
-                        log.debug("Claim values match or the flow is configured to allow when claims doesn't match. "
-                                          + "Hence the flow is allowed.");
-                        return true;
-                    } else {
-                        log.debug("Claim values don't match. Hence the flow is not allowed.");
-                        throw new APISecurityException(APISecurityConstants.API_AUTH_ACCESS_TOKEN_CLAIMS_MISMATCH,
-                                                       APISecurityConstants.API_AUTH_ACCESS_TOKEN_CLAIMS_MISMATCH_MESSAGE,
-                                                       APISecurityConstants.API_AUTH_ACCESS_TOKEN_CLAIMS_MISMATCH_DESCRIPTION);
-                    }
-                } else {
-                    log.debug("A regex is not provided, validating the claim values based on equality.");
-                    if ((StringUtils.equals(accessVerificationClaimValue, claimValueSentInToken))
-                            || shouldAllowValidation) {
-                        log.debug("Claim values match or the flow is configured to allow when claims doesn't match. "
-                                          + "Hence the flow is allowed.");
-                        return true;
-                    } else {
-                        log.debug("Claim values don't match. Hence the flow is not allowed.");
-                        throw new APISecurityException(APISecurityConstants.API_AUTH_ACCESS_TOKEN_CLAIMS_MISMATCH,
-                                                       APISecurityConstants.API_AUTH_ACCESS_TOKEN_CLAIMS_MISMATCH_MESSAGE,
-                                                       APISecurityConstants.API_AUTH_ACCESS_TOKEN_CLAIMS_MISMATCH_DESCRIPTION);
-                    }
-                }
             }
+
+            if (isClaimMatched(tokenClaimValues) || shouldAllowValidation) {
+                log.debug("Claim values match or the flow is configured to allow when claims doesn't match. "
+                                  + "Hence the flow is allowed.");
+                return true;
+            }
+
+            log.debug("Claim values don't match. Hence the flow is not allowed.");
+            throw new APISecurityException(APISecurityConstants.API_AUTH_ACCESS_TOKEN_CLAIMS_MISMATCH,
+                                           APISecurityConstants.API_AUTH_ACCESS_TOKEN_CLAIMS_MISMATCH_MESSAGE,
+                                           APISecurityConstants.API_AUTH_ACCESS_TOKEN_CLAIMS_MISMATCH_DESCRIPTION);
         } catch (APISecurityException e) {
             handleAuthFailure(e.getErrorCode(), messageContext, e.getMessage(), e.getDescription());
             return false;
         }
+    }
+
+    private List<String> getClaimValues(Object claimValueSentInToken) {
+
+        List<String> tokenClaimValues = new ArrayList<>();
+        if (claimValueSentInToken == null) {
+            return tokenClaimValues;
+        }
+
+        if (claimValueSentInToken instanceof Collection<?>) {
+            for (Object claimValue : (Collection<?>) claimValueSentInToken) {
+                addClaimValue(tokenClaimValues, claimValue);
+            }
+        } else if (claimValueSentInToken.getClass().isArray()) {
+            for (int i = 0; i < Array.getLength(claimValueSentInToken); i++) {
+                addClaimValue(tokenClaimValues, Array.get(claimValueSentInToken, i));
+            }
+        } else {
+            addClaimValue(tokenClaimValues, claimValueSentInToken);
+        }
+        return tokenClaimValues;
+    }
+
+    private void addClaimValue(List<String> tokenClaimValues, Object claimValue) {
+
+        if (claimValue != null && StringUtils.isNotBlank(String.valueOf(claimValue))) {
+            tokenClaimValues.add(String.valueOf(claimValue));
+        }
+    }
+
+    private boolean isClaimMatched(List<String> tokenClaimValues) {
+
+        if (StringUtils.isNotBlank(accessVerificationClaimValueRegex)) {
+            log.debug("A regex is provided, hence, validating the claim values using the provided regex.");
+            Pattern pattern = Pattern.compile(accessVerificationClaimValueRegex);
+            Matcher configuredClaimValueMatcher = pattern.matcher(StringUtils.defaultString(accessVerificationClaimValue));
+            return configuredClaimValueMatcher.matches()
+                    && tokenClaimValues.stream().anyMatch(tokenClaimValue -> pattern.matcher(tokenClaimValue).matches());
+        }
+
+        log.debug("A regex is not provided, validating the claim values based on equality.");
+        return tokenClaimValues.stream()
+                .anyMatch(tokenClaimValue -> StringUtils.equals(accessVerificationClaimValue, tokenClaimValue));
     }
 
     /**

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/test/java/org/wso2/carbon/apimgt/gateway/mediators/ClaimBasedResourceAccessValidationMediatorTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/test/java/org/wso2/carbon/apimgt/gateway/mediators/ClaimBasedResourceAccessValidationMediatorTest.java
@@ -17,16 +17,29 @@
  */
 package org.wso2.carbon.apimgt.gateway.mediators;
 
+import org.apache.commons.httpclient.HttpStatus;
 import org.apache.synapse.MessageContext;
+import org.apache.synapse.SynapseConstants;
 import org.apache.synapse.core.axis2.Axis2MessageContext;
+import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 import org.testng.Assert;
 import org.wso2.carbon.apimgt.gateway.APIMgtGatewayConstants;
+import org.wso2.carbon.apimgt.gateway.handlers.Utils;
+import org.wso2.carbon.apimgt.gateway.handlers.security.APISecurityConstants;
 
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(Utils.class)
 public class ClaimBasedResourceAccessValidationMediatorTest {
 
     MessageContext messageContext = Mockito.mock(Axis2MessageContext.class);
@@ -35,6 +48,17 @@ public class ClaimBasedResourceAccessValidationMediatorTest {
     public static final String APPLICATION = "APPLICATION";
     public static final String APPLICATION_USER = "APPLICATION_USER";
     public static final String AUT = "aut";
+    public static final String ROLES = "roles";
+    public static final String VALUE_1 = "value1";
+    public static final String VALUE_2 = "value2";
+    public static final String MISSING_VALUE = "missing";
+
+    @Before
+    public void setup() throws Exception {
+
+        PowerMockito.mockStatic(Utils.class);
+        PowerMockito.doNothing().when(Utils.class, "sendFault", Mockito.any(MessageContext.class), Mockito.anyInt());
+    }
 
     @Test
     public void testFlowWhenClaimsMatchingWithRegex() throws Exception {
@@ -123,6 +147,82 @@ public class ClaimBasedResourceAccessValidationMediatorTest {
         mediator.setAccessVerificationClaimValue(APPLICATION_USER);
         mediator.setAccessVerificationClaimValueRegex(claimValueRegex);
         mediator.setShouldAllowValidation(true);
+        Assert.assertTrue(mediator.mediate(messageContext));
+    }
+
+    @Test
+    public void testFlowWhenArrayClaimContainsConfiguredClaimWithoutRegex() throws Exception {
+
+        Map<String, Object> jwtTokenClaimsMap = new HashMap<>();
+        jwtTokenClaimsMap.put(ROLES, Arrays.asList(VALUE_1, VALUE_2));
+        Mockito.when(messageContext.getProperty(APIMgtGatewayConstants.JWT_CLAIMS))
+                .thenReturn(jwtTokenClaimsMap);
+        mediator.setAccessVerificationClaim(ROLES);
+        mediator.setAccessVerificationClaimValue(VALUE_1);
+        mediator.setAccessVerificationClaimValueRegex("");
+        mediator.setShouldAllowValidation(false);
+
+        Assert.assertTrue(mediator.mediate(messageContext));
+    }
+
+    @Test
+    public void testFlowWhenArrayClaimDoesNotContainConfiguredClaimWithoutRegex() throws Exception {
+
+        Map<String, Object> jwtTokenClaimsMap = new HashMap<>();
+        jwtTokenClaimsMap.put(ROLES, Arrays.asList(VALUE_1, VALUE_2));
+        Mockito.when(messageContext.getProperty(APIMgtGatewayConstants.JWT_CLAIMS))
+                .thenReturn(jwtTokenClaimsMap);
+        mediator.setAccessVerificationClaim(ROLES);
+        mediator.setAccessVerificationClaimValue(MISSING_VALUE);
+        mediator.setAccessVerificationClaimValueRegex("");
+        mediator.setShouldAllowValidation(false);
+
+        Assert.assertFalse(mediator.mediate(messageContext));
+        Mockito.verify(messageContext).setProperty(SynapseConstants.ERROR_CODE,
+                APISecurityConstants.API_AUTH_ACCESS_TOKEN_CLAIMS_MISMATCH);
+        Mockito.verify(messageContext).setProperty(SynapseConstants.ERROR_MESSAGE,
+                APISecurityConstants.API_AUTH_ACCESS_TOKEN_CLAIMS_MISMATCH_MESSAGE);
+        Mockito.verify(messageContext).setProperty(SynapseConstants.ERROR_DETAIL,
+                APISecurityConstants.API_AUTH_ACCESS_TOKEN_CLAIMS_MISMATCH_DESCRIPTION);
+        PowerMockito.verifyStatic(Utils.class);
+        Utils.sendFault(Mockito.eq(messageContext), Mockito.eq(HttpStatus.SC_FORBIDDEN));
+    }
+
+    @Test
+    public void testFlowWhenArrayClaimIsEmpty() throws Exception {
+
+        Map<String, Object> jwtTokenClaimsMap = new HashMap<>();
+        jwtTokenClaimsMap.put(ROLES, Collections.emptyList());
+        Mockito.when(messageContext.getProperty(APIMgtGatewayConstants.JWT_CLAIMS))
+                .thenReturn(jwtTokenClaimsMap);
+        mediator.setAccessVerificationClaim(ROLES);
+        mediator.setAccessVerificationClaimValue(VALUE_1);
+        mediator.setAccessVerificationClaimValueRegex("");
+        mediator.setShouldAllowValidation(false);
+
+        Assert.assertFalse(mediator.mediate(messageContext));
+        Mockito.verify(messageContext).setProperty(SynapseConstants.ERROR_CODE,
+                APISecurityConstants.API_AUTH_ACCESS_TOKEN_CLAIMS_INVALID);
+        Mockito.verify(messageContext).setProperty(SynapseConstants.ERROR_MESSAGE,
+                APISecurityConstants.API_AUTH_ACCESS_TOKEN_CLAIMS_INVALID_MESSAGE);
+        Mockito.verify(messageContext).setProperty(SynapseConstants.ERROR_DETAIL,
+                String.format("Token doesn't contain the claim \"%s\"", ROLES));
+        PowerMockito.verifyStatic(Utils.class);
+        Utils.sendFault(Mockito.eq(messageContext), Mockito.eq(HttpStatus.SC_FORBIDDEN));
+    }
+
+    @Test
+    public void testFlowWhenArrayClaimMatchesConfiguredRegex() throws Exception {
+
+        Map<String, Object> jwtTokenClaimsMap = new HashMap<>();
+        jwtTokenClaimsMap.put(ROLES, Arrays.asList("ADMIN", "VIEWER"));
+        Mockito.when(messageContext.getProperty(APIMgtGatewayConstants.JWT_CLAIMS))
+                .thenReturn(jwtTokenClaimsMap);
+        mediator.setAccessVerificationClaim(ROLES);
+        mediator.setAccessVerificationClaimValue("ADMIN");
+        mediator.setAccessVerificationClaimValueRegex("^[A-Z]+$");
+        mediator.setShouldAllowValidation(false);
+
         Assert.assertTrue(mediator.mediate(messageContext));
     }
 }


### PR DESCRIPTION
## Purpose
This PR addresses a critical bug where the `ClaimBasedResourceAccessValidationMediator` throws a `ClassCastException` (resulting in an HTTP 500 error) when a JWT claim is structured as a JSON array (e.g., `roles: ["value1", "value2"]`). 

Previously, the mediator blindly cast the `jwtTokenClaims.get(claim)` directly to a `String`, which caused the Gateway thread to fail when encountering `java.util.List` or array types parsed by the underlying JWT library. 

This implementation safely extracts the claim value using polymorphism. It checks if the underlying object is an `Array` or a `Collection<?>` and gracefully flattens the values into a `List<String>`, ensuring the Gateway can evaluate array-based claims without crashing.

## Related Issues
- Fixes wso2/api-manager#5126 

## How Testing was done
### 1. Automated Unit Tests (Added)
Added comprehensive unit tests to `ClaimBasedResourceAccessValidationMediatorTest.java`. 
- Mocked Synapse `MessageContext` to inject array-based `List<String>` claims.
- Validated that requests containing the required role within the array evaluate successfully.
- Validated that arrays missing the required role correctly return an HTTP 403 / `900913` Claim Invalid response instead of a `ClassCastException`.
- Ran `mvn clean test` on `org.wso2.carbon.apimgt.gateway` and verified all tests pass.

### 2. Manual Gateway Smoke Test
- Configured a local WSO2 API Manager instance with Claim Based Access Control enabled.
- Appended `http://wso2.org/claims/role` to the OIDC `default` scope to ensure the backend JWT payload included the `roles` JSON array.
- Invoked the Gateway using a token containing `"roles": ["value1", "value2"]`.
- Verified via WSO2 carbon logs and `curl` that the Gateway successfully parsed the array and permitted the request to pass through the mediator sequence without throwing an HTTP 500.

## Checklist
- [x] My code follows the WSO2 coding standards and style guidelines.
- [x] I have performed a self-review of my own code.
- [x] I have added tests that prove my fix is effective.
- [x] New and existing unit tests pass locally with my changes.
- [x] The code cleanly backports to APIM 4.6.0 (`v9.32.147`) without merge conflicts.