### PR TITLE
Gate remote OpenAPI $ref and WSDL schema-import fetches through the network access-control policy

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/ExceptionCodes.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/ExceptionCodes.java
@@ -146,6 +146,8 @@ public enum ExceptionCodes implements ErrorHandler {
     MALFORMED_URL(900403, "Malformed URL", 400, "Malformed URL"),
     UNTRUSTED_URL(900405, "URL is not trusted", 400,
             "The provided URL is not trusted. Please contact the system administrator."),
+    UNTRUSTED_URL_IN_DEFINITION(900407, "URL is not trusted", 400,
+            "The provided definition contains a URL that is not trusted. Please contact the system administrator."),
     NETWORK_SECURITY_ACCESS_CONTROL_MISCONFIGURED(900406,
             "Internal server error. Please contact the system administrator.", 500,
             "Internal server error. Please contact the system administrator."),

--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/model/OASParserOptions.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/model/OASParserOptions.java
@@ -19,6 +19,8 @@ package org.wso2.carbon.apimgt.api.model;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
+import java.util.List;
+
 /**
  * Model class to hold OpenAPI Specification parser options.
  */
@@ -28,8 +30,27 @@ public class OASParserOptions {
 
     private boolean explicitStyleAndExplode = true;
     private Integer yamlCodePointLimit = null;
+    private List<String> remoteRefAllowList;
+    private List<String> remoteRefBlockList;
+    private boolean networkAccessControlEnabled = false;
 
     public OASParserOptions() {
+    }
+
+    /**
+     * Copy-constructor. Copies fields directly (no re-conversion) so that already-computed values such as
+     * {@code yamlCodePointLimit} are not re-interpreted through their String setters.
+     *
+     * @param other the instance to copy from; if {@code null}, this instance retains its default values
+     */
+    public OASParserOptions(OASParserOptions other) {
+        if (other != null) {
+            this.explicitStyleAndExplode = other.explicitStyleAndExplode;
+            this.yamlCodePointLimit = other.yamlCodePointLimit;
+            this.remoteRefAllowList = other.remoteRefAllowList;
+            this.remoteRefBlockList = other.remoteRefBlockList;
+            this.networkAccessControlEnabled = other.networkAccessControlEnabled;
+        }
     }
 
     public boolean isExplicitStyleAndExplode() {
@@ -82,6 +103,38 @@ public class OASParserOptions {
         // Consider 4 bytes per character
         double limit = fileSizeInMB * 1024 * 1024 * 4;
         this.yamlCodePointLimit = limit > Integer.MAX_VALUE ? Integer.MAX_VALUE : (int) limit;
+    }
+
+    public List<String> getRemoteRefAllowList() {
+        return remoteRefAllowList;
+    }
+
+    public void setRemoteRefAllowList(List<String> remoteRefAllowList) {
+        this.remoteRefAllowList = remoteRefAllowList;
+    }
+
+    public List<String> getRemoteRefBlockList() {
+        return remoteRefBlockList;
+    }
+
+    public void setRemoteRefBlockList(List<String> remoteRefBlockList) {
+        this.remoteRefBlockList = remoteRefBlockList;
+    }
+
+    public boolean isNetworkAccessControlEnabled() {
+        return networkAccessControlEnabled;
+    }
+
+    /**
+     * Configure whether the network access-control policy is in force for remote {@code $ref} resolution. When
+     * {@code false} (the default), the parser retains its historical behaviour and resolves remote refs without any
+     * host validation - preserving backwards compatibility for deployments that have not configured the policy. It
+     * is set to {@code true} only when a platform or tenant network access-control policy is present.
+     *
+     * @param networkAccessControlEnabled whether the network access-control policy is configured
+     */
+    public void setNetworkAccessControlEnabled(boolean networkAccessControlEnabled) {
+        this.networkAccessControlEnabled = networkAccessControlEnabled;
     }
 
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/test/java/org/wso2/carbon/apimgt/api/model/OASParserOptionsTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/test/java/org/wso2/carbon/apimgt/api/model/OASParserOptionsTest.java
@@ -1,0 +1,68 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.apimgt.api.model;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+
+public class OASParserOptionsTest {
+    @Test
+    public void testRemoteRefListsDefaultNullAndRoundTrip() {
+        OASParserOptions o = new OASParserOptions();
+        Assert.assertNull(o.getRemoteRefAllowList());
+        Assert.assertNull(o.getRemoteRefBlockList());
+        // Backwards compatibility: network access control is off unless explicitly enabled.
+        Assert.assertFalse(o.isNetworkAccessControlEnabled());
+        o.setRemoteRefAllowList(Arrays.asList("*.wso2.com", "api.github.com"));
+        o.setRemoteRefBlockList(Arrays.asList("*.internal"));
+        o.setNetworkAccessControlEnabled(true);
+        Assert.assertEquals(2, o.getRemoteRefAllowList().size());
+        Assert.assertEquals("*.internal", o.getRemoteRefBlockList().get(0));
+        Assert.assertTrue(o.isNetworkAccessControlEnabled());
+    }
+
+    @Test
+    public void testCopyConstructorCopiesFieldsRaw() {
+        OASParserOptions that = new OASParserOptions();
+        that.setExplicitStyleAndExplode("false");
+        that.setYamlCodePointLimit("10");
+        that.setRemoteRefAllowList(Arrays.asList("*.wso2.com", "api.github.com"));
+        that.setRemoteRefBlockList(Arrays.asList("*.internal"));
+        that.setNetworkAccessControlEnabled(true);
+
+        OASParserOptions copy = new OASParserOptions(that);
+
+        Assert.assertEquals(that.isExplicitStyleAndExplode(), copy.isExplicitStyleAndExplode());
+        // Must be copied verbatim (already a code-point count), not re-converted as if it were MB.
+        Assert.assertEquals(that.getYamlCodePointLimit(), copy.getYamlCodePointLimit());
+        Assert.assertNotEquals(Integer.valueOf(Integer.MAX_VALUE), copy.getYamlCodePointLimit());
+        Assert.assertEquals(that.getRemoteRefAllowList(), copy.getRemoteRefAllowList());
+        Assert.assertEquals(that.getRemoteRefBlockList(), copy.getRemoteRefBlockList());
+        Assert.assertTrue(copy.isNetworkAccessControlEnabled());
+
+        OASParserOptions fromNull = new OASParserOptions(null);
+        Assert.assertNull(fromNull.getRemoteRefAllowList());
+        Assert.assertNull(fromNull.getRemoteRefBlockList());
+        Assert.assertNull(fromNull.getYamlCodePointLimit());
+        Assert.assertTrue(fromNull.isExplicitStyleAndExplode());
+        Assert.assertFalse(fromNull.isNetworkAccessControlEnabled());
+    }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/restapi/publisher/ApisApiServiceImplUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/restapi/publisher/ApisApiServiceImplUtils.java
@@ -78,6 +78,7 @@ import org.wso2.carbon.apimgt.spec.parser.definitions.OAS2Parser;
 import org.wso2.carbon.apimgt.spec.parser.definitions.OAS3Parser;
 import org.wso2.carbon.apimgt.spec.parser.definitions.OASParserUtil;
 import org.wso2.carbon.base.ServerConfiguration;
+import org.wso2.carbon.context.CarbonContext;
 import org.wso2.carbon.core.util.CryptoException;
 import org.wso2.carbon.core.util.CryptoUtil;
 import org.wso2.carbon.utils.CarbonUtils;
@@ -651,8 +652,10 @@ public class ApisApiServiceImplUtils {
                                                                             boolean returnContent)
             throws APIManagementException {
         APIDefinitionValidationResponse validationResponse = new APIDefinitionValidationResponse();
-        OASParserOptions parserOptions = ServiceReferenceHolder.getInstance().getAPIMDependencyConfigurationService()
-                .getAPIMDependencyConfigurations().getOasParserOptions();
+        OASParserOptions baseParserOptions = ServiceReferenceHolder.getInstance()
+                .getAPIMDependencyConfigurationService().getAPIMDependencyConfigurations().getOasParserOptions();
+        OASParserOptions parserOptions = APIUtil.buildRefResolutionOptions(baseParserOptions,
+                CarbonContext.getThreadLocalCarbonContext().getTenantDomain());
         if (url != null) {
             try {
                 URL urlObj = new URL(url);

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
@@ -12545,7 +12545,8 @@ public final class APIUtil {
      * @param tenantDomain the tenant domain whose config should be merged in
      * @return a new {@link OASParserOptions} instance; never null
      */
-    public static OASParserOptions buildRefResolutionOptions(OASParserOptions base, String tenantDomain) {
+    public static OASParserOptions buildRefResolutionOptions(OASParserOptions base, String tenantDomain)
+            throws APIManagementException {
         OASParserOptions options = new OASParserOptions(base);
         List<String> allowList = new ArrayList<>();
         List<String> blockList = new ArrayList<>();
@@ -12556,6 +12557,7 @@ public final class APIUtil {
         // Platform policy (static fields populated in init()).
         if (networkSecurityEnabled) {
             policyConfigured = true;
+            validateNetworkSecurityMode(networkSecurityMode);
             if (networkSecurityHosts != null) {
                 if (APIConstants.NetworkSecurityAccessControl.MODE_ALLOW.equalsIgnoreCase(networkSecurityMode)) {
                     allowList.addAll(networkSecurityHosts);
@@ -12565,32 +12567,35 @@ public final class APIUtil {
             }
         }
 
-        // Tenant policy.
+        // Tenant policy. Only the config read is guarded; a misconfigured tenant policy must surface, not be swallowed.
+        JSONObject tenantConfig;
         try {
-            JSONObject tenantConfig = getTenantConfig(tenantDomain);
-            if (tenantConfig != null) {
-                Object nsac = tenantConfig.get(APIConstants.NetworkSecurityAccessControl.TENANT_CONFIG_KEY);
-                if (nsac instanceof JSONObject) {
-                    policyConfigured = true;
-                    JSONObject policy = (JSONObject) nsac;
-                    String tMode = (String) policy.get(APIConstants.NetworkSecurityAccessControl.TENANT_MODE);
-                    Object tHostsObj = policy.get(APIConstants.NetworkSecurityAccessControl.TENANT_HOSTS);
-                    List<String> tHosts = new ArrayList<>();
-                    if (tHostsObj instanceof JSONArray) {
-                        for (Object h : (JSONArray) tHostsObj) {
-                            tHosts.add(h.toString());
-                        }
-                    }
-                    if (APIConstants.NetworkSecurityAccessControl.MODE_ALLOW.equalsIgnoreCase(tMode)) {
-                        allowList.addAll(tHosts);
-                    } else if (APIConstants.NetworkSecurityAccessControl.MODE_DENY.equalsIgnoreCase(tMode)) {
-                        blockList.addAll(tHosts);
-                    }
-                }
-            }
+            tenantConfig = getTenantConfig(tenantDomain);
         } catch (APIManagementException e) {
             log.warn("Could not read tenant network access-control policy for $ref resolution; "
                     + "proceeding with platform policy only.", e);
+            tenantConfig = null;
+        }
+        if (tenantConfig != null) {
+            Object nsac = tenantConfig.get(APIConstants.NetworkSecurityAccessControl.TENANT_CONFIG_KEY);
+            if (nsac instanceof JSONObject) {
+                policyConfigured = true;
+                JSONObject policy = (JSONObject) nsac;
+                String tMode = (String) policy.get(APIConstants.NetworkSecurityAccessControl.TENANT_MODE);
+                Object tHostsObj = policy.get(APIConstants.NetworkSecurityAccessControl.TENANT_HOSTS);
+                List<String> tHosts = new ArrayList<>();
+                if (tHostsObj instanceof JSONArray) {
+                    for (Object h : (JSONArray) tHostsObj) {
+                        tHosts.add(h.toString());
+                    }
+                }
+                validateNetworkSecurityMode(tMode);
+                if (APIConstants.NetworkSecurityAccessControl.MODE_ALLOW.equalsIgnoreCase(tMode)) {
+                    allowList.addAll(tHosts);
+                } else if (APIConstants.NetworkSecurityAccessControl.MODE_DENY.equalsIgnoreCase(tMode)) {
+                    blockList.addAll(tHosts);
+                }
+            }
         }
 
         if (!allowList.isEmpty()) {
@@ -12601,6 +12606,30 @@ public final class APIUtil {
         }
         options.setNetworkAccessControlEnabled(policyConfigured);
         return options;
+    }
+
+    /**
+     * Validates the configured network access-control mode for an enabled policy. A blank mode is permitted (it means
+     * private-network blocking only, with no host allow/deny list). Any non-blank value other than
+     * {@code allow}/{@code deny} is a misconfiguration and is rejected, mirroring {@code applyAccessControlPolicy}.
+     *
+     * @param mode the configured mode, or {@code null}/blank for the private-network-only policy
+     * @throws APIManagementException with {@code NETWORK_SECURITY_ACCESS_CONTROL_MISCONFIGURED} if the mode is invalid
+     */
+    private static void validateNetworkSecurityMode(String mode) throws APIManagementException {
+        // Blank mode is valid (private-network-only) and handled by applyAccessControlPolicy; not a misconfiguration.
+        if (StringUtils.isBlank(mode)) {
+            return;
+        }
+        if (!APIConstants.NetworkSecurityAccessControl.MODE_ALLOW.equalsIgnoreCase(mode)
+                && !APIConstants.NetworkSecurityAccessControl.MODE_DENY.equalsIgnoreCase(mode)) {
+            APIManagementException ex = new APIManagementException(
+                    ExceptionCodes.NETWORK_SECURITY_ACCESS_CONTROL_MISCONFIGURED.getErrorMessage(),
+                    ExceptionCodes.NETWORK_SECURITY_ACCESS_CONTROL_MISCONFIGURED);
+            log.error("Network security access control misconfiguration: mode='" + mode + "' is not a valid value "
+                    + "(expected 'allow' or 'deny').", ex);
+            throw ex;
+        }
     }
 
     /**

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
@@ -130,6 +130,7 @@ import org.wso2.carbon.apimgt.api.model.Identifier;
 import org.wso2.carbon.apimgt.api.model.KeyManagerConfiguration;
 import org.wso2.carbon.apimgt.api.model.KeyManagerConnectorConfiguration;
 import org.wso2.carbon.apimgt.api.model.Mediation;
+import org.wso2.carbon.apimgt.api.model.OASParserOptions;
 import org.wso2.carbon.apimgt.api.model.OperationPolicyData;
 import org.wso2.carbon.apimgt.api.model.OperationPolicyDefinition;
 import org.wso2.carbon.apimgt.api.model.OperationPolicySpecification;
@@ -12532,6 +12533,74 @@ public final class APIUtil {
             }
             applyAccessControlPolicy(host, tenantMode, tenantHosts, tenantBlockPrivate);
         }
+    }
+
+    /**
+     * Builds a per-request {@link OASParserOptions} carrying the remote-$ref allow/block lists derived from the
+     * platform and tenant network access-control policy. Never mutates {@code base} (may be a shared singleton).
+     * allow-mode hosts → allow-list; deny-mode hosts → block-list; platform and tenant lists are unioned.
+     * Private-network blocking is handled by the resolver itself and needs no list entry here.
+     *
+     * @param base         base options to copy non-access-control settings from (may be null)
+     * @param tenantDomain the tenant domain whose config should be merged in
+     * @return a new {@link OASParserOptions} instance; never null
+     */
+    public static OASParserOptions buildRefResolutionOptions(OASParserOptions base, String tenantDomain) {
+        OASParserOptions options = new OASParserOptions(base);
+        List<String> allowList = new ArrayList<>();
+        List<String> blockList = new ArrayList<>();
+        // Whether any network access-control policy is configured. With no policy (neither platform nor tenant),
+        // safe resolution stays off so the parser keeps resolving remote refs as before (backwards compatibility).
+        boolean policyConfigured = false;
+
+        // Platform policy (static fields populated in init()).
+        if (networkSecurityEnabled) {
+            policyConfigured = true;
+            if (networkSecurityHosts != null) {
+                if (APIConstants.NetworkSecurityAccessControl.MODE_ALLOW.equalsIgnoreCase(networkSecurityMode)) {
+                    allowList.addAll(networkSecurityHosts);
+                } else if (APIConstants.NetworkSecurityAccessControl.MODE_DENY.equalsIgnoreCase(networkSecurityMode)) {
+                    blockList.addAll(networkSecurityHosts);
+                }
+            }
+        }
+
+        // Tenant policy.
+        try {
+            JSONObject tenantConfig = getTenantConfig(tenantDomain);
+            if (tenantConfig != null) {
+                Object nsac = tenantConfig.get(APIConstants.NetworkSecurityAccessControl.TENANT_CONFIG_KEY);
+                if (nsac instanceof JSONObject) {
+                    policyConfigured = true;
+                    JSONObject policy = (JSONObject) nsac;
+                    String tMode = (String) policy.get(APIConstants.NetworkSecurityAccessControl.TENANT_MODE);
+                    Object tHostsObj = policy.get(APIConstants.NetworkSecurityAccessControl.TENANT_HOSTS);
+                    List<String> tHosts = new ArrayList<>();
+                    if (tHostsObj instanceof JSONArray) {
+                        for (Object h : (JSONArray) tHostsObj) {
+                            tHosts.add(h.toString());
+                        }
+                    }
+                    if (APIConstants.NetworkSecurityAccessControl.MODE_ALLOW.equalsIgnoreCase(tMode)) {
+                        allowList.addAll(tHosts);
+                    } else if (APIConstants.NetworkSecurityAccessControl.MODE_DENY.equalsIgnoreCase(tMode)) {
+                        blockList.addAll(tHosts);
+                    }
+                }
+            }
+        } catch (APIManagementException e) {
+            log.warn("Could not read tenant network access-control policy for $ref resolution; "
+                    + "proceeding with platform policy only.", e);
+        }
+
+        if (!allowList.isEmpty()) {
+            options.setRemoteRefAllowList(allowList);
+        }
+        if (!blockList.isEmpty()) {
+            options.setRemoteRefBlockList(blockList);
+        }
+        options.setNetworkAccessControlEnabled(policyConfigured);
+        return options;
     }
 
     /**

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/wsdl/AccessControlledUriResolver.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/wsdl/AccessControlledUriResolver.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.apimgt.impl.wsdl;
+
+import org.apache.woden.WSDLException;
+import org.apache.woden.internal.resolver.SimpleURIResolver;
+import org.apache.woden.resolver.URIResolver;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.wso2.carbon.apimgt.api.APIManagementException;
+import org.wso2.carbon.apimgt.impl.utils.APIUtil;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Woden {@link URIResolver} that gates every remote ({@code http}/{@code https}) nested WSDL/XSD
+ * reference ({@code wsdl:import}, {@code xsd:import}, {@code xsd:include}) through the network-security
+ * policy. Local and catalog references (e.g. Woden's bundled XML-Schema resources served by
+ * {@link SimpleURIResolver} as {@code jar:} URIs) are delegated unchanged. A reference whose target is
+ * rejected by the policy is redirected to a harmless local empty stub so the parser never opens a
+ * connection to the blocked host.
+ * <p>
+ * Note: returning {@code null} or throwing from a Woden resolver does NOT stop the fetch — Woden falls
+ * back to the raw URI. Only redirecting to a different URI prevents the outbound request.
+ */
+public class AccessControlledUriResolver implements URIResolver {
+
+    private static final Logger log = LoggerFactory.getLogger(AccessControlledUriResolver.class);
+
+    private static final String STUB_WSDL_RESOURCE = "/wsdl/blocked-reference.wsdl";
+    private static final String STUB_XSD_RESOURCE = "/wsdl/blocked-reference.xsd";
+    // Non-remote fallbacks used only if the bundled stub cannot be located: Woden opens these, so the
+    // worst case is a local parse failure (fail-closed), never a fetch of the blocked host.
+    private static final URI FALLBACK_WSDL_STUB = URI.create("file:/apim-blocked-reference.wsdl");
+    private static final URI FALLBACK_XSD_STUB = URI.create("file:/apim-blocked-reference.xsd");
+
+    private final URIResolver delegate;
+    private final String tenantDomain;
+    private final List<String> blockedReferences = new ArrayList<>();
+
+    public AccessControlledUriResolver(String tenantDomain) throws WSDLException {
+        this(new SimpleURIResolver(), tenantDomain);
+    }
+
+    AccessControlledUriResolver(URIResolver delegate, String tenantDomain) {
+        this.delegate = delegate;
+        this.tenantDomain = tenantDomain;
+    }
+
+    @Override
+    public URI resolveURI(URI uri) throws WSDLException, IOException {
+        URI resolved = delegate.resolveURI(uri);
+        // What Woden will actually open: the delegate's result, or the original URI if unmapped.
+        URI effective = (resolved != null) ? resolved : uri;
+        if (isRemote(effective)) {
+            try {
+                APIUtil.validateRemoteURL(effective.toString(), tenantDomain);
+            } catch (APIManagementException e) {
+                if (log.isDebugEnabled()) {
+                    log.debug("Blocked WSDL/XSD nested reference by network security policy: " + effective, e);
+                }
+                blockedReferences.add(effective.toString());
+                return stubFor(effective);
+            }
+        }
+        return resolved;
+    }
+
+    /** @return true if at least one remote reference was blocked by the policy during resolution. */
+    public boolean hasBlockedReferences() {
+        return !blockedReferences.isEmpty();
+    }
+
+    /** @return the remote reference URLs that were blocked by the policy (for user feedback / logging). */
+    public List<String> getBlockedReferences() {
+        return blockedReferences;
+    }
+
+    private static boolean isRemote(URI uri) {
+        String scheme = uri.getScheme();
+        return scheme != null && ("http".equalsIgnoreCase(scheme) || "https".equalsIgnoreCase(scheme));
+    }
+
+    /**
+     * Resolves the blocked reference to a bundled, non-remote stub URI. Never throws, never returns
+     * {@code null}, and never returns a remote URI, so a resolver return can never cause Woden to fall
+     * back to fetching the blocked host. If the bundled resource cannot be located/converted, a
+     * hardcoded non-remote fallback is returned (fail-closed).
+     */
+    private static URI stubFor(URI blocked) {
+        String path = blocked.getPath();
+        boolean xsd = path != null && path.toLowerCase().endsWith(".xsd");
+        String resource = xsd ? STUB_XSD_RESOURCE : STUB_WSDL_RESOURCE;
+        URI fallback = xsd ? FALLBACK_XSD_STUB : FALLBACK_WSDL_STUB;
+        try {
+            URL url = AccessControlledUriResolver.class.getResource(resource);
+            if (url != null) {
+                return url.toURI();
+            }
+            log.warn("Blocked-reference stub resource not found on classpath: " + resource
+                    + " — using non-remote fallback to keep the block fail-closed");
+        } catch (URISyntaxException e) {
+            log.warn("Could not convert blocked-reference stub resource to a URI: " + resource
+                    + " — using non-remote fallback", e);
+        }
+        return fallback;
+    }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/wsdl/AccessControlledUriResolver.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/wsdl/AccessControlledUriResolver.java
@@ -42,6 +42,10 @@ import java.util.List;
  * <p>
  * Note: returning {@code null} or throwing from a Woden resolver does NOT stop the fetch — Woden falls
  * back to the raw URI. Only redirecting to a different URI prevents the outbound request.
+ * <p>
+ * Known limitation: only the initially-referenced host is validated. If an allow-listed host responds with
+ * an HTTP redirect, Woden follows it using the JDK's default behavior without re-validating the redirect
+ * target — an accepted residual, consistent with the WSDL 1.1 remote-import fetcher ({@link RemoteSchemaFetcher}).
  */
 public class AccessControlledUriResolver implements URIResolver {
 

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/wsdl/AccessControlledWSDLLocator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/wsdl/AccessControlledWSDLLocator.java
@@ -1,0 +1,305 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.apimgt.impl.wsdl;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.wso2.carbon.apimgt.api.APIManagementException;
+import org.wso2.carbon.apimgt.impl.utils.APIFileUtil;
+import org.xml.sax.InputSource;
+
+import javax.wsdl.xml.WSDLLocator;
+import java.io.IOException;
+import java.io.StringReader;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * {@link WSDLLocator} that gates every nested WSDL 1.1 schema reference ({@code xsd:import},
+ * {@code xsd:include}, {@code xsd:redefine} {@code schemaLocation}) discovered by WSDL4J while parsing a
+ * WSDL 1.1 document.
+ * <p>
+ * A reference is classified as:
+ * <ul>
+ *     <li><b>REMOTE</b> — absolute {@code http}/{@code https}, or relative resolved against a remote
+ *     {@code parentLocation} — routed through the injected {@link RemoteSchemaFetcher}, which validates the
+ *     URL against the network-security access-control policy before fetching it.</li>
+ *     <li><b>LOCAL</b> — relative resolved against a local/archive {@code parentLocation} — contained to the
+ *     extracted WSDL archive root via {@link APIFileUtil#resolveFilePath(String, String)}.</li>
+ *     <li><b>LOCAL-ABSOLUTE</b> — a {@code file:} URI or an absolute filesystem path — always blocked; there
+ *     is nothing safe to anchor an absolute local path to.</li>
+ * </ul>
+ * A blocked reference is never surfaced as a fetch of the blocked target: it is recorded (for later
+ * reporting via {@link #hasBlockedReferences()} / {@link #getBlockedReferences()}) and a harmless empty
+ * schema stub is returned instead, so the WSDL4J parse degrades gracefully (the blocked types are simply
+ * omitted) rather than aborting outright — {@link #getImportInputSource(String, String)} never returns
+ * {@code null}.
+ */
+public class AccessControlledWSDLLocator implements WSDLLocator {
+
+    private static final Logger log = LoggerFactory.getLogger(AccessControlledWSDLLocator.class);
+
+    static final String EMPTY_SCHEMA_STUB = "<xsd:schema xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"/>";
+
+    private final String archiveRoot;
+    private final String baseUri;
+    private final RemoteSchemaFetcher fetcher;
+    private final List<String> blockedReferences = new ArrayList<>();
+
+    private String latestImportURI;
+
+    public AccessControlledWSDLLocator(String archiveRootOrNull, String baseUriOrNull, String tenantDomain) {
+        this(archiveRootOrNull, baseUriOrNull, new PolicyGatedSchemaFetcher(tenantDomain));
+    }
+
+    AccessControlledWSDLLocator(String archiveRootOrNull, String baseUriOrNull, RemoteSchemaFetcher fetcher) {
+        this.archiveRoot = archiveRootOrNull;
+        this.baseUri = baseUriOrNull;
+        this.fetcher = fetcher;
+    }
+
+    @Override
+    public InputSource getBaseInputSource() {
+        // Defensive: the readWSDL(WSDLLocator, Element) overload this locator is installed through never calls it.
+        InputSource source = new InputSource(new StringReader(EMPTY_SCHEMA_STUB));
+        source.setSystemId(baseUri);
+        return source;
+    }
+
+    @Override
+    public InputSource getImportInputSource(String parentLocation, String importLocation) {
+        Classification classification = classify(parentLocation, importLocation);
+        switch (classification.type) {
+        case REMOTE:
+            return fetchRemote(classification.effective);
+        case LOCAL:
+            return readLocal(parentLocation, classification.effective);
+        case LOCAL_ABSOLUTE:
+        default:
+            recordBlocked(importLocation);
+            return stub();
+        }
+    }
+
+    @Override
+    public String getBaseURI() {
+        return baseUri;
+    }
+
+    @Override
+    public String getLatestImportURI() {
+        return latestImportURI;
+    }
+
+    @Override
+    public void close() {
+    }
+
+    /** @return true if at least one nested reference was blocked by the policy during parsing. */
+    public boolean hasBlockedReferences() {
+        return !blockedReferences.isEmpty();
+    }
+
+    /** @return the nested reference locations that were blocked (for user feedback / logging). */
+    public List<String> getBlockedReferences() {
+        return blockedReferences;
+    }
+
+    /**
+     * Classifies {@code importLocation} relative to {@code parentLocation} to decide the routing.
+     */
+    private Classification classify(String parentLocation, String importLocation) {
+        if (isRemoteAbsolute(importLocation)) {
+            return new Classification(Type.REMOTE, importLocation);
+        }
+        if (isLocalAbsolute(importLocation)) {
+            return new Classification(Type.LOCAL_ABSOLUTE, importLocation);
+        }
+        if (isRemoteAbsolute(parentLocation)) {
+            String effective = resolveUri(parentLocation, importLocation);
+            // Re-check the scheme on the FINAL effective URL: a relative ref carrying its own absolute
+            // non-http(s) scheme (ftp:/jar:/file:) is unchanged by URI#resolve and must not inherit REMOTE.
+            if (effective == null || !isRemoteAbsolute(effective)) {
+                return new Classification(Type.LOCAL_ABSOLUTE, importLocation);
+            }
+            return new Classification(Type.REMOTE, effective);
+        }
+        return new Classification(Type.LOCAL, importLocation);
+    }
+
+    private InputSource fetchRemote(String effectiveUrl) {
+        try {
+            java.io.InputStream stream = fetcher.fetch(effectiveUrl);
+            latestImportURI = effectiveUrl;
+            InputSource source = new InputSource(stream);
+            source.setSystemId(effectiveUrl);
+            return source;
+        } catch (APIManagementException e) {
+            // Policy block (expected): record it and degrade to a harmless stub rather than aborting the parse.
+            recordBlocked(effectiveUrl);
+            return stub();
+        } catch (IOException e) {
+            // Transport error (timeout, 404), not a policy block: re-thrown (wrapped, no checked exceptions) so a
+            // broken reference fails the parse instead of silently "validating" with missing types.
+            throw new SchemaResolutionRuntimeException(e);
+        }
+    }
+
+    private InputSource readLocal(String parentLocation, String relativeRef) {
+        if (archiveRoot == null) {
+            // No archive root to anchor a relative local ref to (e.g. a pasted single WSDL) -> block.
+            recordBlocked(relativeRef);
+            return stub();
+        }
+        Path root = Paths.get(archiveRoot).toAbsolutePath().normalize();
+        Path candidate;
+        try {
+            // Resolve against the referring doc's dir (parentLocation); parentDirWithin clamps it to the archive root.
+            Path parentDir = parentDirWithin(parentLocation, root);
+            candidate = parentDir.resolve(relativeRef).normalize();
+        } catch (InvalidPathException e) {
+            // relativeRef is not a valid filesystem path fragment -> treat as a (non-fetch) block.
+            recordBlocked(relativeRef);
+            return stub();
+        }
+        try {
+            // Containment check via APIFileUtil.resolveFilePath: an escaping candidate is ".."-prefixed and rejected.
+            String rel = root.relativize(candidate).toString();
+            Path resolved = APIFileUtil.resolveFilePath(archiveRoot, rel);
+            latestImportURI = resolved.toUri().toString();
+            InputSource source = new InputSource(Files.newInputStream(resolved));
+            source.setSystemId(latestImportURI);
+            return source;
+        } catch (APIManagementException | IllegalArgumentException e) {
+            // Containment rejection (escape / incompatible root): fail-closed (non-fetch) block, recorded + stubbed.
+            recordBlocked(relativeRef);
+            return stub();
+        } catch (IOException e) {
+            // Unreadable in-archive file: not a policy block, so re-thrown (like fetchRemote) rather than stubbed.
+            throw new SchemaResolutionRuntimeException(e);
+        }
+    }
+
+    /**
+     * Derives the directory to resolve a relative local reference against: the directory of the REFERRING
+     * document ({@code parentLocation}), contained to the archive {@code root}. {@code parentLocation} may be
+     * a plain filesystem path (the top-level document base set by the processor) or a {@code file:} URI (a
+     * previously-resolved import's systemId — see {@code latestImportURI}). If it is blank, unparseable, has
+     * no parent, or resolves OUTSIDE the archive root, the archive root itself is returned — a defensive
+     * clamp so {@code parentLocation} can never widen the resolution base beyond the archive.
+     */
+    private static Path parentDirWithin(String parentLocation, Path root) {
+        if (parentLocation == null || parentLocation.trim().isEmpty()) {
+            return root;
+        }
+        try {
+            Path parentPath = (schemeOf(parentLocation) != null)
+                    ? Paths.get(URI.create(parentLocation))
+                    : Paths.get(parentLocation);
+            Path parentDir = parentPath.getParent();
+            if (parentDir == null) {
+                return root;
+            }
+            parentDir = parentDir.toAbsolutePath().normalize();
+            if (!parentDir.startsWith(root)) {
+                return root;
+            }
+            return parentDir;
+        } catch (RuntimeException e) {
+            // Unparseable/non-local parentLocation: fall back to the archive root rather than trusting it.
+            return root;
+        }
+    }
+
+    private void recordBlocked(String ref) {
+        if (log.isDebugEnabled()) {
+            log.debug("Blocked WSDL schema reference: " + ref);
+        }
+        blockedReferences.add(ref);
+        // WSDL4J looks up getLatestImportURI() in a Hashtable after every import, including blocked ones,
+        // and a null key throws NPE — so this must be set on every block path or the first block breaks the parse.
+        latestImportURI = (ref != null) ? ref : "urn:apim:blocked-reference";
+    }
+
+    private static InputSource stub() {
+        return new InputSource(new StringReader(EMPTY_SCHEMA_STUB));
+    }
+
+    private static boolean isRemoteAbsolute(String location) {
+        if (location == null) {
+            return false;
+        }
+        String scheme = schemeOf(location);
+        return "http".equalsIgnoreCase(scheme) || "https".equalsIgnoreCase(scheme);
+    }
+
+    private static boolean isLocalAbsolute(String location) {
+        if (location == null) {
+            return false;
+        }
+        String scheme = schemeOf(location);
+        if ("file".equalsIgnoreCase(scheme)) {
+            return true;
+        }
+        try {
+            return java.nio.file.Paths.get(location).isAbsolute();
+        } catch (java.nio.file.InvalidPathException e) {
+            return false;
+        }
+    }
+
+    private static String schemeOf(String location) {
+        try {
+            return new URI(location).getScheme();
+        } catch (URISyntaxException e) {
+            return null;
+        }
+    }
+
+    /**
+     * Resolves {@code importLocation} against a remote {@code parentLocation}, returning the fully-resolved
+     * absolute URI string, or {@code null} if resolution fails.
+     */
+    private static String resolveUri(String parentLocation, String importLocation) {
+        try {
+            return new URI(parentLocation).resolve(importLocation).toString();
+        } catch (URISyntaxException | IllegalArgumentException e) {
+            return null;
+        }
+    }
+
+    private enum Type {
+        REMOTE, LOCAL, LOCAL_ABSOLUTE
+    }
+
+    private static final class Classification {
+        private final Type type;
+        private final String effective;
+
+        private Classification(Type type, String effective) {
+            this.type = type;
+            this.effective = effective;
+        }
+    }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/wsdl/PolicyGatedSchemaFetcher.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/wsdl/PolicyGatedSchemaFetcher.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.apimgt.impl.wsdl;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.wso2.carbon.apimgt.api.APIConstants;
+import org.wso2.carbon.apimgt.api.APIManagementException;
+import org.wso2.carbon.apimgt.api.SizeLimitedInputStream;
+import org.wso2.carbon.apimgt.impl.internal.ServiceReferenceHolder;
+import org.wso2.carbon.apimgt.impl.utils.APIUtil;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+
+/**
+ * Policy-gated {@link RemoteSchemaFetcher} used to retrieve remote XML schema/WSDL documents (e.g. the
+ * WSDL 1.1 remote-import locator's nested {@code xsd:import}/{@code include} targets). The requested URL is
+ * validated against the network-security access-control policy ({@link APIUtil#validateRemoteURL(String,
+ * String)}) BEFORE a connection is opened to it, so a request that targets a blocked host is never made.
+ * <p>
+ * Redirect handling is intentionally out of scope: any redirect returned by the server is followed using
+ * the JDK's default behavior without re-validation, matching the accepted residual of the shipped WSDL 2.0
+ * gate. This class does not disable or loop over redirects itself.
+ * <p>
+ * The response body is wrapped in a {@link SizeLimitedInputStream} enforcing the same
+ * {@code API_PUBLISHER_IMPORT_WSDL_FILE_SIZE_LIMIT} configuration limit used by
+ * {@link WSDL11ProcessorImpl#init(URL)} for direct WSDL fetches, so a remote schema fetched through this
+ * class cannot be used to exhaust memory/disk.
+ */
+public class PolicyGatedSchemaFetcher implements RemoteSchemaFetcher {
+
+    private static final Logger log = LoggerFactory.getLogger(PolicyGatedSchemaFetcher.class);
+
+    private final String tenantDomain;
+    private final RemoteUrlValidator validator;
+    private final long maxFileSize;
+
+    public PolicyGatedSchemaFetcher(String tenantDomain) {
+        this(tenantDomain, APIUtil::validateRemoteURL);
+    }
+
+    PolicyGatedSchemaFetcher(String tenantDomain, RemoteUrlValidator validator) {
+        this(tenantDomain, validator, getMaxFileSize());
+    }
+
+    PolicyGatedSchemaFetcher(String tenantDomain, RemoteUrlValidator validator, long maxFileSize) {
+        this.tenantDomain = tenantDomain;
+        this.validator = validator;
+        this.maxFileSize = maxFileSize;
+    }
+
+    @Override
+    public InputStream fetch(String url) throws APIManagementException, IOException {
+        validator.validate(url, tenantDomain);
+        return new SizeLimitedInputStream(new URL(url).openStream(), maxFileSize);
+    }
+
+    /**
+     * Resolves the maximum allowed remote-schema body size, reusing the same configuration key
+     * ({@code API_PUBLISHER_IMPORT_WSDL_FILE_SIZE_LIMIT}) that {@link WSDL11ProcessorImpl#init(URL)} reads
+     * for direct WSDL fetches. Falls back to the same default if the value cannot be resolved.
+     * <p>
+     * The API Manager configuration service being unavailable (e.g. in unit tests, before OSGi wiring) is
+     * expected and falls back quietly. Any other failure (e.g. a non-numeric configured value) is
+     * unexpected and is logged at WARN so a misconfiguration is visible instead of silently falling back.
+     */
+    private static long getMaxFileSize() {
+        try {
+            String maxWSDLSizeStr = ServiceReferenceHolder.getInstance().getAPIManagerConfigurationService()
+                    .getAPIManagerConfiguration().getFirstProperty(
+                            APIConstants.API_PUBLISHER_IMPORT_WSDL_FILE_SIZE_LIMIT);
+            if (maxWSDLSizeStr == null || maxWSDLSizeStr.trim().isEmpty()) {
+                maxWSDLSizeStr = APIConstants.API_PUBLISHER_IMPORT_WSDL_FILE_SIZE_LIMIT_DEFAULT_MB;
+            }
+            return Long.parseLong(maxWSDLSizeStr) * 1024L * 1024L;
+        } catch (NullPointerException e) {
+            // The API Manager configuration service is not available (e.g. running outside OSGi in a unit
+            // test) — this is expected in that context, so fall back to the default quietly.
+            return defaultMaxFileSize();
+        } catch (NumberFormatException e) {
+            log.warn("Configured WSDL import file size limit ('" + APIConstants
+                    .API_PUBLISHER_IMPORT_WSDL_FILE_SIZE_LIMIT + "') is not a valid number — falling back to "
+                    + "the default of " + APIConstants.API_PUBLISHER_IMPORT_WSDL_FILE_SIZE_LIMIT_DEFAULT_MB
+                    + "MB", e);
+            return defaultMaxFileSize();
+        }
+    }
+
+    private static long defaultMaxFileSize() {
+        return Long.parseLong(APIConstants.API_PUBLISHER_IMPORT_WSDL_FILE_SIZE_LIMIT_DEFAULT_MB) * 1024L * 1024L;
+    }
+
+    /**
+     * Validates a URL against the network-security access-control policy before it is fetched. Extracted
+     * as a functional interface so tests can supply a fake without needing to mock {@link APIUtil}.
+     */
+    @FunctionalInterface
+    interface RemoteUrlValidator {
+        void validate(String url, String tenantDomain) throws APIManagementException;
+    }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/wsdl/PolicyGatedSchemaFetcher.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/wsdl/PolicyGatedSchemaFetcher.java
@@ -28,6 +28,7 @@ import org.wso2.carbon.apimgt.impl.utils.APIUtil;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
+import java.net.URLConnection;
 
 /**
  * Policy-gated {@link RemoteSchemaFetcher} used to retrieve remote XML schema/WSDL documents (e.g. the
@@ -43,14 +44,22 @@ import java.net.URL;
  * {@code API_PUBLISHER_IMPORT_WSDL_FILE_SIZE_LIMIT} configuration limit used by
  * {@link WSDL11ProcessorImpl#init(URL)} for direct WSDL fetches, so a remote schema fetched through this
  * class cannot be used to exhaust memory/disk.
+ * <p>
+ * The connection is opened with finite connect and read timeouts so a slow or unresponsive host cannot
+ * block the fetching thread indefinitely.
  */
 public class PolicyGatedSchemaFetcher implements RemoteSchemaFetcher {
 
     private static final Logger log = LoggerFactory.getLogger(PolicyGatedSchemaFetcher.class);
 
+    private static final int CONNECT_TIMEOUT_MILLIS = 10000;
+    private static final int READ_TIMEOUT_MILLIS = 30000;
+
     private final String tenantDomain;
     private final RemoteUrlValidator validator;
     private final long maxFileSize;
+    private final int connectTimeoutMillis;
+    private final int readTimeoutMillis;
 
     public PolicyGatedSchemaFetcher(String tenantDomain) {
         this(tenantDomain, APIUtil::validateRemoteURL);
@@ -61,15 +70,25 @@ public class PolicyGatedSchemaFetcher implements RemoteSchemaFetcher {
     }
 
     PolicyGatedSchemaFetcher(String tenantDomain, RemoteUrlValidator validator, long maxFileSize) {
+        this(tenantDomain, validator, maxFileSize, CONNECT_TIMEOUT_MILLIS, READ_TIMEOUT_MILLIS);
+    }
+
+    PolicyGatedSchemaFetcher(String tenantDomain, RemoteUrlValidator validator, long maxFileSize,
+            int connectTimeoutMillis, int readTimeoutMillis) {
         this.tenantDomain = tenantDomain;
         this.validator = validator;
         this.maxFileSize = maxFileSize;
+        this.connectTimeoutMillis = connectTimeoutMillis;
+        this.readTimeoutMillis = readTimeoutMillis;
     }
 
     @Override
     public InputStream fetch(String url) throws APIManagementException, IOException {
         validator.validate(url, tenantDomain);
-        return new SizeLimitedInputStream(new URL(url).openStream(), maxFileSize);
+        URLConnection connection = new URL(url).openConnection();
+        connection.setConnectTimeout(connectTimeoutMillis);
+        connection.setReadTimeout(readTimeoutMillis);
+        return new SizeLimitedInputStream(connection.getInputStream(), maxFileSize);
     }
 
     /**

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/wsdl/RemoteSchemaFetcher.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/wsdl/RemoteSchemaFetcher.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.apimgt.impl.wsdl;
+
+import org.wso2.carbon.apimgt.api.APIManagementException;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * Abstraction for fetching the body of a remote XML schema/WSDL document by URL, AFTER the requested URL's
+ * host has been validated against the network-security access-control policy. Implementations are expected
+ * to perform that validation before opening any connection, so callers (e.g. the WSDL 1.1 remote-import
+ * locator) never need to reason about network access-control safety themselves for the initial request.
+ * <p>
+ * Redirect targets are NOT re-validated: a redirect returned by the server is followed using the JDK's
+ * default behavior. This is an accepted residual, consistent with the shipped WSDL 2.0 gate — there is no
+ * per-hop revalidation and no "too many redirects" guarantee here.
+ */
+public interface RemoteSchemaFetcher {
+
+    /**
+     * Fetches the body of the given URL. The URL itself is validated against the network-security policy
+     * before the fetch; any redirect the server returns is then followed using JDK-default behavior without
+     * re-validating the redirect target.
+     *
+     * @param url the URL to fetch
+     * @return an {@link InputStream} over the response body
+     * @throws APIManagementException if the URL is blocked by network-security policy
+     * @throws IOException            if the fetch fails for a transport reason (e.g. connection failure)
+     */
+    InputStream fetch(String url) throws APIManagementException, IOException;
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/wsdl/SchemaResolutionRuntimeException.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/wsdl/SchemaResolutionRuntimeException.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.apimgt.impl.wsdl;
+
+/**
+ * Unchecked wrapper for a GENUINE (non-policy) failure to resolve or fetch a nested WSDL 1.1 schema
+ * reference from within {@link AccessControlledWSDLLocator} — e.g. a remote fetch transport error or a
+ * missing local file that nonetheless resolved safely inside the archive root.
+ * <p>
+ * {@link javax.wsdl.xml.WSDLLocator#getImportInputSource(String, String)} declares no checked exceptions, so
+ * such a failure cannot be thrown as-is. WSDL4J's {@code parseSchema} rethrows a {@link RuntimeException}
+ * escaping the locator <em>unwrapped</em> (its exception table does NOT convert it to a
+ * {@link javax.wsdl.WSDLException}), so this dedicated type lets {@link WSDL11ProcessorImpl}'s init methods
+ * catch precisely this failure — and only this one — and map it to {@code CANNOT_PROCESS_WSDL_CONTENT},
+ * without broadly swallowing every {@link RuntimeException}.
+ */
+class SchemaResolutionRuntimeException extends RuntimeException {
+
+    private static final long serialVersionUID = 1L;
+
+    SchemaResolutionRuntimeException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/wsdl/WSDL11ProcessorImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/wsdl/WSDL11ProcessorImpl.java
@@ -114,19 +114,29 @@ public class WSDL11ProcessorImpl extends AbstractWSDLProcessor {
         // switch off the verbose mode
         wsdlReader.setFeature(JAVAX_WSDL_VERBOSE_MODE, false);
         wsdlReader.setFeature(JAVAX_WSDL_IMPORT_DOCUMENTS, false);
+        AccessControlledWSDLLocator locator = new AccessControlledWSDLLocator(null, null, resolveTenantDomain());
         try {
-            wsdlDefinition = wsdlReader.readWSDL(null, getSecuredParsedDocumentFromContent(wsdlContent));
+            wsdlDefinition = wsdlReader.readWSDL(locator, getSecuredParsedDocumentFromContent(wsdlContent)
+                    .getDocumentElement());
             if (log.isDebugEnabled()) {
                 log.debug("Successfully initialized an instance of " + this.getClass().getSimpleName()
                         + " with a single WSDL.");
             }
         } catch (WSDLException | APIManagementException e) {
-            //This implementation class cannot process the WSDL.
             log.debug("Cannot process the WSDL by " + this.getClass().getName(), e);
             setError(new ErrorItem(ExceptionCodes.CANNOT_PROCESS_WSDL_CONTENT.getErrorMessage(), e.getMessage(),
                     ExceptionCodes.CANNOT_PROCESS_WSDL_CONTENT.getErrorCode(),
                     ExceptionCodes.CANNOT_PROCESS_WSDL_CONTENT.getHttpStatusCode()));
+        } catch (SchemaResolutionRuntimeException e) {
+            // Genuine (non-policy) resolution failure (policy blocks are reported separately). The cause may carry
+            // a URL or local path, so log it server-side only and keep the client ErrorItem generic.
+            log.warn("Genuine failure while resolving a nested WSDL schema reference", e.getCause());
+            setError(new ErrorItem(ExceptionCodes.CANNOT_PROCESS_WSDL_CONTENT.getErrorMessage(),
+                    ExceptionCodes.CANNOT_PROCESS_WSDL_CONTENT.getErrorDescription(),
+                    ExceptionCodes.CANNOT_PROCESS_WSDL_CONTENT.getErrorCode(),
+                    ExceptionCodes.CANNOT_PROCESS_WSDL_CONTENT.getHttpStatusCode()));
         }
+        reportBlockedReferencesIfAny(locator);
         return !hasError;
     }
 
@@ -138,6 +148,23 @@ public class WSDL11ProcessorImpl extends AbstractWSDLProcessor {
         // switch off the verbose mode
         wsdlReader.setFeature(JAVAX_WSDL_VERBOSE_MODE, false);
         wsdlReader.setFeature(JAVAX_WSDL_IMPORT_DOCUMENTS, false);
+        // For a file: URL, contain relative refs to the WSDL's parent dir so a sibling schema resolves while
+        // resolveFilePath blocks traversal/absolute paths; a remote WSDL leaves it null and uses the gated fetcher.
+        String archiveRoot = null;
+        if ("file".equalsIgnoreCase(url.getProtocol())) {
+            try {
+                java.nio.file.Path parent = java.nio.file.Paths.get(url.toURI()).getParent();
+                // A file: WSDL at the filesystem root has parent "/"; using it as the containment root
+                // would be vacuous, so leave archiveRoot null (block relative local refs).
+                if (parent != null && parent.normalize().getNameCount() > 0) {
+                    archiveRoot = parent.toString();
+                }
+            } catch (Exception e) {
+                // leave archiveRoot null -> relative local refs are blocked, as before this fix.
+            }
+        }
+        AccessControlledWSDLLocator locator = new AccessControlledWSDLLocator(archiveRoot, url.toString(),
+                resolveTenantDomain());
         try {
             String maxWSDLSizeStr = ServiceReferenceHolder.getInstance().getAPIManagerConfigurationService()
                     .getAPIManagerConfiguration().getFirstProperty(
@@ -146,7 +173,8 @@ public class WSDL11ProcessorImpl extends AbstractWSDLProcessor {
                 maxWSDLSizeStr = org.wso2.carbon.apimgt.api.APIConstants.API_PUBLISHER_IMPORT_WSDL_FILE_SIZE_LIMIT_DEFAULT_MB;
             }
             long maxFileSize = Long.parseLong(maxWSDLSizeStr) * 1024L * 1024L;
-            wsdlDefinition = wsdlReader.readWSDL(url.toString(), getSecuredParsedDocumentFromURL(url, maxFileSize));
+            wsdlDefinition = wsdlReader.readWSDL(locator, getSecuredParsedDocumentFromURL(url, maxFileSize)
+                    .getDocumentElement());
             if (log.isDebugEnabled()) {
                 log.debug("Successfully initialized an instance of " + this.getClass().getSimpleName()
                         + " with a single WSDL.");
@@ -166,7 +194,19 @@ public class WSDL11ProcessorImpl extends AbstractWSDLProcessor {
                         ExceptionCodes.CANNOT_PROCESS_WSDL_CONTENT.getErrorCode(),
                         ExceptionCodes.CANNOT_PROCESS_WSDL_CONTENT.getHttpStatusCode()));
             }
+        } catch (SchemaResolutionRuntimeException e) {
+            // Genuine (non-policy) failure -- see the init(byte[]) catch above. The cause may carry the attempted
+            // remote URL, so it is logged server-side only and kept out of the client-facing ErrorItem.
+            if (log.isDebugEnabled()) {
+                log.debug("Cannot process the WSDL by " + this.getClass().getName(), e);
+            }
+            log.warn("Genuine failure while resolving a nested WSDL schema reference", e.getCause());
+            setError(new ErrorItem(ExceptionCodes.CANNOT_PROCESS_WSDL_CONTENT.getErrorMessage(),
+                    ExceptionCodes.CANNOT_PROCESS_WSDL_CONTENT.getErrorDescription(),
+                    ExceptionCodes.CANNOT_PROCESS_WSDL_CONTENT.getErrorCode(),
+                    ExceptionCodes.CANNOT_PROCESS_WSDL_CONTENT.getHttpStatusCode()));
         }
+        reportBlockedReferencesIfAny(locator);
         return !hasError;
     }
 
@@ -177,6 +217,10 @@ public class WSDL11ProcessorImpl extends AbstractWSDLProcessor {
         wsdlArchiveExtractedPath = path;
         WSDLReader wsdlReader = getWsdlFactoryInstance().newWSDLReader();
 
+        boolean anyBlocked = false;
+        // Declared outside the try/loop so the catch clause below can still inspect the in-flight file's
+        // locator if readWSDL blows up mid-loop.
+        AccessControlledWSDLLocator locator = null;
         try {
             // switch off the verbose mode
             wsdlReader.setFeature(JAVAX_WSDL_VERBOSE_MODE, false);
@@ -186,13 +230,17 @@ public class WSDL11ProcessorImpl extends AbstractWSDLProcessor {
             if (log.isDebugEnabled()) {
                 log.debug("Found " + foundWSDLFiles.size() + " WSDL file(s) in path " + path);
             }
+            String tenantDomain = resolveTenantDomain();
             for (File file : foundWSDLFiles) {
                 String absWSDLPath = file.getAbsolutePath();
                 if (log.isDebugEnabled()) {
                     log.debug("Processing WSDL file: " + absWSDLPath);
                 }
-                Definition definition = wsdlReader.readWSDL(absWSDLPath, getSecuredParsedDocumentFromPath(absWSDLPath));
+                locator = new AccessControlledWSDLLocator(path, absWSDLPath, tenantDomain);
+                Definition definition = wsdlReader.readWSDL(locator, getSecuredParsedDocumentFromPath(absWSDLPath)
+                        .getDocumentElement());
                 pathToDefinitionMap.put(absWSDLPath, definition);
+                anyBlocked |= locator.hasBlockedReferences();
 
                 // set the first found WSDL as wsdlDefinition variable assuming that it is the root WSDL
                 if (wsdlDefinition == null) {
@@ -211,6 +259,21 @@ public class WSDL11ProcessorImpl extends AbstractWSDLProcessor {
             setError(new ErrorItem(ExceptionCodes.CANNOT_PROCESS_WSDL_CONTENT.getErrorMessage(), e.getMessage(),
                     ExceptionCodes.CANNOT_PROCESS_WSDL_CONTENT.getErrorCode(),
                     ExceptionCodes.CANNOT_PROCESS_WSDL_CONTENT.getHttpStatusCode()));
+        } catch (SchemaResolutionRuntimeException e) {
+            // Genuine (non-policy) failure (see init(byte[]) above). The cause may carry a local path or URL, so
+            // log it server-side only; the debug path below is the caller's own archive path, not the offending ref.
+            log.debug(this.getClass().getName() + " was unable to process the WSDL Files for the path: " + path, e);
+            log.warn("Genuine failure while resolving a nested WSDL schema reference", e.getCause());
+            setError(new ErrorItem(ExceptionCodes.CANNOT_PROCESS_WSDL_CONTENT.getErrorMessage(),
+                    ExceptionCodes.CANNOT_PROCESS_WSDL_CONTENT.getErrorDescription(),
+                    ExceptionCodes.CANNOT_PROCESS_WSDL_CONTENT.getErrorCode(),
+                    ExceptionCodes.CANNOT_PROCESS_WSDL_CONTENT.getHttpStatusCode()));
+        }
+        if (locator != null && locator.hasBlockedReferences()) {
+            anyBlocked = true;
+        }
+        if (anyBlocked) {
+            setError(ExceptionCodes.UNTRUSTED_URL_IN_DEFINITION);
         }
         return !hasError;
     }
@@ -538,5 +601,20 @@ public class WSDL11ProcessorImpl extends AbstractWSDLProcessor {
     private void setError(ErrorHandler error) {
         this.hasError = true;
         this.error = error;
+    }
+
+    private String resolveTenantDomain() {
+        return WsdlTenantResolver.resolveTenantDomain();
+    }
+
+    /**
+     * If the locator blocked any nested schema reference by the network-security policy (or by the
+     * archive-containment/local-absolute rules), report it to the user as {@link ExceptionCodes#UNTRUSTED_URL}
+     * (parity with the WSDL 2.0 / OpenAPI $ref case).
+     */
+    private void reportBlockedReferencesIfAny(AccessControlledWSDLLocator locator) {
+        if (locator != null && locator.hasBlockedReferences()) {
+            setError(ExceptionCodes.UNTRUSTED_URL_IN_DEFINITION);
+        }
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/wsdl/WSDL11SOAPOperationExtractor.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/wsdl/WSDL11SOAPOperationExtractor.java
@@ -43,6 +43,7 @@ import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import org.wso2.carbon.apimgt.api.APIManagementException;
+import org.wso2.carbon.apimgt.api.ExceptionCodes;
 import org.wso2.carbon.apimgt.impl.utils.APIFileUtil;
 import org.wso2.carbon.apimgt.impl.wsdl.exceptions.APIMgtWSDLException;
 import org.wso2.carbon.apimgt.impl.wsdl.model.WSDLInfo;
@@ -54,6 +55,7 @@ import org.wso2.carbon.apimgt.impl.wsdl.util.SOAPOperationBindingUtils;
 import org.wso2.carbon.apimgt.impl.wsdl.util.SOAPToRESTConstants;
 import org.wso2.carbon.apimgt.impl.wsdl.util.SwaggerFieldsExcludeStrategy;
 import org.wso2.carbon.apimgt.impl.utils.APIMWSDLReader;
+import org.wso2.carbon.apimgt.impl.utils.APIUtil;
 import javax.wsdl.extensions.schema.SchemaImport;
 import javax.wsdl.extensions.schema.SchemaReference;
 import javax.wsdl.extensions.soap12.SOAP12Operation;
@@ -306,6 +308,10 @@ public class WSDL11SOAPOperationExtractor extends WSDL11ProcessorImpl {
                     try {
                         traverseTypeElement(node, null, model, currentProperty);
                     } catch (APIManagementException e) {
+                        if (e.getErrorHandler() != null) {
+                            // preserve UNTRUSTED_URL (and any coded error) so it surfaces to the user
+                            throw new APIMgtWSDLException(e.getMessage(), e, e.getErrorHandler());
+                        }
                         throw new APIMgtWSDLException(e);
                     }
                     if (StringUtils.isNotBlank(model.getName())) {
@@ -500,17 +506,31 @@ public class WSDL11SOAPOperationExtractor extends WSDL11ProcessorImpl {
         }
     }
 
-    private Document getBasedXSDofWSDL(String ns) {
+    private Document getBasedXSDofWSDL(String ns) throws APIManagementException {
         if (basedSchemas.containsKey(ns)) {
             return basedSchemas.get(ns);
         }
-        Document doc = null;
-        APIMWSDLReader reader = new APIMWSDLReader(ns + ".xsd");
+        String schemaUrl = ns + ".xsd";
+        // Gate this namespace-derived remote fetch through the network access-control policy before opening a
+        // connection; no-op when unconfigured, else a blocked/internal host throws UNTRUSTED_URL to fail the import.
+        String tenantDomain = WsdlTenantResolver.resolveTenantDomain();
         try {
-            doc = reader.getSecuredParsedDocumentFromURL(ns + ".xsd");
+            APIUtil.validateRemoteURL(schemaUrl, tenantDomain);
         } catch (APIManagementException e) {
-            String error = "Error occurred reading wsdl document.";
-            log.error(error, e);
+            // namespace-derived xsd fetch is an EMBEDDED reference -> definition-scoped message.
+            if (ExceptionCodes.UNTRUSTED_URL.equals(e.getErrorHandler())) {
+                throw new APIManagementException(e.getMessage(), e, ExceptionCodes.UNTRUSTED_URL_IN_DEFINITION);
+            }
+            throw e;
+        }
+
+        Document doc = null;
+        APIMWSDLReader reader = new APIMWSDLReader(schemaUrl);
+        try {
+            doc = reader.getSecuredParsedDocumentFromURL(schemaUrl);
+        } catch (APIManagementException e) {
+            // Genuine fetch/parse failure (not a policy block) — best-effort, swallow as before.
+            log.error("Error occurred reading wsdl document: " + schemaUrl, e);
         }
         basedSchemas.put(ns, doc);
         return doc;

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/wsdl/WSDL20ProcessorImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/wsdl/WSDL20ProcessorImpl.java
@@ -100,11 +100,12 @@ public class WSDL20ProcessorImpl extends AbstractWSDLProcessor {
         WSDLReader reader;
         try {
             reader = WSDLFactory.newInstance().newWSDLReader();
+            reader.setFeature(WSDLReader.FEATURE_VALIDATION, false);
+            reader.setURIResolver(new AccessControlledUriResolver(resolveTenantDomain()));
         } catch (WSDLException e) {
             throw new APIMgtWSDLException("Error while initializing the WSDL reader", e);
         }
 
-        reader.setFeature(WSDLReader.FEATURE_VALIDATION, false);
         try {
             String maxWSDLSizeStr = ServiceReferenceHolder.getInstance().getAPIManagerConfigurationService()
                     .getAPIManagerConfiguration()
@@ -123,6 +124,7 @@ public class WSDL20ProcessorImpl extends AbstractWSDLProcessor {
                     ExceptionCodes.CANNOT_PROCESS_WSDL_CONTENT.getErrorCode(),
                     ExceptionCodes.CANNOT_PROCESS_WSDL_CONTENT.getHttpStatusCode()));
         }
+        reportBlockedReferencesIfAny(reader);
         return !hasError;
     }
 
@@ -132,11 +134,12 @@ public class WSDL20ProcessorImpl extends AbstractWSDLProcessor {
         WSDLReader reader;
         try {
             reader = getWsdlFactoryInstance().newWSDLReader();
+            reader.setFeature(WSDLReader.FEATURE_VALIDATION, false);
+            reader.setURIResolver(new AccessControlledUriResolver(resolveTenantDomain()));
         } catch (WSDLException e) {
             throw new APIMgtWSDLException("Error while initializing the WSDL reader", e);
         }
 
-        reader.setFeature(WSDLReader.FEATURE_VALIDATION, false);
         Document document = getSecuredParsedDocumentFromContent(wsdlContent);
         WSDLSource wsdlSource = getWSDLSourceFromDocument(document, reader);
         try {
@@ -152,6 +155,7 @@ public class WSDL20ProcessorImpl extends AbstractWSDLProcessor {
                     ExceptionCodes.CANNOT_PROCESS_WSDL_CONTENT.getErrorCode(),
                     ExceptionCodes.CANNOT_PROCESS_WSDL_CONTENT.getHttpStatusCode()));
         }
+        reportBlockedReferencesIfAny(reader);
         return !hasError;
     }
 
@@ -163,11 +167,12 @@ public class WSDL20ProcessorImpl extends AbstractWSDLProcessor {
         WSDLReader reader;
         try {
             reader = getWsdlFactoryInstance().newWSDLReader();
+            reader.setFeature(WSDLReader.FEATURE_VALIDATION, false);
+            reader.setURIResolver(new AccessControlledUriResolver(resolveTenantDomain()));
         } catch (WSDLException e) {
             throw new APIMgtWSDLException("Error while initializing the WSDL reader", e);
         }
 
-        reader.setFeature(WSDLReader.FEATURE_VALIDATION, false);
         File folderToImport = new File(path);
         Collection<File> foundWSDLFiles = APIFileUtil.searchFilesWithMatchingExtension(folderToImport, "wsdl");
         if (log.isDebugEnabled()) {
@@ -198,6 +203,7 @@ public class WSDL20ProcessorImpl extends AbstractWSDLProcessor {
                     ExceptionCodes.CANNOT_PROCESS_WSDL_CONTENT.getErrorCode(),
                     ExceptionCodes.CANNOT_PROCESS_WSDL_CONTENT.getHttpStatusCode()));
         }
+        reportBlockedReferencesIfAny(reader);
         return !hasError;
     }
 
@@ -391,6 +397,21 @@ public class WSDL20ProcessorImpl extends AbstractWSDLProcessor {
         return serviceEndpointMap;
     }
 
+    private String resolveTenantDomain() {
+        return WsdlTenantResolver.resolveTenantDomain();
+    }
+
+    /**
+     * If the resolver blocked any remote nested reference by the network-security policy, report it to
+     * the user as {@link ExceptionCodes#UNTRUSTED_URL} (parity with the OpenAPI $ref case).
+     */
+    private void reportBlockedReferencesIfAny(WSDLReader reader) {
+        if (reader.getURIResolver() instanceof AccessControlledUriResolver
+                && ((AccessControlledUriResolver) reader.getURIResolver()).hasBlockedReferences()) {
+            setError(ExceptionCodes.UNTRUSTED_URL_IN_DEFINITION);
+        }
+    }
+
     private void setError(ErrorHandler error) {
         this.hasError = true;
         this.error = error;
@@ -400,6 +421,16 @@ public class WSDL20ProcessorImpl extends AbstractWSDLProcessor {
         endpoint.setAddress(uri);
     }
 
+    /*
+     * Network access-control note (WSDL 2.0 nested schema-import vector): this builds Woden's WSDLSource from a raw DOM
+     * element and never calls wsdlSource.setBaseURI(...). With a null document base URI, Woden aborts
+     * inline-schema parsing (WSDL521, "missing base URI") before it ever walks into <types> to discover
+     * a nested <xsd:import>/<xsd:include> schemaLocation -- so, unlike WSDL 1.1 (where WSDL4J DID fetch
+     * such nested locations, gated via AccessControlledWSDLLocator), an untrusted nested
+     * schemaLocation here is never dereferenced. Absolute <wsdl:import>/<wsdl:include> is a separate,
+     * still-reachable vector and remains gated by AccessControlledUriResolver (see
+     * WSDL20ProcessorImplResolverTest). Regression-locked by WSDL20SchemaImportNonReachableTest.
+     */
     private WSDLSource getWSDLSourceFromDocument(Document document, WSDLReader reader) {
         Element domElement = document.getDocumentElement();
         WSDLSource wsdlSource = reader.createWSDLSource();

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/wsdl/WsdlTenantResolver.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/wsdl/WsdlTenantResolver.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.apimgt.impl.wsdl;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.wso2.carbon.base.MultitenantConstants;
+import org.wso2.carbon.context.PrivilegedCarbonContext;
+
+/**
+ * Resolves the current tenant domain for gating WSDL/schema references through the network access-control
+ * policy. Falls back to the super tenant domain when no CarbonContext is available on the current thread
+ * (e.g. a non-request or pooled thread), so a missing thread-local degrades gracefully instead of failing
+ * the parse/import. This only selects WHICH tenant's policy applies; it never bypasses the gate.
+ */
+final class WsdlTenantResolver {
+
+    private static final Logger log = LoggerFactory.getLogger(WsdlTenantResolver.class);
+
+    private WsdlTenantResolver() {
+    }
+
+    static String resolveTenantDomain() {
+        try {
+            return PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain();
+        } catch (NullPointerException e) {
+            log.warn("CarbonContext tenant domain was unavailable while resolving the tenant for WSDL/schema "
+                    + "reference policy evaluation; falling back to the super tenant domain ("
+                    + MultitenantConstants.SUPER_TENANT_DOMAIN_NAME + ").");
+            return MultitenantConstants.SUPER_TENANT_DOMAIN_NAME;
+        }
+    }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/resources/wsdl/blocked-reference.wsdl
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/resources/wsdl/blocked-reference.wsdl
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<description xmlns="http://www.w3.org/ns/wsdl"
+             xmlns:xs="http://www.w3.org/2001/XMLSchema"
+             targetNamespace="urn:apim:blocked-reference">
+  <types><xs:schema targetNamespace="urn:apim:blocked-reference"/></types>
+</description>

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/resources/wsdl/blocked-reference.xsd
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/resources/wsdl/blocked-reference.xsd
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="urn:apim:blocked-reference"/>

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/utils/APIUtilRefOptionsTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/utils/APIUtilRefOptionsTest.java
@@ -16,6 +16,7 @@
 
 package org.wso2.carbon.apimgt.impl.utils;
 
+import org.json.simple.JSONObject;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -23,7 +24,10 @@ import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 import org.powermock.reflect.Whitebox;
+import org.wso2.carbon.apimgt.api.APIManagementException;
+import org.wso2.carbon.apimgt.api.ExceptionCodes;
 import org.wso2.carbon.apimgt.api.model.OASParserOptions;
+import org.wso2.carbon.apimgt.impl.APIConstants;
 
 import java.util.Arrays;
 
@@ -120,5 +124,47 @@ public class APIUtilRefOptionsTest {
 
         Assert.assertEquals(base.getYamlCodePointLimit(), out.getYamlCodePointLimit());
         Assert.assertNotEquals(Integer.valueOf(Integer.MAX_VALUE), out.getYamlCodePointLimit());
+    }
+
+    @Test
+    public void testInvalidModePlatformThrowsMisconfigured() throws Exception {
+        // An enabled platform policy whose mode is neither 'allow' nor 'deny' must fail fast rather than silently
+        // producing empty lists, matching the behaviour of the runtime access-control check.
+        PowerMockito.spy(APIUtil.class);
+        PowerMockito.doReturn(null).when(APIUtil.class, "getTenantConfig", TENANT);
+        Whitebox.setInternalState(APIUtil.class, "networkSecurityEnabled", true);
+        Whitebox.setInternalState(APIUtil.class, "networkSecurityMode", "block");
+        Whitebox.setInternalState(APIUtil.class, "networkSecurityHosts", Arrays.asList("*.wso2.com"));
+        Whitebox.setInternalState(APIUtil.class, "networkSecurityBlockPrivateAccess", true);
+
+        try {
+            APIUtil.buildRefResolutionOptions(new OASParserOptions(), TENANT);
+            Assert.fail("An invalid platform mode must raise a misconfiguration error");
+        } catch (APIManagementException e) {
+            Assert.assertEquals(ExceptionCodes.NETWORK_SECURITY_ACCESS_CONTROL_MISCONFIGURED, e.getErrorHandler());
+        }
+    }
+
+    @Test
+    public void testInvalidModeTenantThrowsMisconfigured() throws Exception {
+        // An enabled tenant policy with an invalid mode must also propagate a misconfiguration error instead of being
+        // swallowed by the tenant-config read guard.
+        PowerMockito.spy(APIUtil.class);
+        JSONObject policy = new JSONObject();
+        policy.put(APIConstants.NetworkSecurityAccessControl.TENANT_MODE, "block");
+        JSONObject tenantConfig = new JSONObject();
+        tenantConfig.put(APIConstants.NetworkSecurityAccessControl.TENANT_CONFIG_KEY, policy);
+        PowerMockito.doReturn(tenantConfig).when(APIUtil.class, "getTenantConfig", TENANT);
+        Whitebox.setInternalState(APIUtil.class, "networkSecurityEnabled", false);
+        Whitebox.setInternalState(APIUtil.class, "networkSecurityMode", (String) null);
+        Whitebox.setInternalState(APIUtil.class, "networkSecurityHosts", (java.util.List) null);
+        Whitebox.setInternalState(APIUtil.class, "networkSecurityBlockPrivateAccess", false);
+
+        try {
+            APIUtil.buildRefResolutionOptions(new OASParserOptions(), TENANT);
+            Assert.fail("An invalid tenant mode must raise a misconfiguration error");
+        } catch (APIManagementException e) {
+            Assert.assertEquals(ExceptionCodes.NETWORK_SECURITY_ACCESS_CONTROL_MISCONFIGURED, e.getErrorHandler());
+        }
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/utils/APIUtilRefOptionsTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/utils/APIUtilRefOptionsTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.carbon.apimgt.impl.utils;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.powermock.reflect.Whitebox;
+import org.wso2.carbon.apimgt.api.model.OASParserOptions;
+
+import java.util.Arrays;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({APIUtil.class})
+public class APIUtilRefOptionsTest {
+
+    private static final String TENANT = "carbon.super";
+
+    @Test
+    public void testAllowModePlatformProducesAllowList() throws Exception {
+        PowerMockito.spy(APIUtil.class);
+        PowerMockito.doReturn(null).when(APIUtil.class, "getTenantConfig", TENANT);
+        Whitebox.setInternalState(APIUtil.class, "networkSecurityEnabled", true);
+        Whitebox.setInternalState(APIUtil.class, "networkSecurityMode", "allow");
+        Whitebox.setInternalState(APIUtil.class, "networkSecurityHosts", Arrays.asList("*.wso2.com"));
+        Whitebox.setInternalState(APIUtil.class, "networkSecurityBlockPrivateAccess", true);
+
+        OASParserOptions out = APIUtil.buildRefResolutionOptions(new OASParserOptions(), TENANT);
+
+        Assert.assertEquals(Arrays.asList("*.wso2.com"), out.getRemoteRefAllowList());
+        Assert.assertTrue(out.getRemoteRefBlockList() == null || out.getRemoteRefBlockList().isEmpty());
+        Assert.assertTrue("A configured platform policy must enable network access control",
+                out.isNetworkAccessControlEnabled());
+    }
+
+    @Test
+    public void testDenyModePlatformProducesBlockList() throws Exception {
+        PowerMockito.spy(APIUtil.class);
+        PowerMockito.doReturn(null).when(APIUtil.class, "getTenantConfig", TENANT);
+        Whitebox.setInternalState(APIUtil.class, "networkSecurityEnabled", true);
+        Whitebox.setInternalState(APIUtil.class, "networkSecurityMode", "deny");
+        Whitebox.setInternalState(APIUtil.class, "networkSecurityHosts", Arrays.asList("*.internal"));
+        Whitebox.setInternalState(APIUtil.class, "networkSecurityBlockPrivateAccess", true);
+
+        OASParserOptions out = APIUtil.buildRefResolutionOptions(new OASParserOptions(), TENANT);
+
+        Assert.assertEquals(Arrays.asList("*.internal"), out.getRemoteRefBlockList());
+        Assert.assertTrue(out.getRemoteRefAllowList() == null || out.getRemoteRefAllowList().isEmpty());
+        Assert.assertTrue("A configured platform policy must enable network access control",
+                out.isNetworkAccessControlEnabled());
+    }
+
+    @Test
+    public void testInactivePolicyProducesEmptyLists() throws Exception {
+        PowerMockito.spy(APIUtil.class);
+        PowerMockito.doReturn(null).when(APIUtil.class, "getTenantConfig", TENANT);
+        Whitebox.setInternalState(APIUtil.class, "networkSecurityEnabled", false);
+        Whitebox.setInternalState(APIUtil.class, "networkSecurityMode", (String) null);
+        Whitebox.setInternalState(APIUtil.class, "networkSecurityHosts", (java.util.List) null);
+        Whitebox.setInternalState(APIUtil.class, "networkSecurityBlockPrivateAccess", false);
+
+        OASParserOptions out = APIUtil.buildRefResolutionOptions(new OASParserOptions(), TENANT);
+
+        Assert.assertTrue(out.getRemoteRefAllowList() == null || out.getRemoteRefAllowList().isEmpty());
+        Assert.assertTrue(out.getRemoteRefBlockList() == null || out.getRemoteRefBlockList().isEmpty());
+        // Backwards compatibility: with no policy configured, network access control must stay off so remote refs
+        // resolve exactly as they did before the feature existed.
+        Assert.assertFalse("No configured policy must leave network access control disabled",
+                out.isNetworkAccessControlEnabled());
+    }
+
+    @Test
+    public void testPlatformPolicyEnabledWithoutHostsStillEnablesNetworkAccessControl() throws Exception {
+        // The policy block can be present with no hosts (e.g. only block_private_network_access set). Presence of the
+        // block alone means the admin opted in, so network access control is on even though both lists are empty.
+        PowerMockito.spy(APIUtil.class);
+        PowerMockito.doReturn(null).when(APIUtil.class, "getTenantConfig", TENANT);
+        Whitebox.setInternalState(APIUtil.class, "networkSecurityEnabled", true);
+        Whitebox.setInternalState(APIUtil.class, "networkSecurityMode", (String) null);
+        Whitebox.setInternalState(APIUtil.class, "networkSecurityHosts", (java.util.List) null);
+        Whitebox.setInternalState(APIUtil.class, "networkSecurityBlockPrivateAccess", true);
+
+        OASParserOptions out = APIUtil.buildRefResolutionOptions(new OASParserOptions(), TENANT);
+
+        Assert.assertTrue(out.getRemoteRefAllowList() == null || out.getRemoteRefAllowList().isEmpty());
+        Assert.assertTrue(out.getRemoteRefBlockList() == null || out.getRemoteRefBlockList().isEmpty());
+        Assert.assertTrue(out.isNetworkAccessControlEnabled());
+    }
+
+    @Test
+    public void testYamlCodePointLimitPreserved() throws Exception {
+        PowerMockito.spy(APIUtil.class);
+        PowerMockito.doReturn(null).when(APIUtil.class, "getTenantConfig", TENANT);
+        Whitebox.setInternalState(APIUtil.class, "networkSecurityEnabled", false);
+        Whitebox.setInternalState(APIUtil.class, "networkSecurityMode", (String) null);
+        Whitebox.setInternalState(APIUtil.class, "networkSecurityHosts", (java.util.List) null);
+        Whitebox.setInternalState(APIUtil.class, "networkSecurityBlockPrivateAccess", false);
+
+        OASParserOptions base = new OASParserOptions();
+        base.setYamlCodePointLimit("10");
+
+        OASParserOptions out = APIUtil.buildRefResolutionOptions(base, TENANT);
+
+        Assert.assertEquals(base.getYamlCodePointLimit(), out.getYamlCodePointLimit());
+        Assert.assertNotEquals(Integer.valueOf(Integer.MAX_VALUE), out.getYamlCodePointLimit());
+    }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/wsdl/AccessControlledUriResolverTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/wsdl/AccessControlledUriResolverTest.java
@@ -1,0 +1,84 @@
+package org.wso2.carbon.apimgt.impl.wsdl;
+
+import org.apache.woden.resolver.URIResolver;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.wso2.carbon.apimgt.api.APIManagementException;
+import org.wso2.carbon.apimgt.api.ExceptionCodes;
+import org.wso2.carbon.apimgt.impl.utils.APIUtil;
+
+import java.net.URI;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({APIUtil.class})
+public class AccessControlledUriResolverTest {
+
+    /** delegate that never maps anything (simulates a URI not in Woden's catalog). */
+    private URIResolver passThroughDelegate() {
+        return uri -> null;
+    }
+
+    @Test
+    public void blockedRemoteUriIsRedirectedToLocalStub() throws Exception {
+        PowerMockito.mockStatic(APIUtil.class);
+        PowerMockito.doThrow(new APIManagementException("URL is not trusted", ExceptionCodes.UNTRUSTED_URL))
+                .when(APIUtil.class);
+        APIUtil.validateRemoteURL(Mockito.anyString(), Mockito.anyString());
+
+        AccessControlledUriResolver resolver =
+                new AccessControlledUriResolver(passThroughDelegate(), "carbon.super");
+
+        URI out = resolver.resolveURI(URI.create("http://169.254.169.254/latest/meta.xsd"));
+
+        // Blocked reference must resolve to a non-remote stub or Woden would fetch the raw URL; scheme is
+        // file:/jar: depending on packaging, so assert "not remote" rather than a specific scheme.
+        assertNotNull("blocked reference must resolve to a non-null stub", out);
+        assertFalse("blocked reference must NOT resolve to a remote URL",
+                "http".equalsIgnoreCase(out.getScheme()) || "https".equalsIgnoreCase(out.getScheme()));
+        assertNotEquals("169.254.169.254", out.getHost());
+        assertTrue("blocked URL must be recorded for user feedback",
+                resolver.getBlockedReferences().contains("http://169.254.169.254/latest/meta.xsd"));
+    }
+
+    @Test
+    public void allowedRemoteUriPassesThroughAfterValidation() throws Exception {
+        PowerMockito.mockStatic(APIUtil.class); // validateRemoteURL is a no-op (allowed)
+
+        AccessControlledUriResolver resolver =
+                new AccessControlledUriResolver(passThroughDelegate(), "carbon.super");
+
+        // delegate returns null -> resolver returns null -> Woden opens the original (allowed) URI
+        URI out = resolver.resolveURI(URI.create("http://api.github.com/schema.xsd"));
+        assertNull(out);
+
+        PowerMockito.verifyStatic(APIUtil.class);
+        APIUtil.validateRemoteURL("http://api.github.com/schema.xsd", "carbon.super");
+    }
+
+    @Test
+    public void localCatalogUriIsReturnedWithoutPolicyCheck() throws Exception {
+        PowerMockito.mockStatic(APIUtil.class);
+        URI local = URI.create("jar:file:/woden.jar!/org/apache/woden/resolver/XMLSchema.xsd");
+        URIResolver catalogDelegate = uri -> local; // simulate a catalog hit
+
+        AccessControlledUriResolver resolver =
+                new AccessControlledUriResolver(catalogDelegate, "carbon.super");
+
+        URI out = resolver.resolveURI(URI.create("http://www.w3.org/2001/XMLSchema.xsd"));
+        assertEquals(local, out);
+
+        PowerMockito.verifyStatic(APIUtil.class, Mockito.never());
+        APIUtil.validateRemoteURL(Mockito.anyString(), Mockito.anyString());
+    }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/wsdl/AccessControlledUriResolverTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/wsdl/AccessControlledUriResolverTest.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.wso2.carbon.apimgt.impl.wsdl;
 
 import org.apache.woden.resolver.URIResolver;

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/wsdl/AccessControlledWSDLLocatorTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/wsdl/AccessControlledWSDLLocatorTest.java
@@ -1,0 +1,251 @@
+package org.wso2.carbon.apimgt.impl.wsdl;
+
+import org.apache.commons.io.IOUtils;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.wso2.carbon.apimgt.api.APIManagementException;
+import org.wso2.carbon.apimgt.api.ExceptionCodes;
+import org.xml.sax.InputSource;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class AccessControlledWSDLLocatorTest {
+
+    @Rule
+    public TemporaryFolder tmp = new TemporaryFolder();
+
+    // local ref inside archive resolves to the real file
+    @Test
+    public void resolvesInArchiveRelativeRef() throws Exception {
+        File root = tmp.getRoot();
+        File child = new File(root, "types.xsd");
+        Files.writeString(child.toPath(), "<xsd:schema xmlns:xsd='http://www.w3.org/2001/XMLSchema' id='inarchive'/>");
+        AccessControlledWSDLLocator loc = new AccessControlledWSDLLocator(
+                root.getAbsolutePath(), new File(root, "service.wsdl").getAbsolutePath(),
+                (u) -> { throw new AssertionError("no remote"); });
+        InputSource is = loc.getImportInputSource(new File(root, "service.wsdl").getAbsolutePath(), "types.xsd");
+        assertTrue(read(is).contains("inarchive"));
+        assertFalse(loc.hasBlockedReferences());
+    }
+
+    // traversal escaping the archive is blocked (recorded + stub, no exception, no file read)
+    @Test
+    public void blocksArchiveEscape() throws Exception {
+        AccessControlledWSDLLocator loc = new AccessControlledWSDLLocator(
+                tmp.getRoot().getAbsolutePath(), null, (u) -> { throw new AssertionError("no remote"); });
+        InputSource is = loc.getImportInputSource(tmp.getRoot().getAbsolutePath(), "../../../../etc/hostname");
+        assertTrue(read(is).contains("xsd:schema"));      // harmless stub
+        assertTrue(loc.hasBlockedReferences());
+    }
+
+    // absolute file: ref is blocked
+    @Test
+    public void blocksAbsoluteFileRef() throws Exception {
+        AccessControlledWSDLLocator loc = new AccessControlledWSDLLocator(
+                tmp.getRoot().getAbsolutePath(), null, (u) -> { throw new AssertionError("no remote"); });
+        loc.getImportInputSource(tmp.getRoot().getAbsolutePath(), "file:///etc/passwd");
+        assertTrue(loc.hasBlockedReferences());
+        assertTrue(loc.getBlockedReferences().contains("file:///etc/passwd"));
+    }
+
+    // no archive root: any local ref blocked
+    @Test
+    public void blocksLocalRefWhenNoArchiveRoot() throws Exception {
+        AccessControlledWSDLLocator loc = new AccessControlledWSDLLocator(null, null,
+                (u) -> { throw new AssertionError("no remote"); });
+        loc.getImportInputSource(null, "sibling.xsd");
+        assertTrue(loc.hasBlockedReferences());
+        assertTrue(loc.getBlockedReferences().contains("sibling.xsd"));
+    }
+
+    // A relative import whose scheme is not http/https (e.g. ftp:) is already an absolute URI, so URI#resolve
+    // returns it unchanged; it must be blocked (not inherit the remote parent) and the fetcher must never run.
+    @Test
+    public void blocksNonHttpSchemeUnderRemoteParent() throws Exception {
+        AccessControlledWSDLLocator loc = new AccessControlledWSDLLocator(null, "http://h/dir/root.wsdl",
+                (u) -> {
+                    throw new AssertionError("fetcher must not be invoked for a non-http/https scheme: " + u);
+                });
+        InputSource is = loc.getImportInputSource("http://h/dir/root.wsdl", "ftp://internal/x.xsd");
+        assertTrue(read(is).contains("xsd:schema"));   // harmless stub
+        assertTrue(loc.hasBlockedReferences());
+        assertTrue(loc.getBlockedReferences().contains("ftp://internal/x.xsd"));
+    }
+
+    // Same gap, another absolute scheme: "jar:http://internal/x.jar!/y.xsd" is opaque-but-absolute, so it
+    // also resolves ~unchanged against an http/https parent and must be blocked rather than fetched.
+    @Test
+    public void blocksJarSchemeUnderRemoteParent() throws Exception {
+        AccessControlledWSDLLocator loc = new AccessControlledWSDLLocator(null, "http://h/dir/root.wsdl",
+                (u) -> {
+                    throw new AssertionError("fetcher must not be invoked for a non-http/https scheme: " + u);
+                });
+        InputSource is = loc.getImportInputSource("http://h/dir/root.wsdl", "jar:http://internal/x.jar!/y.xsd");
+        assertTrue(read(is).contains("xsd:schema"));   // harmless stub
+        assertTrue(loc.hasBlockedReferences());
+    }
+
+    // A genuine (non-policy) fetch failure must propagate out of getImportInputSource rather than
+    // silently degrading to a stub -- it must NOT be recorded as a blocked reference either.
+    @Test
+    public void propagatesGenuineFetchFailure() {
+        AccessControlledWSDLLocator loc = new AccessControlledWSDLLocator(null, null,
+                (u) -> { throw new IOException("boom"); });
+        try {
+            loc.getImportInputSource(null, "http://trusted.example/a.xsd");
+            fail("expected getImportInputSource to propagate the genuine fetch failure");
+        } catch (RuntimeException e) {
+            assertTrue(e.getCause() instanceof IOException);
+        }
+        assertFalse(loc.hasBlockedReferences());
+    }
+
+    // A reference that resolves safely INSIDE the archive root but does not exist on
+    // disk is a genuine failure (Files.newInputStream throws), not a policy block -- it must propagate too.
+    @Test
+    public void propagatesMissingContainedLocalFile() {
+        File root = tmp.getRoot();
+        AccessControlledWSDLLocator loc = new AccessControlledWSDLLocator(
+                root.getAbsolutePath(), new File(root, "service.wsdl").getAbsolutePath(),
+                (u) -> { throw new AssertionError("no remote"); });
+        try {
+            loc.getImportInputSource(new File(root, "service.wsdl").getAbsolutePath(), "present.xsd");
+            fail("expected getImportInputSource to propagate the missing-file failure");
+        } catch (RuntimeException e) {
+            assertTrue(e.getCause() instanceof IOException);
+        }
+        assertFalse(loc.hasBlockedReferences());
+    }
+
+    // remote allowed: delegates to fetcher, records latestImportURI, not blocked
+    @Test
+    public void fetchesAllowedRemoteRef() throws Exception {
+        AccessControlledWSDLLocator loc = new AccessControlledWSDLLocator(null, null,
+                (u) -> new ByteArrayInputStream(
+                        "<xsd:schema xmlns:xsd='http://www.w3.org/2001/XMLSchema' id='remote'/>".getBytes()));
+        InputSource is = loc.getImportInputSource(null, "http://trusted.example/a.xsd");
+        assertTrue(read(is).contains("remote"));
+        assertEquals("http://trusted.example/a.xsd", loc.getLatestImportURI());
+        assertFalse(loc.hasBlockedReferences());
+    }
+
+    // remote blocked: fetcher throws -> recorded + stub, no exception out of getImportInputSource
+    @Test
+    public void blocksUntrustedRemoteRef() throws Exception {
+        AccessControlledWSDLLocator loc = new AccessControlledWSDLLocator(null, null,
+                (u) -> { throw new APIManagementException(ExceptionCodes.UNTRUSTED_URL); });
+        InputSource is = loc.getImportInputSource(null, "http://169.254.169.254/x.xsd");
+        assertTrue(read(is).contains("xsd:schema"));   // stub
+        assertTrue(loc.hasBlockedReferences());
+    }
+
+    // Every block path must set latestImportURI to a non-null value -- WSDL4J's parseSchema looks it
+    // up in a java.util.Hashtable after each import, and a null key NPEs there.
+    @Test
+    public void blockSetsNonNullLatestImportURI() throws Exception {
+        AccessControlledWSDLLocator remoteBlocked = new AccessControlledWSDLLocator(null, null,
+                (u) -> { throw new APIManagementException(ExceptionCodes.UNTRUSTED_URL); });
+        assertEquals(null, remoteBlocked.getLatestImportURI());
+        remoteBlocked.getImportInputSource(null, "http://169.254.169.254/x.xsd");
+        assertTrue(remoteBlocked.getLatestImportURI() != null);
+
+        AccessControlledWSDLLocator archiveEscape = new AccessControlledWSDLLocator(
+                tmp.getRoot().getAbsolutePath(), null, (u) -> { throw new AssertionError("no remote"); });
+        archiveEscape.getImportInputSource(tmp.getRoot().getAbsolutePath(), "../x");
+        assertTrue(archiveEscape.getLatestImportURI() != null);
+    }
+
+    // multi-level chaining: latestImportURI feeds the next parentLocation
+    @Test
+    public void chainsNestedRelativeRefViaLatestImportURI() throws Exception {
+        // level-1 relative remote via remote base, then a second relative resolved against latestImportURI
+        AccessControlledWSDLLocator loc = new AccessControlledWSDLLocator(null, "http://h/dir/root.wsdl",
+                (u) -> new ByteArrayInputStream(
+                        "<xsd:schema xmlns:xsd='http://www.w3.org/2001/XMLSchema'/>".getBytes()));
+        loc.getImportInputSource("http://h/dir/root.wsdl", "a/one.xsd");
+        assertEquals("http://h/dir/a/one.xsd", loc.getLatestImportURI());
+        loc.getImportInputSource(loc.getLatestImportURI(), "../two.xsd");
+        assertEquals("http://h/dir/two.xsd", loc.getLatestImportURI());
+    }
+
+    // A relative ref is resolved against the REFERRING document's directory (parentLocation's parent),
+    // not the fixed archive root. With a same-named decoy at the root, the SUBDIR sibling must win.
+    @Test
+    public void resolvesRefRelativeToParentDir() throws Exception {
+        File root = tmp.getRoot();
+        File subdir = new File(root, "sub");
+        assertTrue(subdir.mkdirs());
+        Files.writeString(new File(subdir, "sibling.xsd").toPath(),
+                "<xsd:schema xmlns:xsd='http://www.w3.org/2001/XMLSchema' id='insubdir'/>");
+        // decoy with the same name at the archive root -- must NOT be the one resolved
+        Files.writeString(new File(root, "sibling.xsd").toPath(),
+                "<xsd:schema xmlns:xsd='http://www.w3.org/2001/XMLSchema' id='atroot'/>");
+        AccessControlledWSDLLocator loc = new AccessControlledWSDLLocator(
+                root.getAbsolutePath(), new File(subdir, "a.xsd").getAbsolutePath(),
+                (u) -> { throw new AssertionError("no remote"); });
+        InputSource is = loc.getImportInputSource(new File(subdir, "a.xsd").getAbsolutePath(), "sibling.xsd");
+        String content = read(is);
+        assertTrue("must resolve the SUBDIR sibling, not the root decoy", content.contains("insubdir"));
+        assertFalse(content.contains("atroot"));
+        assertFalse(loc.hasBlockedReferences());
+    }
+
+    // A scheme-relative ref ("//somehost/x.xsd") under a remote parent must be blocked, not read as a local
+    // file: Paths.get reports it absolute, so classify() marks it LOCAL_ABSOLUTE and blocks before the fetcher.
+    @Test
+    public void blocksSchemeRelativeAuthorityRefUnderRemoteParent() throws Exception {
+        AccessControlledWSDLLocator loc = new AccessControlledWSDLLocator(null, "http://h/dir/root.wsdl",
+                (u) -> {
+                    throw new AssertionError("fetcher must not be invoked for a scheme-relative ref: " + u);
+                });
+        InputSource is = loc.getImportInputSource("http://h/dir/root.wsdl", "//somehost/x.xsd");
+        assertTrue(read(is).contains("xsd:schema"));   // harmless stub, not a local file's content
+        assertTrue(loc.hasBlockedReferences());
+        assertTrue(loc.getBlockedReferences().contains("//somehost/x.xsd"));
+    }
+
+    // After ONE reference is blocked, a second, unrelated, legitimate reference resolved via the SAME locator
+    // instance must still resolve correctly -- the block must not leave state that corrupts a later lookup.
+    @Test
+    public void blockedReferenceDoesNotCorruptSubsequentSiblingResolution() throws Exception {
+        File root = tmp.getRoot();
+        Files.writeString(new File(root, "sibling.xsd").toPath(),
+                "<xsd:schema xmlns:xsd='http://www.w3.org/2001/XMLSchema' id='sibling'/>");
+        AccessControlledWSDLLocator loc = new AccessControlledWSDLLocator(
+                root.getAbsolutePath(), new File(root, "service.wsdl").getAbsolutePath(),
+                (u) -> { throw new AssertionError("no remote"); });
+
+        // First import: a traversal outside the archive root -> blocked.
+        InputSource blocked = loc.getImportInputSource(
+                new File(root, "service.wsdl").getAbsolutePath(), "../../../../etc/hostname");
+        assertTrue(read(blocked).contains("xsd:schema"));   // harmless stub
+        assertTrue(loc.hasBlockedReferences());
+
+        // Second import: an unrelated, legitimate in-archive sibling -> must still resolve to the real file.
+        InputSource legit = loc.getImportInputSource(
+                new File(root, "service.wsdl").getAbsolutePath(), "sibling.xsd");
+        assertTrue("the blocked first import must not corrupt resolution of the unrelated second import",
+                read(legit).contains("id='sibling'"));
+        assertEquals(1, loc.getBlockedReferences().size());
+        assertTrue(loc.getBlockedReferences().get(0).contains("etc/hostname"));
+    }
+
+    // ---- test helpers ----
+
+    private static String read(InputSource is) throws IOException {
+        if (is.getCharacterStream() != null) {
+            return IOUtils.toString(is.getCharacterStream());
+        }
+        return IOUtils.toString(is.getByteStream(), StandardCharsets.UTF_8);
+    }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/wsdl/AccessControlledWSDLLocatorTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/wsdl/AccessControlledWSDLLocatorTest.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.wso2.carbon.apimgt.impl.wsdl;
 
 import org.apache.commons.io.IOUtils;

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/wsdl/PolicyGatedSchemaFetcherTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/wsdl/PolicyGatedSchemaFetcherTest.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.wso2.carbon.apimgt.impl.wsdl;
 
 import com.sun.net.httpserver.HttpExchange;
@@ -15,6 +33,7 @@ import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 public class PolicyGatedSchemaFetcherTest {
@@ -52,6 +71,33 @@ public class PolicyGatedSchemaFetcherTest {
                 fail("expected size-limit failure");
             } catch (Exception expected) {
                 // SizeLimitedInputStream aborts past the cap
+            }
+        } finally {
+            s.stop(0);
+        }
+    }
+
+    // slow host: a finite read timeout aborts the fetch quickly instead of blocking indefinitely
+    @Test
+    public void readTimeoutAbortsSlowFetch() throws Exception {
+        HttpServer s = server(ctx -> {
+            try {
+                Thread.sleep(2000);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            respond(ctx, 200, "SLOW");
+        });
+        try {
+            long start = System.nanoTime();
+            try {
+                new PolicyGatedSchemaFetcher("carbon.super", (u, t) -> { /* allow all */ }, 1_000_000L, 1000, 200)
+                        .fetch(base(s) + "/slow.xsd");
+                fail("expected read timeout");
+            } catch (IOException expected) {
+                long elapsedMillis = (System.nanoTime() - start) / 1_000_000L;
+                assertTrue("fetch should abort well before the server responds, took " + elapsedMillis + "ms",
+                        elapsedMillis < 1500);
             }
         } finally {
             s.stop(0);

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/wsdl/PolicyGatedSchemaFetcherTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/wsdl/PolicyGatedSchemaFetcherTest.java
@@ -1,0 +1,95 @@
+package org.wso2.carbon.apimgt.impl.wsdl;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+import org.apache.commons.io.IOUtils;
+import org.junit.Test;
+import org.wso2.carbon.apimgt.api.APIManagementException;
+import org.wso2.carbon.apimgt.api.ExceptionCodes;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+public class PolicyGatedSchemaFetcherTest {
+
+    // allowed fetch returns body
+    @Test
+    public void fetchesAllowedUrl() throws Exception {
+        HttpServer s = server(ctx -> respond(ctx, 200, "HELLO"));
+        try {
+            String body = read(new PolicyGatedSchemaFetcher("carbon.super", (u, t) -> { /* allow all */ })
+                    .fetch(base(s) + "/x.xsd"));
+            assertEquals("HELLO", body);
+        } finally {
+            s.stop(0);
+        }
+    }
+
+    // untrusted host: validator throws -> propagates, host never fetched
+    @Test(expected = APIManagementException.class)
+    public void blocksUntrustedHost() throws Exception {
+        new PolicyGatedSchemaFetcher("carbon.super",
+                (u, t) -> { throw new APIManagementException(ExceptionCodes.UNTRUSTED_URL); })
+                .fetch("http://169.254.169.254/x.xsd");
+    }
+
+    // size cap actually rejects oversized bodies (inject a small cap; do not loosen prod default)
+    @Test
+    public void rejectsOversizedBody() throws Exception {
+        HttpServer s = server(ctx -> respond(ctx, 200, "X".repeat(10_000)));
+        try {
+            InputStream in = new PolicyGatedSchemaFetcher("carbon.super", (u, t) -> {}, 100L)
+                    .fetch(base(s) + "/big.xsd");
+            try {
+                read(in);
+                fail("expected size-limit failure");
+            } catch (Exception expected) {
+                // SizeLimitedInputStream aborts past the cap
+            }
+        } finally {
+            s.stop(0);
+        }
+    }
+
+    // ---- test helpers ----
+
+    private static HttpServer server(HttpHandler handler) throws IOException {
+        HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.createContext("/", handler);
+        server.start();
+        return server;
+    }
+
+    private static String base(HttpServer s) {
+        return "http://127.0.0.1:" + s.getAddress().getPort();
+    }
+
+    private static void respond(HttpExchange ctx, int status, String body) {
+        try {
+            byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
+            ctx.sendResponseHeaders(status, bytes.length);
+            try (OutputStream os = ctx.getResponseBody()) {
+                os.write(bytes);
+            }
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        } finally {
+            ctx.close();
+        }
+    }
+
+    private static String read(InputStream in) throws IOException {
+        try {
+            return IOUtils.toString(in, StandardCharsets.UTF_8);
+        } finally {
+            IOUtils.closeQuietly(in);
+        }
+    }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/wsdl/WSDL11ProcessorAccessControlIntegrationTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/wsdl/WSDL11ProcessorAccessControlIntegrationTest.java
@@ -1,0 +1,480 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.apimgt.impl.wsdl;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.wso2.carbon.apimgt.api.ExceptionCodes;
+import org.wso2.carbon.apimgt.impl.APIManagerConfiguration;
+import org.wso2.carbon.apimgt.impl.APIManagerConfigurationServiceImpl;
+import org.wso2.carbon.apimgt.impl.config.APIMConfigService;
+import org.wso2.carbon.apimgt.impl.internal.ServiceReferenceHolder;
+import org.wso2.carbon.context.PrivilegedCarbonContext;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * End-to-end network access-control wiring tests for {@link WSDL11ProcessorImpl}: proves that every entry point
+ * (init(byte[]), init(URL), initPath) routes nested WSDL 1.1 schema imports through
+ * {@link AccessControlledWSDLLocator} rather than the raw WSDL4J default locator.
+ * <p>
+ * No PowerMock, no network-security policy configuration is applied here: the block proofs rely on
+ * references that {@link org.wso2.carbon.apimgt.impl.utils.APIFileUtil#resolveFilePath(String, String)} /
+ * the locator's own classification reject unconditionally (local traversal, file: URIs, pasted-relative
+ * refs with no archive root) -- independent of any policy state. The remote-allowed test relies on
+ * {@code validateRemoteURL} being a no-op when no policy is configured (backwards-compat), proving the
+ * wiring still resolves legitimate remote schemas.
+ */
+public class WSDL11ProcessorAccessControlIntegrationTest {
+
+    @Rule
+    public TemporaryFolder tmp = new TemporaryFolder();
+
+    private static final String XSD_BODY =
+            "<xsd:schema targetNamespace=\"urn:c\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"/>";
+
+    // Wire the real collaborators the init paths need outside OSGi: an empty APIManagerConfiguration, a started tenant
+    // flow for resolveTenantDomain, and a no-op APIMConfigService so validateRemoteURL takes its no-policy no-op path.
+    @Before
+    public void wireApiManagerConfigurationService() {
+        ServiceReferenceHolder.getInstance().setAPIManagerConfigurationService(
+                new APIManagerConfigurationServiceImpl(new APIManagerConfiguration()));
+        ServiceReferenceHolder.getInstance().setAPIMConfigService(new NoOpApimConfigService());
+        PrivilegedCarbonContext.startTenantFlow();
+        PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantId(-1234); // super tenant, no resolution
+        PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantDomain("carbon.super");
+    }
+
+    /** Trivial no-op {@link APIMConfigService}: no tenant config stored for any organization. */
+    private static final class NoOpApimConfigService implements APIMConfigService {
+        @Override
+        public void addExternalStoreConfig(String organization, String externalStoreConfig) { }
+
+        @Override
+        public void updateExternalStoreConfig(String organization, String externalStoreConfig) { }
+
+        @Override
+        public String getExternalStoreConfig(String organization) {
+            return null;
+        }
+
+        @Override
+        public void addTenantConfig(String organization, String tenantConfig) { }
+
+        @Override
+        public String getTenantConfig(String organization) {
+            return null;
+        }
+
+        @Override
+        public void updateTenantConfig(String organization, String tenantConfig) { }
+
+        @Override
+        public String getWorkFlowConfig(String organization) {
+            return null;
+        }
+
+        @Override
+        public void updateWorkflowConfig(String organization, String workflowConfig) { }
+
+        @Override
+        public void addWorkflowConfig(String organization, String workflowConfig) { }
+
+        @Override
+        public String getGAConfig(String organization) {
+            return null;
+        }
+
+        @Override
+        public void updateGAConfig(String organization, String gaConfig) { }
+
+        @Override
+        public void addGAConfig(String organization, String gaConfig) { }
+
+        @Override
+        public Object getSelfSighupConfig(String organization) {
+            return null;
+        }
+
+        @Override
+        public void updateSelfSighupConfig(String organization, String selfSignUpConfig) { }
+
+        @Override
+        public void addSelfSighupConfig(String organization, String selfSignUpConfig) { }
+    }
+
+    @After
+    public void endTenantFlow() {
+        PrivilegedCarbonContext.endTenantFlow();
+    }
+
+    // ---- fixture helpers -------------------------------------------------
+
+    private static String wsdlWithXsdImport(String schemaLocation) {
+        return "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+                + "<wsdl:definitions xmlns:wsdl=\"http://schemas.xmlsoap.org/wsdl/\"\n"
+                + "                  xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"\n"
+                + "                  xmlns:tns=\"urn:poc\"\n"
+                + "                  targetNamespace=\"urn:poc\">\n"
+                + "  <wsdl:types>\n"
+                + "    <xsd:schema targetNamespace=\"urn:poc\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\">\n"
+                + "      <xsd:import namespace=\"urn:c\" schemaLocation=\"" + schemaLocation + "\"/>\n"
+                + "    </xsd:schema>\n"
+                + "  </wsdl:types>\n"
+                + "  <wsdl:message name=\"req\"/>\n"
+                + "  <wsdl:portType name=\"pt\"/>\n"
+                + "</wsdl:definitions>\n";
+    }
+
+    /** A minimal WSDL 1.1 document with no {@code xsd:import} at all -- nothing for the locator to gate. */
+    private static final String PLAIN_WSDL_NO_IMPORTS =
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+                    + "<wsdl:definitions xmlns:wsdl=\"http://schemas.xmlsoap.org/wsdl/\"\n"
+                    + "                  xmlns:tns=\"urn:poc\"\n"
+                    + "                  targetNamespace=\"urn:poc\">\n"
+                    + "  <wsdl:message name=\"req\"/>\n"
+                    + "  <wsdl:portType name=\"pt\"/>\n"
+                    + "</wsdl:definitions>\n";
+
+    private static String wsdlWithTwoXsdImports(String firstSchemaLocation, String secondNamespace,
+            String secondSchemaLocation) {
+        return "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+                + "<wsdl:definitions xmlns:wsdl=\"http://schemas.xmlsoap.org/wsdl/\"\n"
+                + "                  xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"\n"
+                + "                  xmlns:tns=\"urn:poc\"\n"
+                + "                  targetNamespace=\"urn:poc\">\n"
+                + "  <wsdl:types>\n"
+                + "    <xsd:schema targetNamespace=\"urn:poc\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\">\n"
+                + "      <xsd:import namespace=\"urn:c\" schemaLocation=\"" + firstSchemaLocation + "\"/>\n"
+                + "      <xsd:import namespace=\"" + secondNamespace + "\" schemaLocation=\""
+                + secondSchemaLocation + "\"/>\n"
+                + "    </xsd:schema>\n"
+                + "  </wsdl:types>\n"
+                + "  <wsdl:message name=\"req\"/>\n"
+                + "  <wsdl:portType name=\"pt\"/>\n"
+                + "</wsdl:definitions>\n";
+    }
+
+    private File extractedArchiveWith(String wsdlXml) throws IOException {
+        File dir = tmp.newFolder("archive-" + System.nanoTime());
+        Files.write(new File(dir, "service.wsdl").toPath(), wsdlXml.getBytes(StandardCharsets.UTF_8));
+        return dir;
+    }
+
+    private File extractedArchiveWithSiblingXsd() throws IOException {
+        File dir = extractedArchiveWith(wsdlWithXsdImport("types.xsd"));
+        String typesXsd =
+                "<xsd:schema targetNamespace=\"urn:c\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"/>";
+        Files.write(new File(dir, "types.xsd").toPath(), typesXsd.getBytes(StandardCharsets.UTF_8));
+        return dir;
+    }
+
+    /** A standalone XSD (targetNamespace urn:c) that itself imports another schema. */
+    private static String schemaImporting(String importNamespace, String schemaLocation) {
+        return "<xsd:schema targetNamespace=\"urn:c\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\">\n"
+                + "  <xsd:import namespace=\"" + importNamespace + "\" schemaLocation=\"" + schemaLocation + "\"/>\n"
+                + "</xsd:schema>";
+    }
+
+    /** A leaf XSD with no nested imports. */
+    private static String leafSchema(String namespace) {
+        return "<xsd:schema targetNamespace=\"" + namespace + "\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"/>";
+    }
+
+    private static void write(File file, String content) throws IOException {
+        Files.write(file.toPath(), content.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private HttpServer server(HttpHandler handler) throws IOException {
+        HttpServer httpServer = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        httpServer.createContext("/", handler);
+        httpServer.start();
+        return httpServer;
+    }
+
+    private static void respond(HttpExchange exchange, int status, String body) throws IOException {
+        byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
+        exchange.sendResponseHeaders(status, bytes.length);
+        exchange.getResponseBody().write(bytes);
+        exchange.close();
+    }
+
+    private static int port(HttpServer httpServer) {
+        return httpServer.getAddress().getPort();
+    }
+
+    // ---- tests -------------------------------------------------------
+
+    // initPath: local traversal xsd:import is blocked end-to-end -> UNTRUSTED_URL, file NOT read
+    @Test
+    public void archiveTraversalSchemaImportBlocked() throws Exception {
+        File dir = extractedArchiveWith(wsdlWithXsdImport("../../../../../../etc/hostname"));
+        WSDL11ProcessorImpl p = new WSDL11ProcessorImpl();
+        boolean ok = p.initPath(dir.getAbsolutePath());
+        assertFalse(ok);
+        assertTrue(p.hasError());
+        assertEquals(900405, p.getError().getErrorCode());   // UNTRUSTED_URL surfaced via reportBlockedReferencesIfAny
+    }
+
+    // initPath: remote xsd:import IS fetched when no policy configured (no-op) -> wiring resolves remote schemas
+    @Test
+    public void archiveRemoteSchemaImportFetchedWhenAllowed() throws Exception {
+        AtomicInteger hits = new AtomicInteger();
+        HttpServer canary = server(ctx -> { hits.incrementAndGet(); respond(ctx, 200, XSD_BODY); });
+        File dir = extractedArchiveWith(wsdlWithXsdImport("http://127.0.0.1:" + port(canary) + "/c.xsd"));
+        try {
+            WSDL11ProcessorImpl p = new WSDL11ProcessorImpl();
+            p.initPath(dir.getAbsolutePath());
+            assertTrue("no policy -> remote schema fetched (backwards-compat)", hits.get() >= 1);
+            assertFalse(p.hasError());
+        } finally {
+            canary.stop(0);
+        }
+    }
+
+    // initPath: legitimate in-archive relative schema still resolves (no error)
+    @Test
+    public void archiveLocalSchemaImportStillWorks() throws Exception {
+        File dir = extractedArchiveWithSiblingXsd();   // service.wsdl + types.xsd, schemaLocation="types.xsd"
+        WSDL11ProcessorImpl p = new WSDL11ProcessorImpl();
+        assertTrue(p.initPath(dir.getAbsolutePath()));
+        assertFalse(p.hasError());
+    }
+
+    // init(byte[]): pasted WSDL with a local (relative) xsd:import has no archive root -> blocked -> UNTRUSTED_URL
+    @Test
+    public void pastedLocalSchemaImportBlocked() throws Exception {
+        byte[] wsdl = wsdlWithXsdImport("types.xsd").getBytes(StandardCharsets.UTF_8);
+        WSDL11ProcessorImpl p = new WSDL11ProcessorImpl();
+        p.init(wsdl);
+        assertTrue(p.hasError());
+        assertEquals(900405, p.getError().getErrorCode());
+    }
+
+    // A bare Thread does not inherit the @Before tenant flow (non-inheritable ThreadLocal); resolveTenantDomain's
+    // NPE-fallback must let init(byte[]) still succeed when there is no xsd:import to gate.
+    @Test
+    public void initSucceedsOnThreadWithoutTenantFlow() throws Exception {
+        byte[] wsdl = PLAIN_WSDL_NO_IMPORTS.getBytes(StandardCharsets.UTF_8);
+        AtomicReference<Boolean> result = new AtomicReference<>();
+        AtomicReference<Throwable> failure = new AtomicReference<>();
+        Thread worker = new Thread(() -> {
+            try {
+                WSDL11ProcessorImpl p = new WSDL11ProcessorImpl();
+                result.set(p.init(wsdl));
+                if (p.hasError()) {
+                    failure.set(new AssertionError("expected no error; got errorCode="
+                            + p.getError().getErrorCode()));
+                }
+            } catch (Throwable t) {
+                failure.set(t);
+            }
+        });
+        worker.start();
+        worker.join();
+        assertNull("init() must not throw / error out when there is no CarbonContext on the current thread",
+                failure.get());
+        assertTrue("no xsd:import to block -> init should succeed via the tenant-domain fallback",
+                Boolean.TRUE.equals(result.get()));
+    }
+
+    // Within one WSDL, a blocked first xsd:import must not corrupt a legitimate second sibling import:
+    // the block is recorded (UNTRUSTED_URL) but the import degrades to a stub, so the WSDL still parses.
+    @Test
+    public void siblingImportIndependentOfEarlierBlockedImport() throws Exception {
+        File dir = tmp.newFolder("archive-" + System.nanoTime());
+        write(new File(dir, "service.wsdl"),
+                wsdlWithTwoXsdImports("../../../../../../etc/hostname", "urn:d", "legit.xsd"));
+        write(new File(dir, "legit.xsd"), leafSchema("urn:d"));
+        WSDL11ProcessorImpl p = new WSDL11ProcessorImpl();
+        boolean ok = p.initPath(dir.getAbsolutePath());
+        assertFalse(ok);
+        assertTrue(p.hasError());
+        assertEquals(900405, p.getError().getErrorCode());   // UNTRUSTED_URL surfaced from the first import
+        // the WSDL still parsed: the blocked FIRST import did not abort the whole parse, so the SECOND,
+        // unrelated sibling import was not corrupted by it.
+        assertNotNull(p.getWSDLDefinition());
+    }
+
+    // init(URL): remote WSDL whose xsd:import is a file: ref -> LOCAL_ABSOLUTE -> blocked -> UNTRUSTED_URL, file NOT read
+    @Test
+    public void remoteWsdlWithFileSchemaImportBlocked() throws Exception {
+        HttpServer wsdlHost = server(ctx -> respond(ctx, 200, wsdlWithXsdImport("file:///etc/hostname")));
+        try {
+            WSDL11ProcessorImpl p = new WSDL11ProcessorImpl();
+            p.init(new URL("http://127.0.0.1:" + port(wsdlHost) + "/service.wsdl"));
+            assertTrue(p.hasError());
+            assertEquals(900405, p.getError().getErrorCode());
+        } finally {
+            wsdlHost.stop(0);
+        }
+    }
+
+    // SOAP-to-REST extractor: legit in-archive schema still extracts types (schema content NOT disabled)
+    @Test
+    public void soapToRestUnaffectedForLocalSchema() throws Exception {
+        File dir = extractedArchiveWithSiblingXsd();
+        WSDL11SOAPOperationExtractor ex = new WSDL11SOAPOperationExtractor();
+        assertTrue(ex.initPath(dir.getAbsolutePath()));
+        assertFalse(ex.hasError());
+    }
+
+    // init(URL) with a file: URL has relative refs to the WSDL's OWN directory: a sibling schema
+    // (schemaLocation="types.xsd") must resolve because the file: URL's parent dir is the containment root, not null.
+    @Test
+    public void fileUrlWsdlWithSiblingSchemaResolves() throws Exception {
+        File dir = extractedArchiveWithSiblingXsd();   // writes service.wsdl + types.xsd (schemaLocation="types.xsd")
+        WSDL11ProcessorImpl p = new WSDL11ProcessorImpl();
+        boolean ok = p.init(new File(dir, "service.wsdl").toURI().toURL());
+        assertTrue("sibling schema should resolve via document-dir containment, not be blocked", ok);
+        assertFalse(p.hasError());
+    }
+
+    // A schema in a subdirectory (xsd/a.xsd) importing a SIBLING (b.xsd) must resolve relative to its
+    // OWN directory (xsd/), not the fixed archive root. Before the fix this looked for root/b.xsd and failed.
+    @Test
+    public void nestedSubdirCrossImportResolves() throws Exception {
+        File dir = tmp.newFolder("archive-" + System.nanoTime());
+        write(new File(dir, "service.wsdl"), wsdlWithXsdImport("xsd/a.xsd"));
+        File xsd = new File(dir, "xsd");
+        assertTrue(xsd.mkdirs());
+        write(new File(xsd, "a.xsd"), schemaImporting("urn:d", "b.xsd"));
+        write(new File(xsd, "b.xsd"), leafSchema("urn:d"));
+        WSDL11ProcessorImpl p = new WSDL11ProcessorImpl();
+        assertTrue(p.initPath(dir.getAbsolutePath()));
+        assertFalse(p.hasError());
+    }
+
+    // A "../"-ref from a subdirectory schema that lands back INSIDE the archive (xsd/a.xsd -> ../common/c.xsd)
+    // must resolve. Before the fix it was resolved against the archive root, escaped it, and was wrongly blocked.
+    @Test
+    public void dotDotRefWithinArchiveResolves() throws Exception {
+        File dir = tmp.newFolder("archive-" + System.nanoTime());
+        write(new File(dir, "service.wsdl"), wsdlWithXsdImport("xsd/a.xsd"));
+        File xsd = new File(dir, "xsd");
+        File common = new File(dir, "common");
+        assertTrue(xsd.mkdirs());
+        assertTrue(common.mkdirs());
+        write(new File(xsd, "a.xsd"), schemaImporting("urn:d", "../common/c.xsd"));
+        write(new File(common, "c.xsd"), leafSchema("urn:d"));
+        WSDL11ProcessorImpl p = new WSDL11ProcessorImpl();
+        assertTrue(p.initPath(dir.getAbsolutePath()));
+        assertFalse(p.hasError());
+    }
+
+    // A WSDL located in a subdirectory (wsdl/service.wsdl) importing a sibling schema (types.xsd) must
+    // resolve relative to the WSDL's own directory. Before the fix this looked for root/types.xsd and failed.
+    @Test
+    public void wsdlInSubdirSiblingResolves() throws Exception {
+        File dir = tmp.newFolder("archive-" + System.nanoTime());
+        File wsdlDir = new File(dir, "wsdl");
+        assertTrue(wsdlDir.mkdirs());
+        write(new File(wsdlDir, "service.wsdl"), wsdlWithXsdImport("types.xsd"));
+        write(new File(wsdlDir, "types.xsd"), leafSchema("urn:c"));
+        WSDL11ProcessorImpl p = new WSDL11ProcessorImpl();
+        assertTrue(p.initPath(dir.getAbsolutePath()));
+        assertFalse(p.hasError());
+    }
+
+    // A nested-subdir schema whose import escapes the archive root
+    // (xsd/a.xsd -> ../../../../etc/hostname) must STILL be blocked -> UNTRUSTED_URL, nothing outside read.
+    @Test
+    public void archiveEscapeStillBlocked() throws Exception {
+        File dir = tmp.newFolder("archive-" + System.nanoTime());
+        write(new File(dir, "service.wsdl"), wsdlWithXsdImport("xsd/a.xsd"));
+        File xsd = new File(dir, "xsd");
+        assertTrue(xsd.mkdirs());
+        write(new File(xsd, "a.xsd"), schemaImporting("urn:d", "../../../../etc/hostname"));
+        WSDL11ProcessorImpl p = new WSDL11ProcessorImpl();
+        boolean ok = p.initPath(dir.getAbsolutePath());
+        assertFalse(ok);
+        assertTrue(p.hasError());
+        assertEquals(900405, p.getError().getErrorCode());
+    }
+
+    // A schema reference that resolves INSIDE the archive but is absent on disk is a GENUINE failure, not a
+    // policy block: it must map to CANNOT_PROCESS_WSDL_CONTENT (900676) and NOT escape initPath as a RuntimeException.
+    @Test
+    public void missingContainedSchemaMapsToCannotProcess() throws Exception {
+        File dir = extractedArchiveWith(wsdlWithXsdImport("missing.xsd"));
+        WSDL11ProcessorImpl p = new WSDL11ProcessorImpl();
+        boolean ok = p.initPath(dir.getAbsolutePath());   // must NOT throw
+        assertFalse(ok);
+        assertTrue(p.hasError());
+        assertEquals(ExceptionCodes.CANNOT_PROCESS_WSDL_CONTENT.getErrorCode(), p.getError().getErrorCode());
+    }
+
+    // A multi-WSDL archive where ONE file has a blocked (traversal) import and another is clean: the whole
+    // import is reported UNTRUSTED_URL, yet the clean file still parses (the blocked ref degrades to a stub).
+    @Test
+    public void multiFileArchiveOneFileBlocked() throws Exception {
+        File dir = tmp.newFolder("archive-" + System.nanoTime());
+        write(new File(dir, "clean.wsdl"), wsdlWithXsdImport("types.xsd"));
+        write(new File(dir, "types.xsd"), leafSchema("urn:c"));
+        write(new File(dir, "evil.wsdl"), wsdlWithXsdImport("../../../../../../etc/hostname"));
+        WSDL11ProcessorImpl p = new WSDL11ProcessorImpl();
+        boolean ok = p.initPath(dir.getAbsolutePath());
+        assertFalse(ok);
+        assertTrue(p.hasError());
+        assertEquals(900405, p.getError().getErrorCode());
+        // getWSDLDefinition() is protected but this test is in-package: proves at least one WSDL parsed.
+        assertNotNull(p.getWSDLDefinition());
+    }
+
+    // init(URL) on a file: WSDL whose xsd:import is a traversal ("../../..") must be blocked.
+    @Test
+    public void fileUrlTraversalBlocked() throws Exception {
+        File dir = tmp.newFolder("archive-" + System.nanoTime());
+        write(new File(dir, "service.wsdl"), wsdlWithXsdImport("../../../../../../etc/hostname"));
+        WSDL11ProcessorImpl p = new WSDL11ProcessorImpl();
+        p.init(new File(dir, "service.wsdl").toURI().toURL());
+        assertTrue(p.hasError());
+        assertEquals(900405, p.getError().getErrorCode());
+    }
+
+    // init(URL) on a file: WSDL whose xsd:import is an ABSOLUTE local path ("/etc/hostname") must be
+    // blocked (LOCAL_ABSOLUTE classification).
+    @Test
+    public void fileUrlAbsoluteBlocked() throws Exception {
+        File dir = tmp.newFolder("archive-" + System.nanoTime());
+        write(new File(dir, "service.wsdl"), wsdlWithXsdImport("/etc/hostname"));
+        WSDL11ProcessorImpl p = new WSDL11ProcessorImpl();
+        p.init(new File(dir, "service.wsdl").toURI().toURL());
+        assertTrue(p.hasError());
+        assertEquals(900405, p.getError().getErrorCode());
+    }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/wsdl/WSDL11ProcessorAccessControlIntegrationTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/wsdl/WSDL11ProcessorAccessControlIntegrationTest.java
@@ -247,7 +247,8 @@ public class WSDL11ProcessorAccessControlIntegrationTest {
         boolean ok = p.initPath(dir.getAbsolutePath());
         assertFalse(ok);
         assertTrue(p.hasError());
-        assertEquals(900405, p.getError().getErrorCode());   // UNTRUSTED_URL surfaced via reportBlockedReferencesIfAny
+        // UNTRUSTED_URL_IN_DEFINITION surfaced via reportBlockedReferencesIfAny
+        assertEquals(ExceptionCodes.UNTRUSTED_URL_IN_DEFINITION.getErrorCode(), p.getError().getErrorCode());
     }
 
     // initPath: remote xsd:import IS fetched when no policy configured (no-op) -> wiring resolves remote schemas
@@ -282,7 +283,7 @@ public class WSDL11ProcessorAccessControlIntegrationTest {
         WSDL11ProcessorImpl p = new WSDL11ProcessorImpl();
         p.init(wsdl);
         assertTrue(p.hasError());
-        assertEquals(900405, p.getError().getErrorCode());
+        assertEquals(ExceptionCodes.UNTRUSTED_URL_IN_DEFINITION.getErrorCode(), p.getError().getErrorCode());
     }
 
     // A bare Thread does not inherit the @Before tenant flow (non-inheritable ThreadLocal); resolveTenantDomain's
@@ -324,7 +325,8 @@ public class WSDL11ProcessorAccessControlIntegrationTest {
         boolean ok = p.initPath(dir.getAbsolutePath());
         assertFalse(ok);
         assertTrue(p.hasError());
-        assertEquals(900405, p.getError().getErrorCode());   // UNTRUSTED_URL surfaced from the first import
+        // UNTRUSTED_URL_IN_DEFINITION surfaced from the first import
+        assertEquals(ExceptionCodes.UNTRUSTED_URL_IN_DEFINITION.getErrorCode(), p.getError().getErrorCode());
         // the WSDL still parsed: the blocked FIRST import did not abort the whole parse, so the SECOND,
         // unrelated sibling import was not corrupted by it.
         assertNotNull(p.getWSDLDefinition());
@@ -338,7 +340,7 @@ public class WSDL11ProcessorAccessControlIntegrationTest {
             WSDL11ProcessorImpl p = new WSDL11ProcessorImpl();
             p.init(new URL("http://127.0.0.1:" + port(wsdlHost) + "/service.wsdl"));
             assertTrue(p.hasError());
-            assertEquals(900405, p.getError().getErrorCode());
+            assertEquals(ExceptionCodes.UNTRUSTED_URL_IN_DEFINITION.getErrorCode(), p.getError().getErrorCode());
         } finally {
             wsdlHost.stop(0);
         }
@@ -423,7 +425,7 @@ public class WSDL11ProcessorAccessControlIntegrationTest {
         boolean ok = p.initPath(dir.getAbsolutePath());
         assertFalse(ok);
         assertTrue(p.hasError());
-        assertEquals(900405, p.getError().getErrorCode());
+        assertEquals(ExceptionCodes.UNTRUSTED_URL_IN_DEFINITION.getErrorCode(), p.getError().getErrorCode());
     }
 
     // A schema reference that resolves INSIDE the archive but is absent on disk is a GENUINE failure, not a
@@ -450,7 +452,7 @@ public class WSDL11ProcessorAccessControlIntegrationTest {
         boolean ok = p.initPath(dir.getAbsolutePath());
         assertFalse(ok);
         assertTrue(p.hasError());
-        assertEquals(900405, p.getError().getErrorCode());
+        assertEquals(ExceptionCodes.UNTRUSTED_URL_IN_DEFINITION.getErrorCode(), p.getError().getErrorCode());
         // getWSDLDefinition() is protected but this test is in-package: proves at least one WSDL parsed.
         assertNotNull(p.getWSDLDefinition());
     }
@@ -463,7 +465,7 @@ public class WSDL11ProcessorAccessControlIntegrationTest {
         WSDL11ProcessorImpl p = new WSDL11ProcessorImpl();
         p.init(new File(dir, "service.wsdl").toURI().toURL());
         assertTrue(p.hasError());
-        assertEquals(900405, p.getError().getErrorCode());
+        assertEquals(ExceptionCodes.UNTRUSTED_URL_IN_DEFINITION.getErrorCode(), p.getError().getErrorCode());
     }
 
     // init(URL) on a file: WSDL whose xsd:import is an ABSOLUTE local path ("/etc/hostname") must be
@@ -475,6 +477,6 @@ public class WSDL11ProcessorAccessControlIntegrationTest {
         WSDL11ProcessorImpl p = new WSDL11ProcessorImpl();
         p.init(new File(dir, "service.wsdl").toURI().toURL());
         assertTrue(p.hasError());
-        assertEquals(900405, p.getError().getErrorCode());
+        assertEquals(ExceptionCodes.UNTRUSTED_URL_IN_DEFINITION.getErrorCode(), p.getError().getErrorCode());
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/wsdl/WSDL11SOAPOperationExtractorAccessControlTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/wsdl/WSDL11SOAPOperationExtractorAccessControlTest.java
@@ -1,0 +1,55 @@
+package org.wso2.carbon.apimgt.impl.wsdl;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.wso2.carbon.apimgt.api.APIManagementException;
+import org.wso2.carbon.apimgt.api.ExceptionCodes;
+import org.wso2.carbon.apimgt.impl.utils.APIUtil;
+import org.wso2.carbon.context.PrivilegedCarbonContext;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({APIUtil.class, PrivilegedCarbonContext.class})
+public class WSDL11SOAPOperationExtractorAccessControlTest {
+
+    @Test
+    public void blockedNamespaceUrlIsValidatedAndPropagatesUntrustedUrl() throws Exception {
+        PowerMockito.mockStatic(PrivilegedCarbonContext.class);
+        PrivilegedCarbonContext ctx = Mockito.mock(PrivilegedCarbonContext.class);
+        PowerMockito.when(PrivilegedCarbonContext.getThreadLocalCarbonContext()).thenReturn(ctx);
+        Mockito.when(ctx.getTenantDomain()).thenReturn("carbon.super");
+
+        PowerMockito.mockStatic(APIUtil.class);
+        PowerMockito.doThrow(new APIManagementException("URL is not trusted", ExceptionCodes.UNTRUSTED_URL))
+                .when(APIUtil.class);
+        APIUtil.validateRemoteURL("http://169.254.169.254/latest/meta-data/.xsd", "carbon.super");
+
+        WSDL11SOAPOperationExtractor extractor = new WSDL11SOAPOperationExtractor();
+        Method getBasedXSDofWSDL =
+                WSDL11SOAPOperationExtractor.class.getDeclaredMethod("getBasedXSDofWSDL", String.class);
+        getBasedXSDofWSDL.setAccessible(true);
+
+        try {
+            getBasedXSDofWSDL.invoke(extractor, "http://169.254.169.254/latest/meta-data/");
+            fail("a blocked namespace URL must propagate UNTRUSTED_URL, not fetch");
+        } catch (InvocationTargetException ite) {
+            assertTrue(ite.getCause() instanceof APIManagementException);
+            APIManagementException cause = (APIManagementException) ite.getCause();
+            assertEquals("must carry UNTRUSTED_URL (900405)",
+                    ExceptionCodes.UNTRUSTED_URL.getErrorCode(), cause.getErrorHandler().getErrorCode());
+        }
+
+        PowerMockito.verifyStatic(APIUtil.class);
+        APIUtil.validateRemoteURL("http://169.254.169.254/latest/meta-data/.xsd", "carbon.super");
+    }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/wsdl/WSDL11SOAPOperationExtractorAccessControlTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/wsdl/WSDL11SOAPOperationExtractorAccessControlTest.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.wso2.carbon.apimgt.impl.wsdl;
 
 import org.junit.Test;
@@ -41,12 +59,12 @@ public class WSDL11SOAPOperationExtractorAccessControlTest {
 
         try {
             getBasedXSDofWSDL.invoke(extractor, "http://169.254.169.254/latest/meta-data/");
-            fail("a blocked namespace URL must propagate UNTRUSTED_URL, not fetch");
+            fail("a blocked namespace URL must propagate UNTRUSTED_URL_IN_DEFINITION, not fetch");
         } catch (InvocationTargetException ite) {
             assertTrue(ite.getCause() instanceof APIManagementException);
             APIManagementException cause = (APIManagementException) ite.getCause();
-            assertEquals("must carry UNTRUSTED_URL (900405)",
-                    ExceptionCodes.UNTRUSTED_URL.getErrorCode(), cause.getErrorHandler().getErrorCode());
+            assertEquals("must carry UNTRUSTED_URL_IN_DEFINITION (900407)",
+                    ExceptionCodes.UNTRUSTED_URL_IN_DEFINITION.getErrorCode(), cause.getErrorHandler().getErrorCode());
         }
 
         PowerMockito.verifyStatic(APIUtil.class);

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/wsdl/WSDL20ProcessorImplResolverTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/wsdl/WSDL20ProcessorImplResolverTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.apimgt.impl.wsdl;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.wso2.carbon.apimgt.api.APIManagementException;
+import org.wso2.carbon.apimgt.api.ExceptionCodes;
+import org.wso2.carbon.apimgt.impl.utils.APIUtil;
+import org.wso2.carbon.context.PrivilegedCarbonContext;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({APIUtil.class, PrivilegedCarbonContext.class})
+public class WSDL20ProcessorImplResolverTest {
+
+    private static final String WSDL20_WITH_BLOCKED_IMPORT =
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+          + "<description xmlns=\"http://www.w3.org/ns/wsdl\""
+          + "  xmlns:tns=\"http://example.org/svc\""
+          + "  xmlns:xs=\"http://www.w3.org/2001/XMLSchema\""
+          + "  targetNamespace=\"http://example.org/svc\">"
+          + "  <import namespace=\"http://example.org/imported\""
+          + "          location=\"http://169.254.169.254/meta/import.wsdl\"/>"
+          + "  <types><xs:schema targetNamespace=\"http://example.org/svc\">"
+          + "      <xs:element name=\"Ping\" type=\"xs:string\"/></xs:schema></types>"
+          + "  <interface name=\"I\"/>"
+          + "  <service name=\"S\" interface=\"tns:I\"/>"
+          + "</description>";
+
+    @Test
+    public void blockedNestedImportSurfacesUntrustedUrlError() throws Exception {
+        PowerMockito.mockStatic(PrivilegedCarbonContext.class);
+        PrivilegedCarbonContext ctx = Mockito.mock(PrivilegedCarbonContext.class);
+        PowerMockito.when(PrivilegedCarbonContext.getThreadLocalCarbonContext()).thenReturn(ctx);
+        Mockito.when(ctx.getTenantDomain()).thenReturn("carbon.super");
+
+        PowerMockito.mockStatic(APIUtil.class);
+        PowerMockito.doThrow(new APIManagementException("URL is not trusted", ExceptionCodes.UNTRUSTED_URL))
+                .when(APIUtil.class);
+        APIUtil.validateRemoteURL(Mockito.anyString(), Mockito.anyString());
+
+        WSDL20ProcessorImpl processor = new WSDL20ProcessorImpl();
+        processor.init(WSDL20_WITH_BLOCKED_IMPORT.getBytes(StandardCharsets.UTF_8));
+
+        // blocked import redirected to a local stub (no outbound fetch) AND reported to the user
+        assertTrue("a blocked nested import must be reported as an error", processor.hasError());
+        assertEquals("must report UNTRUSTED_URL (900405)",
+                ExceptionCodes.UNTRUSTED_URL.getErrorCode(), processor.getError().getErrorCode());
+
+        // the policy gate was consulted for the nested import URL
+        PowerMockito.verifyStatic(APIUtil.class);
+        APIUtil.validateRemoteURL("http://169.254.169.254/meta/import.wsdl", "carbon.super");
+    }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/wsdl/WSDL20ProcessorImplResolverTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/wsdl/WSDL20ProcessorImplResolverTest.java
@@ -68,8 +68,8 @@ public class WSDL20ProcessorImplResolverTest {
 
         // blocked import redirected to a local stub (no outbound fetch) AND reported to the user
         assertTrue("a blocked nested import must be reported as an error", processor.hasError());
-        assertEquals("must report UNTRUSTED_URL (900405)",
-                ExceptionCodes.UNTRUSTED_URL.getErrorCode(), processor.getError().getErrorCode());
+        assertEquals("must report UNTRUSTED_URL_IN_DEFINITION (900407)",
+                ExceptionCodes.UNTRUSTED_URL_IN_DEFINITION.getErrorCode(), processor.getError().getErrorCode());
 
         // the policy gate was consulted for the nested import URL
         PowerMockito.verifyStatic(APIUtil.class);

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/wsdl/WSDL20SchemaImportNonReachableTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/wsdl/WSDL20SchemaImportNonReachableTest.java
@@ -1,0 +1,225 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.apimgt.impl.wsdl;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.wso2.carbon.apimgt.impl.APIManagerConfiguration;
+import org.wso2.carbon.apimgt.impl.APIManagerConfigurationServiceImpl;
+import org.wso2.carbon.apimgt.impl.config.APIMConfigService;
+import org.wso2.carbon.apimgt.impl.internal.ServiceReferenceHolder;
+import org.wso2.carbon.context.PrivilegedCarbonContext;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Regression + documentation test: proves that WSDL 2.0's nested {@code <xsd:import>} /
+ * {@code <xsd:schema schemaLocation=...>} inside {@code <types>} is NOT reachable through
+ * {@link WSDL20ProcessorImpl}, unlike the WSDL 1.1 path (covered/gated in
+ * {@link WSDL11ProcessorAccessControlIntegrationTest}).
+ * <p>
+ * Why: {@link WSDL20ProcessorImpl#initPath(String)} (and the other entry points) parse the WSDL
+ * file into a DOM {@code Document} and then build Woden's {@code WSDLSource} from the raw DOM
+ * element via {@code wsdlSource.setSource(domElement)} -- {@code setBaseURI(...)} is never called
+ * (see {@code WSDL20ProcessorImpl#getWSDLSourceFromDocument}). With a {@code null} document base
+ * URI, Apache Woden aborts inline-schema parsing (WSDL521, "Missing base URI") before it ever
+ * walks the {@code <types>} content to discover a nested {@code xsd:import}/{@code xsd:include}.
+ * Consequently, an untrusted nested {@code schemaLocation} is never dereferenced -- no
+ * outbound fetch happens, and no {@code AccessControlledUriResolver} gating is even needed for
+ * this vector.
+ * <p>
+ * This is a genuinely different situation to WSDL 1.1: WSDL4J's WSDL 1.1 reader DID walk into
+ * inline schemas and fetch nested {@code xsd:import} locations, which is exactly the vector
+ * {@link AccessControlledWSDLLocator} was built to gate. For WSDL 2.0 there is nothing to gate
+ * for the nested-schema vector because Woden never reaches it; this test locks that in as a
+ * regression guard (if a future Woden/library upgrade starts resolving base URIs and reaching the
+ * nested import, this test will fail with a nonzero canary-hit count and must be re-evaluated).
+ * <p>
+ * Absolute {@code wsdl:import}/{@code wsdl:include} elements (a different vector, resolved by
+ * Woden's own {@code URIResolver} before any DOM/base-URI concern) ARE reachable and remain gated
+ * by {@link AccessControlledUriResolver} -- see {@link WSDL20ProcessorImplResolverTest} -- and are
+ * unchanged/out of scope here.
+ */
+public class WSDL20SchemaImportNonReachableTest {
+
+    @Rule
+    public TemporaryFolder tmp = new TemporaryFolder();
+
+    private static final String XSD_BODY =
+            "<xsd:schema targetNamespace=\"urn:c\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"/>";
+
+    // initPath() reads size-limit config via ServiceReferenceHolder and calls resolveTenantDomain(), which reads
+    // PrivilegedCarbonContext and throws outside a tenant flow -- needed even though the resolver is never reached.
+    @Before
+    public void wireApiManagerConfigurationService() {
+        ServiceReferenceHolder.getInstance().setAPIManagerConfigurationService(
+                new APIManagerConfigurationServiceImpl(new APIManagerConfiguration()));
+        ServiceReferenceHolder.getInstance().setAPIMConfigService(new NoOpApimConfigService());
+        PrivilegedCarbonContext.startTenantFlow();
+        PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantId(-1234); // super tenant, no resolution
+        PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantDomain("carbon.super");
+    }
+
+    @After
+    public void endTenantFlow() {
+        PrivilegedCarbonContext.endTenantFlow();
+    }
+
+    /** Trivial no-op {@link APIMConfigService}: no tenant config stored for any organization. */
+    private static final class NoOpApimConfigService implements APIMConfigService {
+        @Override
+        public void addExternalStoreConfig(String organization, String externalStoreConfig) { }
+
+        @Override
+        public void updateExternalStoreConfig(String organization, String externalStoreConfig) { }
+
+        @Override
+        public String getExternalStoreConfig(String organization) {
+            return null;
+        }
+
+        @Override
+        public void addTenantConfig(String organization, String tenantConfig) { }
+
+        @Override
+        public String getTenantConfig(String organization) {
+            return null;
+        }
+
+        @Override
+        public void updateTenantConfig(String organization, String tenantConfig) { }
+
+        @Override
+        public String getWorkFlowConfig(String organization) {
+            return null;
+        }
+
+        @Override
+        public void updateWorkflowConfig(String organization, String workflowConfig) { }
+
+        @Override
+        public void addWorkflowConfig(String organization, String workflowConfig) { }
+
+        @Override
+        public String getGAConfig(String organization) {
+            return null;
+        }
+
+        @Override
+        public void updateGAConfig(String organization, String gaConfig) { }
+
+        @Override
+        public void addGAConfig(String organization, String gaConfig) { }
+
+        @Override
+        public Object getSelfSighupConfig(String organization) {
+            return null;
+        }
+
+        @Override
+        public void updateSelfSighupConfig(String organization, String selfSignUpConfig) { }
+
+        @Override
+        public void addSelfSighupConfig(String organization, String selfSignUpConfig) { }
+    }
+
+    // ---- fixture helpers -------------------------------------------------
+
+    /**
+     * A valid WSDL 2.0 document (namespace {@code http://www.w3.org/ns/wsdl}) whose {@code <types>}
+     * contains an inline schema with a nested {@code xsd:import} at the given schemaLocation --
+     * modelled on the earlier manual PoC fixture (scratch-wsdl-poc/arch/w20_http-import/service.wsdl).
+     */
+    private static String wsdl20WithXsdImport(String schemaLocation) {
+        return "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+                + "<description xmlns=\"http://www.w3.org/ns/wsdl\"\n"
+                + "             xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"\n"
+                + "             xmlns:tns=\"urn:poc\"\n"
+                + "             targetNamespace=\"urn:poc\">\n"
+                + "  <types>\n"
+                + "    <xsd:schema targetNamespace=\"urn:poc\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\">\n"
+                + "      <xsd:import namespace=\"urn:c\" schemaLocation=\"" + schemaLocation + "\"/>\n"
+                + "    </xsd:schema>\n"
+                + "  </types>\n"
+                + "</description>\n";
+    }
+
+    private File extractedArchiveWith(String wsdlXml) throws IOException {
+        File dir = tmp.newFolder("archive-" + System.nanoTime());
+        Files.write(new File(dir, "service.wsdl").toPath(), wsdlXml.getBytes(StandardCharsets.UTF_8));
+        return dir;
+    }
+
+    private HttpServer server(HttpHandler handler) throws IOException {
+        HttpServer httpServer = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        httpServer.createContext("/", handler);
+        httpServer.start();
+        return httpServer;
+    }
+
+    private static void respond(HttpExchange exchange, int status, String body) throws IOException {
+        byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
+        exchange.sendResponseHeaders(status, bytes.length);
+        exchange.getResponseBody().write(bytes);
+        exchange.close();
+    }
+
+    private static int port(HttpServer httpServer) {
+        return httpServer.getAddress().getPort();
+    }
+
+    // ---- test -------------------------------------------------------
+
+    /**
+     * initPath: a WSDL 2.0 archive whose inline-schema {@code xsd:import} points at a canary HTTP
+     * server must NEVER cause that canary to be hit -- Woden aborts inline-schema parsing
+     * (WSDL521, missing base URI) before it discovers the nested import. It is fine (expected) for
+     * {@code initPath} to return {@code false} / set an error here; the only thing under test is
+     * that the nested schemaLocation is never dereferenced.
+     */
+    @Test
+    public void wsdl20NestedSchemaImportNotReachable() throws Exception {
+        AtomicInteger hits = new AtomicInteger();
+        HttpServer canary = server(ctx -> {
+            hits.incrementAndGet();
+            respond(ctx, 200, XSD_BODY);
+        });
+        File dir = extractedArchiveWith(wsdl20WithXsdImport("http://127.0.0.1:" + port(canary) + "/c.xsd"));
+        try {
+            WSDL20ProcessorImpl p = new WSDL20ProcessorImpl();
+            p.initPath(dir.getAbsolutePath()); // may return false / set an error (WSDL521) -- that's fine
+            assertEquals("WSDL 2.0 nested xsd:import must not be fetched (null base URI, "
+                    + "Woden aborts inline-schema parsing before discovering it)", 0, hits.get());
+        } finally {
+            canary.stop(0);
+        }
+    }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ImportUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ImportUtils.java
@@ -61,6 +61,7 @@ import org.wso2.carbon.apimgt.api.model.Backend;
 import org.wso2.carbon.apimgt.api.model.Documentation;
 import org.wso2.carbon.apimgt.api.model.Environment;
 import org.wso2.carbon.apimgt.api.model.Identifier;
+import org.wso2.carbon.apimgt.api.model.OASParserOptions;
 import org.wso2.carbon.apimgt.api.model.OperationPolicy;
 import org.wso2.carbon.apimgt.api.model.OperationPolicyData;
 import org.wso2.carbon.apimgt.api.model.OperationPolicyDefinition;
@@ -2775,9 +2776,12 @@ public class ImportUtils {
     public static APIDefinitionValidationResponse retrieveValidatedSwaggerDefinition(String swaggerContent)
             throws APIManagementException {
 
+        OASParserOptions baseParserOptions = ServiceReferenceHolder.getInstance()
+                .getAPIMDependencyConfigurationService().getAPIMDependencyConfigurations().getOasParserOptions();
+        OASParserOptions parserOptions = APIUtil.buildRefResolutionOptions(baseParserOptions,
+                RestApiCommonUtil.getLoggedInUserTenantDomain());
         APIDefinitionValidationResponse validationResponse = OASParserUtil.validateAPIDefinition(swaggerContent,
-                Boolean.TRUE, ServiceReferenceHolder.getInstance().getAPIMDependencyConfigurationService()
-                        .getAPIMDependencyConfigurations().getOasParserOptions());
+                Boolean.TRUE, parserOptions);
         if (!validationResponse.isValid()) {
             String errorDescription = "";
             if (validationResponse.getErrorItems().size() > 0) {

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ImportUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ImportUtils.java
@@ -665,7 +665,7 @@ public class ImportUtils {
                 throw new APIManagementException("Error while importing API: " + e.getMessage(),
                         ExceptionCodes.from(ExceptionCodes.API_CONTEXT_MALFORMED_EXCEPTION, e.getMessage()));
             }
-            throw new APIManagementException(errorMessage + StringUtils.SPACE + e.getMessage(), e);
+            throw new APIManagementException(errorMessage + StringUtils.SPACE + e.getMessage(), e, e.getErrorHandler());
         }
     }
 
@@ -1072,7 +1072,7 @@ public class ImportUtils {
                 throw new APIManagementException("Error while importing API: " + e.getMessage(),
                         ExceptionCodes.from(ExceptionCodes.API_CONTEXT_MALFORMED_EXCEPTION, e.getMessage()));
             }
-            throw new APIManagementException(errorMessage + StringUtils.SPACE + e.getMessage(), e);
+            throw new APIManagementException(errorMessage + StringUtils.SPACE + e.getMessage(), e, e.getErrorHandler());
         }
     }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
@@ -3045,7 +3045,8 @@ public class ApisApiServiceImpl implements ApisApiService {
      */
     private String updateSwagger(String apiId, String apiDefinition, String organization)
             throws APIManagementException, FaultGatewaysException {
-        OASParserOptions oasParserOptions = CommonUtil.getOasParserOptions();
+        OASParserOptions oasParserOptions = APIUtil.buildRefResolutionOptions(
+                CommonUtil.getOasParserOptions(), organization);
         APIDefinitionValidationResponse response = OASParserUtil.validateAPIDefinition(apiDefinition, true,
                 oasParserOptions);
         if (!response.isValid()) {
@@ -3283,7 +3284,11 @@ public class ApisApiServiceImpl implements ApisApiService {
                     inlineApiDefinition,
                     returnContent, false);
         } catch (APIManagementException e) {
-            RestApiUtil.handleInternalServerError("Error occurred while validating API Definition", e, log);
+            if (e.getErrorHandler() != null && e.getErrorHandler().getHttpStatusCode() == 400) {
+                RestApiUtil.handleBadRequest(e.getErrorHandler().getErrorDescription(), log);
+            } else {
+                RestApiUtil.handleInternalServerError("Error occurred while validating API Definition", e, log);
+            }
         }
 
         OpenAPIDefinitionValidationResponseDTO validationResponseDTO = (OpenAPIDefinitionValidationResponseDTO) validationResponseMap
@@ -5110,8 +5115,12 @@ public class ApisApiServiceImpl implements ApisApiService {
                 RestApiUtil.handleBadRequest("Unsupported protocol specified in the Service Definition. Protocol " +
                         "should be either sse or websub or ws", log);
             }
-            RestApiUtil.handleInternalServerError("Error while retrieving the service key of the service " +
-                    "associated with API with id " + apiId, log);
+            if (e.getErrorHandler() != null && e.getErrorHandler().getHttpStatusCode() == 400) {
+                RestApiUtil.handleBadRequest(e.getErrorHandler().getErrorDescription(), log);
+            } else {
+                RestApiUtil.handleInternalServerError("Error while retrieving the service key of the service " +
+                        "associated with API with id " + apiId, log);
+            }
         } catch (FaultGatewaysException e) {
             String errorMessage = "Error while updating API : " + apiId;
             RestApiUtil.handleInternalServerError(errorMessage, e, log);

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/McpServersApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/McpServersApiServiceImpl.java
@@ -2454,9 +2454,10 @@ public class McpServersApiServiceImpl implements McpServersApiService {
             if (StringUtils.isNotBlank(definition)) {
                 APIDefinitionValidationResponse validationResponse =
                         OASParserUtil.validateAPIDefinition(definition, Boolean.TRUE,
-                                ServiceReferenceHolder.getInstance()
+                                APIUtil.buildRefResolutionOptions(ServiceReferenceHolder.getInstance()
                                         .getAPIMDependencyConfigurationService()
-                                        .getAPIMDependencyConfigurations().getOasParserOptions());
+                                        .getAPIMDependencyConfigurations().getOasParserOptions(),
+                                        RestApiCommonUtil.getLoggedInUserTenantDomain()));
                 if (!validationResponse.isValid()) {
                     List<ErrorListItemDTO> errorListItemDTOs =
                             APIMappingUtil.getErrorListItemsDTOsFromErrorHandlers(
@@ -2652,7 +2653,11 @@ public class McpServersApiServiceImpl implements McpServersApiService {
                     inlineAPIDefinition,
                     returnContent, false);
         } catch (APIManagementException e) {
-            RestApiUtil.handleInternalServerError("Error occurred while validating API Definition", e, log);
+            if (e.getErrorHandler() != null && e.getErrorHandler().getHttpStatusCode() == 400) {
+                RestApiUtil.handleBadRequest(e.getErrorHandler().getErrorDescription(), log);
+            } else {
+                RestApiUtil.handleInternalServerError("Error occurred while validating API Definition", e, log);
+            }
         }
 
         OpenAPIDefinitionValidationResponseDTO validationResponseDTO =

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/utils/RestApiPublisherUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/utils/RestApiPublisherUtils.java
@@ -656,6 +656,9 @@ public class RestApiPublisherUtils {
                         validateOpenAPIDefinition(definitionUrl, definition, fileDetail, inlineDefinition,
                                 true, isServiceAPI);
             } catch (APIManagementException e) {
+                if (e.getErrorHandler() != null && e.getErrorHandler().getHttpStatusCode() == 400) {
+                    throw RestApiUtil.buildBadRequestException(e.getErrorHandler().getErrorDescription());
+                }
                 RestApiUtil.handleInternalServerError("Error occurred while validating API Definition", e, log);
                 return null;
             }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.service.catalog/src/main/java/org/wso2/carbon/apimgt/rest/api/service/catalog/impl/ServicesApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.service.catalog/src/main/java/org/wso2/carbon/apimgt/rest/api/service/catalog/impl/ServicesApiServiceImpl.java
@@ -109,7 +109,11 @@ public class ServicesApiServiceImpl implements ServicesApiService {
             ServiceEntry createdService = serviceCatalog.getServiceByUUID(serviceId, tenantId);
             return Response.ok().entity(ServiceEntryMappingUtil.fromServiceToDTO(createdService, false)).build();
         } catch (APIManagementException e) {
-            RestApiUtil.handleInternalServerError("Error when validating the service definition", log);
+            if (e.getErrorHandler() != null && e.getErrorHandler().getHttpStatusCode() == 400) {
+                RestApiUtil.handleBadRequest(e.getErrorHandler().getErrorDescription(), log);
+            } else {
+                RestApiUtil.handleInternalServerError("Error when validating the service definition", log);
+            }
         } catch (IOException e) {
             RestApiUtil.handleInternalServerError("Error when reading the file content", log);
         }
@@ -428,7 +432,11 @@ public class ServicesApiServiceImpl implements ServicesApiService {
             if (RestApiUtil.isDueToResourceNotFound(e)) {
                 RestApiUtil.handleResourceNotFoundError("Service", serviceId, e, log);
             }
-            RestApiUtil.handleInternalServerError("Error when validating the service definition", log);
+            if (e.getErrorHandler() != null && e.getErrorHandler().getHttpStatusCode() == 400) {
+                RestApiUtil.handleBadRequest(e.getErrorHandler().getErrorDescription(), log);
+            } else {
+                RestApiUtil.handleInternalServerError("Error when validating the service definition", log);
+            }
         } catch (IOException e) {
             RestApiUtil.handleInternalServerError("Error when reading the file content", log);
         }
@@ -504,7 +512,8 @@ public class ServicesApiServiceImpl implements ServicesApiService {
     private APIDefinitionValidationResponse validateOpenAPIDefinition(String url, String definitionContent)
             throws APIManagementException {
         APIDefinitionValidationResponse validationResponse = new APIDefinitionValidationResponse();
-        OASParserOptions parserOptions = CommonUtil.getOasParserOptions();
+        OASParserOptions parserOptions = APIUtil.buildRefResolutionOptions(CommonUtil.getOasParserOptions(),
+                RestApiCommonUtil.getLoggedInUserTenantDomain());
         if (definitionContent != null) {
             validationResponse = OASParserUtil.validateAPIDefinition(definitionContent, true, parserOptions);
         } else if (url != null) {

--- a/components/apimgt/org.wso2.carbon.apimgt.spec.parser/src/main/java/org/wso2/carbon/apimgt/spec/parser/definitions/OAS2Parser.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.spec.parser/src/main/java/org/wso2/carbon/apimgt/spec/parser/definitions/OAS2Parser.java
@@ -61,7 +61,9 @@ import io.swagger.models.properties.ObjectProperty;
 import io.swagger.models.properties.Property;
 import io.swagger.models.properties.RefProperty;
 import io.swagger.parser.SwaggerParser;
+import io.swagger.parser.SwaggerResolver;
 import io.swagger.parser.util.DeserializationUtils;
+import io.swagger.parser.util.ParseOptions;
 import io.swagger.parser.util.SwaggerDeserializationResult;
 import io.swagger.util.Json;
 import org.apache.commons.collections.CollectionUtils;
@@ -84,6 +86,7 @@ import org.wso2.carbon.apimgt.api.model.APIOperationMapping;
 import org.wso2.carbon.apimgt.api.model.BackendOperation;
 import org.wso2.carbon.apimgt.api.model.BackendOperationMapping;
 import org.wso2.carbon.apimgt.api.model.CORSConfiguration;
+import org.wso2.carbon.apimgt.api.model.OASParserOptions;
 import org.wso2.carbon.apimgt.api.model.Scope;
 import org.wso2.carbon.apimgt.api.model.SwaggerData;
 import org.wso2.carbon.apimgt.api.model.URITemplate;
@@ -712,10 +715,29 @@ public class OAS2Parser extends APIDefinition {
     public APIDefinitionValidationResponse validateAPIDefinition(String apiDefinition, boolean returnJsonContent)
             throws APIManagementException {
 
+        return validateAPIDefinition(apiDefinition, returnJsonContent, null);
+    }
+
+    /**
+     * Validate the given Swagger 2.0 definition, honoring the supplied network access-control options. When a
+     * policy is configured, remote {@code $ref} resolution is routed through swagger-parser's built-in Safe URL
+     * Resolver ({@link #readWithInfoSafely}) so every ref - including refs nested inside a fetched remote document -
+     * is host-validated before it is fetched; a blocked host surfaces as
+     * {@link ExceptionCodes#UNTRUSTED_URL_IN_DEFINITION}. When no policy is configured, behaviour is identical to
+     * {@link #validateAPIDefinition(String, boolean)}.
+     *
+     * @param apiDefinition     OpenAPI 2.0 definition content
+     * @param returnJsonContent whether to return the converted json form of the definition
+     * @param oasParserOptions  network access-control options; {@code null} preserves the legacy unrestricted behaviour
+     * @return APIDefinitionValidationResponse object with validation information
+     */
+    @Override
+    public APIDefinitionValidationResponse validateAPIDefinition(String apiDefinition, boolean returnJsonContent,
+            OASParserOptions oasParserOptions) throws APIManagementException {
+
         APIDefinitionValidationResponse validationResponse = new APIDefinitionValidationResponse();
-        SwaggerParser parser = new SwaggerParser();
         Set<URITemplate> uriTemplates = null;
-        SwaggerDeserializationResult parseAttemptForV2 = parser.readWithInfo(apiDefinition);
+        SwaggerDeserializationResult parseAttemptForV2 = readWithInfoSafely(apiDefinition, oasParserOptions);
         if (CollectionUtils.isNotEmpty(parseAttemptForV2.getMessages())) {
             for (String message : parseAttemptForV2.getMessages()) {
                 OASParserUtil.addErrorToValidationResponse(validationResponse, message);
@@ -1499,6 +1521,91 @@ public class OAS2Parser extends APIDefinition {
     }
 
     /**
+     * Build the swagger-parser (v1) {@link ParseOptions} that enable the built-in Safe URL Resolver for embedded
+     * remote {@code $ref}s, mirroring {@link OAS3Parser#convertOptionsToParseOptions}. The resolver is enabled only
+     * when a network access-control policy is configured; otherwise resolution stays unrestricted to preserve the
+     * historical (backwards-compatible) behaviour for deployments that have not opted into the policy.
+     *
+     * @param options network access-control options
+     * @return v1 {@link ParseOptions} carrying the safe-resolve flag and the allow/block lists
+     */
+    private ParseOptions convertToV1ParseOptions(OASParserOptions options) {
+        ParseOptions parseOptions = new ParseOptions();
+        parseOptions.setSafelyResolveURL(options.isNetworkAccessControlEnabled());
+        parseOptions.setRemoteRefAllowList(options.getRemoteRefAllowList());
+        parseOptions.setRemoteRefBlockList(options.getRemoteRefBlockList());
+        return parseOptions;
+    }
+
+    /**
+     * Deserialize a Swagger 2.0 definition and resolve its remote {@code $ref}s, routing resolution through
+     * swagger-parser's built-in Safe URL Resolver when a network access-control policy is configured. The single
+     * argument {@link SwaggerParser#readWithInfo(String)} resolves every remote {@code $ref} - including refs nested
+     * inside a fetched remote document - with no host validation; this helper instead deserializes without fetching
+     * and then resolves with {@code safelyResolveURL} enabled, so every ref (top-level and transitively nested) is
+     * host-checked before it is fetched. When no policy is configured, it falls back to the legacy unrestricted
+     * {@link SwaggerParser#readWithInfo(String)} for backwards compatibility.
+     *
+     * @param oasDefinition    OpenAPI 2.0 definition content
+     * @param oasParserOptions network access-control options; {@code null}/non-policy value keeps legacy behaviour
+     * @return the deserialization result (its swagger resolved when a policy is configured)
+     * @throws APIManagementException with {@link ExceptionCodes#UNTRUSTED_URL_IN_DEFINITION} if a remote ref targets a
+     *                                host blocked by the policy
+     */
+    private SwaggerDeserializationResult readWithInfoSafely(String oasDefinition, OASParserOptions oasParserOptions)
+            throws APIManagementException {
+
+        SwaggerParser parser = new SwaggerParser();
+        if (oasParserOptions == null || !oasParserOptions.isNetworkAccessControlEnabled()) {
+            // No policy configured: resolve as the legacy parser always has (unrestricted, backwards compatible).
+            return parser.readWithInfo(oasDefinition);
+        }
+        // Deserialize WITHOUT resolving so the parse messages are preserved and no remote ref is fetched yet.
+        SwaggerDeserializationResult parseResult = parser.readWithInfo(oasDefinition, false);
+        if (parseResult.getSwagger() == null) {
+            return parseResult;
+        }
+        // Resolve through the Safe URL Resolver: ResolverCache validates every ref (nested included) before fetch.
+        ParseOptions parseOptions = convertToV1ParseOptions(oasParserOptions);
+        parseOptions.setResolve(true);
+        try {
+            Swagger resolved = new SwaggerResolver(parseResult.getSwagger(), new ArrayList<>(), null, null,
+                    parseOptions).resolve();
+            parseResult.setSwagger(resolved);
+        } catch (RuntimeException e) {
+            // The v1 resolver rethrows a blocked host as a RuntimeException carrying the HostDeniedException message.
+            // Map only a genuine policy block to the definition-scoped 400; other failures fall to lenient handling.
+            if (OASParserUtil.isUntrustedUrlInDefinition(e.getMessage())) {
+                throw new APIManagementException(ExceptionCodes.UNTRUSTED_URL_IN_DEFINITION.getErrorMessage(),
+                        ExceptionCodes.UNTRUSTED_URL_IN_DEFINITION);
+            }
+            if (log.isDebugEnabled()) {
+                log.debug("Error while resolving remote references in the OpenAPI 2.0 definition", e);
+            }
+        }
+        return parseResult;
+    }
+
+    /**
+     * Get parsed Swagger object, honoring the supplied network access-control options for remote {@code $ref}
+     * resolution (see {@link #readWithInfoSafely}). When {@code oasParserOptions} is {@code null} or carries no
+     * policy, behaviour is identical to {@link #getSwagger(String)}.
+     *
+     * @param oasDefinition    OAS definition
+     * @param oasParserOptions network access-control options; may be {@code null}
+     * @return Swagger
+     * @throws APIManagementException if a remote ref targets a host blocked by the policy
+     */
+    Swagger getSwagger(String oasDefinition, OASParserOptions oasParserOptions) throws APIManagementException {
+
+        SwaggerDeserializationResult parseAttemptForV2 = readWithInfoSafely(oasDefinition, oasParserOptions);
+        if (CollectionUtils.isNotEmpty(parseAttemptForV2.getMessages())) {
+            log.debug("Errors found when parsing OAS definition");
+        }
+        return parseAttemptForV2.getSwagger();
+    }
+
+    /**
      * Get parsed Swagger object
      *
      * @param oasDefinition OAS definition
@@ -1513,6 +1620,93 @@ public class OAS2Parser extends APIDefinition {
             log.debug("Errors found when parsing OAS definition");
         }
         return parseAttemptForV2.getSwagger();
+    }
+
+    // Network access-control aware overloads: with a policy configured, each re-parses through the Safe URL Resolver,
+    // rejecting a remote $ref to a blocked host with UNTRUSTED_URL_IN_DEFINITION; otherwise they delegate unchanged.
+
+    @Override
+    public String generateAPIDefinition(SwaggerData swaggerData, String swagger, OASParserOptions options)
+            throws APIManagementException {
+        if (options != null && options.isNetworkAccessControlEnabled()) {
+            getSwagger(swagger, options);
+        }
+        return generateAPIDefinition(swaggerData, swagger);
+    }
+
+    @Override
+    public String populateCustomManagementInfo(String oasDefinition, SwaggerData swaggerData, OASParserOptions options)
+            throws APIManagementException {
+        if (options != null && options.isNetworkAccessControlEnabled()) {
+            getSwagger(oasDefinition, options);
+        }
+        return populateCustomManagementInfo(oasDefinition, swaggerData);
+    }
+
+    @Override
+    public String getOASDefinitionForStore(API api, String oasDefinition, Map<String, String> hostsWithSchemes,
+            KeyManagerConfigurationDTO keyManagerConfigurationDTO, OASParserOptions options)
+            throws APIManagementException {
+        if (options != null && options.isNetworkAccessControlEnabled()) {
+            getSwagger(oasDefinition, options);
+        }
+        return getOASDefinitionForStore(api, oasDefinition, hostsWithSchemes, keyManagerConfigurationDTO);
+    }
+
+    @Override
+    public String getOASDefinitionForStore(APIProduct product, String oasDefinition,
+            Map<String, String> hostsWithSchemes, KeyManagerConfigurationDTO keyManagerConfigurationDTO,
+            OASParserOptions options) throws APIManagementException {
+        if (options != null && options.isNetworkAccessControlEnabled()) {
+            getSwagger(oasDefinition, options);
+        }
+        return getOASDefinitionForStore(product, oasDefinition, hostsWithSchemes, keyManagerConfigurationDTO);
+    }
+
+    @Override
+    public String getOASDefinitionForPublisher(API api, String oasDefinition, OASParserOptions options)
+            throws APIManagementException {
+        if (options != null && options.isNetworkAccessControlEnabled()) {
+            getSwagger(oasDefinition, options);
+        }
+        return getOASDefinitionForPublisher(api, oasDefinition);
+    }
+
+    @Override
+    public String processOtherSchemeScopes(String resourceConfigsJSON, OASParserOptions options)
+            throws APIManagementException {
+        if (options != null && options.isNetworkAccessControlEnabled()) {
+            getSwagger(resourceConfigsJSON, options);
+        }
+        return processOtherSchemeScopes(resourceConfigsJSON);
+    }
+
+    @Override
+    public String injectMgwThrottlingExtensionsToDefault(String swaggerContent, OASParserOptions options)
+            throws APIManagementException {
+        if (options != null && options.isNetworkAccessControlEnabled()) {
+            getSwagger(swaggerContent, options);
+        }
+        return injectMgwThrottlingExtensionsToDefault(swaggerContent);
+    }
+
+    @Override
+    public String copyVendorExtensions(String existingOASContent, String updatedOASContent, OASParserOptions options)
+            throws APIManagementException {
+        if (options != null && options.isNetworkAccessControlEnabled()) {
+            getSwagger(existingOASContent, options);
+            getSwagger(updatedOASContent, options);
+        }
+        return copyVendorExtensions(existingOASContent, updatedOASContent);
+    }
+
+    @Override
+    public String processDisableSecurityExtension(String swaggerContent, OASParserOptions options)
+            throws APIManagementException {
+        if (options != null && options.isNetworkAccessControlEnabled()) {
+            getSwagger(swaggerContent, options);
+        }
+        return processDisableSecurityExtension(swaggerContent);
     }
 
     /**

--- a/components/apimgt/org.wso2.carbon.apimgt.spec.parser/src/main/java/org/wso2/carbon/apimgt/spec/parser/definitions/OAS3Parser.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.spec.parser/src/main/java/org/wso2/carbon/apimgt/spec/parser/definitions/OAS3Parser.java
@@ -962,12 +962,18 @@ public class OAS3Parser extends APIDefinition {
         APIDefinitionValidationResponse validationResponse = new APIDefinitionValidationResponse();
         String processedDefinition = OASParserUtil.preprocessYamlWithLimit(apiDefinition, parserOptions);
         OpenAPIV3Parser openAPIV3Parser = new OpenAPIV3Parser();
-        ParseOptions options = new ParseOptions();
+        ParseOptions options = parserOptions != null ? convertOptionsToParseOptions(parserOptions)
+                : new ParseOptions();
         options.setResolve(true);
         SwaggerParseResult parseAttemptForV3 = openAPIV3Parser.readContents(processedDefinition, null, options);
         if (CollectionUtils.isNotEmpty(parseAttemptForV3.getMessages())) {
             validationResponse.setValid(false);
             for (String message : parseAttemptForV3.getMessages()) {
+                if (parserOptions != null && parserOptions.isNetworkAccessControlEnabled()
+                        && OASParserUtil.isUntrustedUrlInDefinition(message)) {
+                    throw new APIManagementException(ExceptionCodes.UNTRUSTED_URL_IN_DEFINITION.getErrorMessage(),
+                            ExceptionCodes.UNTRUSTED_URL_IN_DEFINITION);
+                }
                 OASParserUtil.addErrorToValidationResponse(validationResponse, message);
                 if (message.contains(APISpecParserConstants.OPENAPI_IS_MISSING_MSG)) {
                     ErrorItem errorItem = new ErrorItem();
@@ -2033,9 +2039,14 @@ public class OAS3Parser extends APIDefinition {
         return parseAttemptForV3.getOpenAPI();
     }
 
-    private ParseOptions convertOptionsToParseOptions(OASParserOptions options) {
+    ParseOptions convertOptionsToParseOptions(OASParserOptions options) {
         ParseOptions parserOptions = new ParseOptions();
         parserOptions.setExplicitStyleAndExplode(options.isExplicitStyleAndExplode());
+        // Enable swagger-parser's built-in Safe URL Resolver for embedded remote $refs only when a network
+        // access-control policy is configured; otherwise resolution stays unrestricted for backwards compatibility.
+        parserOptions.setSafelyResolveURL(options.isNetworkAccessControlEnabled());
+        parserOptions.setRemoteRefAllowList(options.getRemoteRefAllowList());
+        parserOptions.setRemoteRefBlockList(options.getRemoteRefBlockList());
         return parserOptions;
     }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.spec.parser/src/main/java/org/wso2/carbon/apimgt/spec/parser/definitions/OASParserUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.spec.parser/src/main/java/org/wso2/carbon/apimgt/spec/parser/definitions/OASParserUtil.java
@@ -62,6 +62,9 @@ import io.swagger.v3.parser.ObjectMapperFactory;
 import io.swagger.v3.parser.OpenAPIV3Parser;
 import io.swagger.v3.parser.converter.SwaggerConverter;
 import io.swagger.v3.parser.core.models.ParseOptions;
+import io.swagger.v3.parser.urlresolver.PermittedUrlsChecker;
+import io.swagger.v3.parser.urlresolver.exceptions.HostDeniedException;
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
@@ -107,6 +110,7 @@ import java.util.Arrays;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -1003,6 +1007,9 @@ public class OASParserUtil {
         SwaggerVersion version;
         version = getSwaggerVersion(content);
         String filePath = masterSwagger.getAbsolutePath();
+        // Gate remote (http/https) $refs in the archive through the policy gate before parsing with resolution
+        // enabled, so the parser can't fetch them without host validation; local/relative sibling refs are untouched.
+        gateArchiveRemoteRefs(archiveDirectory, oasParserOptions);
         if (SwaggerVersion.OPEN_API.equals(version)) {
             OpenAPIV3Parser openAPIV3Parser = new OpenAPIV3Parser();
             ParseOptions options = new ParseOptions();
@@ -1109,10 +1116,20 @@ public class OASParserUtil {
             if (!validationResponse.isValid()) {
                 for (ErrorHandler handler : validationResponse.getErrorItems()) {
                     if (ExceptionCodes.INVALID_OAS3_FOUND.getErrorCode() == handler.getErrorCode()) {
-                        return tryOAS2Validation(apiDefinition, returnJsonContent);
+                        return tryOAS2Validation(apiDefinition, returnJsonContent, oasParserOptions);
                     }
                 }
             }
+        } catch (APIManagementException e) {
+            // A policy-gate block on a remote ref must surface as its own 400 error, not be folded into a generic
+            // parse error, so re-throw it; other APIManagementExceptions stay recorded as a validation error item.
+            if (e.getErrorHandler() != null
+                    && ExceptionCodes.UNTRUSTED_URL_IN_DEFINITION.getErrorCode() == e.getErrorHandler()
+                    .getErrorCode()) {
+                throw e;
+            }
+            //catching a generic exception as there can be runtime exceptions when parsing happens
+            addErrorToValidationResponse(validationResponse, e);
         } catch (Exception e) {
             //catching a generic exception as there can be runtime exceptions when parsing happens
             addErrorToValidationResponse(validationResponse, e);
@@ -1136,6 +1153,27 @@ public class OASParserUtil {
         errorItem.setDescription(e.toString());
         validationResponse.getErrorItems().add(errorItem);
         return errorItem;
+    }
+
+    /**
+     * Determine whether the given parser message signals that a URL embedded in the definition was blocked by the
+     * network access control policy (the safe URL resolver's host-denied signal). The message fragments below are
+     * the ones emitted by the swagger-parser safe URL resolver when it refuses to resolve a remote {@code $ref}.
+     *
+     * @param message a parser message
+     * @return {@code true} if the message indicates an embedded URL was blocked by the policy
+     */
+    public static boolean isUntrustedUrlInDefinition(String message) {
+        if (message == null) {
+            return false;
+        }
+        return message.contains("is restricted. URL [")
+                || message.contains("is part of the explicit denylist")
+                || message.contains("does not use a supported protocol. URL [")
+                || message.contains("Failed to resolve IP from hostname. Hostname [")
+                || message.contains("Failed to get hostname from URL. URL [")
+                || message.contains("Failed to create new URL with IP.")
+                || message.contains("Failed to parse URL. URL [");
     }
 
 
@@ -1186,24 +1224,30 @@ public class OASParserUtil {
         if (!validationResponse.isValid()) {
             for (ErrorHandler handler : validationResponse.getErrorItems()) {
                 if (ExceptionCodes.INVALID_OAS3_FOUND.getErrorCode() == handler.getErrorCode()) {
-                    return tryOAS2Validation(apiDefinition, returnJsonContent);
+                    return tryOAS2Validation(apiDefinition, returnJsonContent, oasParserOptions);
                 }
             }
         }
         return validationResponse;
     }
     /**
-     * Try to validate a give openAPI definition using swagger parser
+     * Try to validate a give openAPI definition using swagger parser, gating any remote {@code $ref} URLs present
+     * in the definition through the network access control policy (allow/block list + restricted-IP-range checks)
+     * before handing the definition to the legacy Swagger 2.0 parser, which otherwise fetches remote refs without
+     * any host validation.
      *
      * @param apiDefinition     definition
      * @param returnJsonContent whether to return definition as a json content
+     * @param oasParserOptions  optional OpenAPI parser options; may be {@code null} to use defaults
      * @return APIDefinitionValidationResponse
      * @throws APIManagementException if error occurred while parsing definition
      */
-    private static APIDefinitionValidationResponse tryOAS2Validation(String apiDefinition, boolean returnJsonContent)
-            throws APIManagementException {
+    private static APIDefinitionValidationResponse tryOAS2Validation(String apiDefinition, boolean returnJsonContent,
+            OASParserOptions oasParserOptions) throws APIManagementException {
+        // Remote refs are gated inside OAS2Parser via swagger-parser's built-in Safe URL Resolver (enabled only
+        // when a policy is configured; no-op otherwise), which also validates refs nested in a fetched remote doc.
         APIDefinitionValidationResponse validationResponse =
-                oas2Parser.validateAPIDefinition(apiDefinition, returnJsonContent);
+                oas2Parser.validateAPIDefinition(apiDefinition, returnJsonContent, oasParserOptions);
         if (!validationResponse.isValid()) {
             for (ErrorHandler handler : validationResponse.getErrorItems()) {
                 if (ExceptionCodes.INVALID_OAS2_FOUND.getErrorCode() == handler.getErrorCode()) {
@@ -1213,6 +1257,111 @@ public class OASParserUtil {
             }
         }
         return validationResponse;
+    }
+
+    /**
+     * Gate every remote (http/https) {@code $ref} found in any file of an extracted OpenAPI archive through the
+     * network access control policy, before the archive is parsed with resolution enabled. The archive parser
+     * inlines local sibling files and would otherwise transitively fetch remote refs (from the master document or
+     * any sibling file) without host validation. Local/relative refs are intentionally left untouched so multi-file
+     * archives still resolve. Only the (non-transitively-fetched) refs present in the archive's own files are
+     * covered; refs nested inside a remote document that is itself fetched are not visible here.
+     *
+     * @param archiveDirectory the root directory of the extracted archive
+     * @param oasParserOptions parser options carrying the network access control policy; may be {@code null}
+     * @throws APIManagementException with {@link ExceptionCodes#UNTRUSTED_URL_IN_DEFINITION} if a remote ref is not
+     *         permitted by the policy
+     */
+    private static void gateArchiveRemoteRefs(File archiveDirectory,
+            OASParserOptions oasParserOptions) throws APIManagementException {
+        // Only gate remote refs when a network access-control policy is configured. Without one, the archive parser
+        // resolves refs as it always has - preserving backwards compatibility for deployments without the policy.
+        if (oasParserOptions == null || !oasParserOptions.isNetworkAccessControlEnabled()) {
+            return;
+        }
+        PermittedUrlsChecker checker = new PermittedUrlsChecker(
+                oasParserOptions.getRemoteRefAllowList(), oasParserOptions.getRemoteRefBlockList());
+        for (File file : FileUtils.listFiles(archiveDirectory, null, true)) {
+            String fileContent;
+            try {
+                fileContent = FileUtils.readFileToString(file, APISpecParserConstants.DigestAuthConstants.CHARSET);
+            } catch (IOException e) {
+                // Unreadable/binary file: nothing to gate here; the parser will surface any real problem later.
+                continue;
+            }
+            for (String refUrl : extractRemoteRefUrls(fileContent)) {
+                try {
+                    checker.verify(refUrl);
+                } catch (HostDeniedException e) {
+                    if (log.isDebugEnabled()) {
+                        log.debug("Rejected OpenAPI archive referencing a disallowed remote URL: " + refUrl, e);
+                    }
+                    throw new APIManagementException(ExceptionCodes.UNTRUSTED_URL_IN_DEFINITION);
+                }
+            }
+        }
+    }
+
+    /**
+     * Walk the given JSON definition tree and collect every remote (http/https) {@code $ref} URL present in it.
+     * Used to gate the legacy OpenAPI 2.0 parser (which otherwise fetches remote refs without host validation)
+     * through the network access control policy before parsing. Only top-level (non-transitively-fetched) refs
+     * present in the original document are covered; refs nested inside a remote document that is itself fetched
+     * are not visible here.
+     *
+     * @param jsonDefinition the OpenAPI/Swagger definition, as JSON or YAML text
+     * @return a set of distinct remote {@code $ref} URL values found in the definition; empty if none are found
+     *         or if the definition cannot be parsed
+     */
+    private static Set<String> extractRemoteRefUrls(String jsonDefinition) {
+        Set<String> refUrls = new HashSet<>();
+        try {
+            // The definition may still be YAML here, so a YAML-backed mapper is used: it parses YAML and JSON alike
+            // (JSON is a subset of YAML), so remote refs are found regardless of format.
+            JsonNode root = new ObjectMapper(new YAMLFactory()).readTree(jsonDefinition);
+            collectRemoteRefUrls(root, refUrls);
+        } catch (IOException | RuntimeException e) {
+            // Malformed JSON (or any unexpected parsing issue) here is not this method's concern - the legacy
+            // parser invoked afterwards will surface a proper parse error to the caller. Fail safe with no refs.
+            if (log.isDebugEnabled()) {
+                log.debug("Could not parse OpenAPI definition while scanning for remote $ref URLs", e);
+            }
+        }
+        return refUrls;
+    }
+
+    private static final String REF_FIELD_NAME = "$ref";
+
+    /**
+     * Recursively walk a JSON tree collecting the string value of every {@code $ref} field whose value starts
+     * with {@code http://} or {@code https://}.
+     *
+     * @param node    the current JSON node
+     * @param refUrls the set to accumulate discovered remote ref URLs into
+     */
+    private static void collectRemoteRefUrls(JsonNode node, Set<String> refUrls) {
+        if (node == null) {
+            return;
+        }
+        if (node.isObject()) {
+            Iterator<Map.Entry<String, JsonNode>> fields = node.fields();
+            while (fields.hasNext()) {
+                Map.Entry<String, JsonNode> field = fields.next();
+                JsonNode value = field.getValue();
+                if (REF_FIELD_NAME.equals(field.getKey()) && value != null && value.isTextual()) {
+                    String refValue = value.textValue();
+                    if (refValue != null && (refValue.startsWith("http://") || refValue.startsWith("https://"))) {
+                        refUrls.add(refValue);
+                    }
+                } else {
+                    collectRemoteRefUrls(value, refUrls);
+                }
+            }
+        } else if (node.isArray()) {
+            for (JsonNode element : node) {
+                collectRemoteRefUrls(element, refUrls);
+            }
+        }
     }
 
     /**

--- a/components/apimgt/org.wso2.carbon.apimgt.spec.parser/src/test/java/org/wso2/carbon/apimgt/spec/parser/definitions/OAS3ParserTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.spec.parser/src/test/java/org/wso2/carbon/apimgt/spec/parser/definitions/OAS3ParserTest.java
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.models.PathItem;
 import io.swagger.v3.oas.models.security.OAuthFlow;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.parser.OpenAPIV3Parser;
+import io.swagger.v3.parser.core.models.ParseOptions;
 import io.swagger.v3.parser.core.models.SwaggerParseResult;
 import org.apache.commons.io.IOUtils;
 import org.junit.Assert;
@@ -15,6 +16,7 @@ import org.junit.Test;
 import org.mockito.Mockito;
 import org.wso2.carbon.apimgt.api.APIDefinition;
 import org.wso2.carbon.apimgt.api.APIDefinitionValidationResponse;
+import org.wso2.carbon.apimgt.api.APIManagementException;
 import org.wso2.carbon.apimgt.api.ExceptionCodes;
 import org.wso2.carbon.apimgt.api.model.API;
 import org.wso2.carbon.apimgt.api.model.APIIdentifier;
@@ -25,6 +27,7 @@ import org.wso2.carbon.apimgt.api.model.URITemplate;
 
 import java.io.File;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -550,5 +553,158 @@ public class OAS3ParserTest extends OASTestBase {
         apiScopes.add(globalScope);
         apiScopes.add(petLocalScope);
         return apiScopes;
+    }
+
+    @Test
+    public void testConvertOptionsToParseOptionsEnablesSafeResolution() {
+        OASParserOptions opts = new OASParserOptions();
+        opts.setNetworkAccessControlEnabled(true);
+        opts.setRemoteRefAllowList(Arrays.asList("*.wso2.com"));
+        opts.setRemoteRefBlockList(Arrays.asList("*.internal"));
+        ParseOptions po = new OAS3Parser().convertOptionsToParseOptions(opts);
+        Assert.assertTrue(po.isSafelyResolveURL());
+        Assert.assertEquals(Arrays.asList("*.wso2.com"), po.getRemoteRefAllowList());
+        Assert.assertEquals(Arrays.asList("*.internal"), po.getRemoteRefBlockList());
+    }
+
+    @Test
+    public void testConvertOptionsLeavesSafeResolutionOffWhenPolicyNotConfigured() {
+        // Backwards compatibility: with no network access-control policy configured, safe URL resolution must stay
+        // off so remote refs resolve exactly as they did before the feature was introduced.
+        OASParserOptions opts = new OASParserOptions();
+        ParseOptions po = new OAS3Parser().convertOptionsToParseOptions(opts);
+        Assert.assertFalse("Safe URL resolution must remain off when the policy is not configured",
+                po.isSafelyResolveURL());
+    }
+
+    @Test
+    public void testBlockedRemoteRefIsRejected() throws Exception {
+        String def = IOUtils.toString(getClass().getClassLoader().getResourceAsStream(
+                "definitions/oas3/ref_blocked_loopback.json"), "UTF-8");
+        OASParserOptions opts = new OASParserOptions();
+        opts.setNetworkAccessControlEnabled(true);
+        opts.setRemoteRefBlockList(Arrays.asList("169.254.169.254"));
+        try {
+            OASParserUtil.validateAPIDefinition(def, true, opts);
+            Assert.fail("A blocked remote $ref must be rejected");
+        } catch (APIManagementException e) {
+            Assert.assertEquals("A blocked remote $ref must surface as UNTRUSTED_URL_IN_DEFINITION",
+                    ExceptionCodes.UNTRUSTED_URL_IN_DEFINITION.getErrorCode(), e.getErrorHandler().getErrorCode());
+        }
+    }
+
+    @Test
+    public void testOAS2BlockedRemoteRefIsRejected() throws Exception {
+        // OAS2 definitions fall back to the legacy SwaggerParser, which would otherwise fetch remote $refs
+        // unchecked; assert the gate in tryOAS2Validation rejects a blocked ref before that fetch.
+        String def = IOUtils.toString(getClass().getClassLoader().getResourceAsStream(
+                "definitions/oas2/ref_blocked_loopback.json"), "UTF-8");
+        OASParserOptions opts = new OASParserOptions();
+        opts.setNetworkAccessControlEnabled(true);
+        opts.setRemoteRefBlockList(Arrays.asList("169.254.169.254"));
+
+        long start = System.nanoTime();
+        try {
+            OASParserUtil.validateAPIDefinition(def, true, opts);
+            Assert.fail("A blocked remote $ref in an OAS2 definition must be rejected");
+        } catch (APIManagementException e) {
+            Assert.assertEquals("A blocked remote $ref must surface as UNTRUSTED_URL_IN_DEFINITION",
+                    ExceptionCodes.UNTRUSTED_URL_IN_DEFINITION.getErrorCode(), e.getErrorHandler().getErrorCode());
+        }
+        long elapsedMillis = (System.nanoTime() - start) / 1_000_000;
+
+        // The safe resolver validates the host BEFORE any fetch, so a blocked direct ref is rejected without a
+        // network round trip. A fast (well under a second) rejection confirms no network fetch was attempted.
+        Assert.assertTrue("Expected the OAS2 remote-ref gate to reject quickly without attempting a network fetch, "
+                        + "but validation took " + elapsedMillis + "ms",
+                elapsedMillis < 5000);
+    }
+
+    @Test
+    public void testOAS2CleanIsValid() throws Exception {
+        String def = IOUtils.toString(getClass().getClassLoader().getResourceAsStream(
+                "definitions/oas2/ref_clean_no_remote.json"), "UTF-8");
+        OASParserOptions opts = new OASParserOptions();
+        opts.setNetworkAccessControlEnabled(true);
+        opts.setRemoteRefBlockList(Arrays.asList("169.254.169.254"));
+        APIDefinitionValidationResponse resp = OASParserUtil.validateAPIDefinition(def, true, opts);
+        Assert.assertTrue("A clean OAS2 definition with no remote $ref must validate successfully", resp.isValid());
+    }
+
+    @Test
+    public void testOAS2BlockedRemoteRefInYamlIsRejected() throws Exception {
+        // YAML variant of the OAS2 gate test: the gate scans the raw definition, so remote-ref extraction must
+        // handle YAML as well as JSON - otherwise a YAML body slips past and the legacy parser fetches unchecked.
+        String def = IOUtils.toString(getClass().getClassLoader().getResourceAsStream(
+                "definitions/oas2/ref_blocked_loopback.yaml"), "UTF-8");
+        OASParserOptions opts = new OASParserOptions();
+        opts.setNetworkAccessControlEnabled(true);
+        opts.setRemoteRefBlockList(Arrays.asList("169.254.169.254"));
+
+        long start = System.nanoTime();
+        try {
+            OASParserUtil.validateAPIDefinition(def, true, opts);
+            Assert.fail("A blocked remote $ref in a YAML OAS2 definition must be rejected");
+        } catch (APIManagementException e) {
+            Assert.assertEquals("A blocked remote $ref must surface as UNTRUSTED_URL_IN_DEFINITION",
+                    ExceptionCodes.UNTRUSTED_URL_IN_DEFINITION.getErrorCode(), e.getErrorHandler().getErrorCode());
+        }
+        long elapsedMillis = (System.nanoTime() - start) / 1_000_000;
+
+        Assert.assertTrue("Expected the OAS2 remote-ref gate to reject the YAML definition quickly without a network "
+                        + "fetch, but validation took " + elapsedMillis + "ms",
+                elapsedMillis < 5000);
+    }
+
+    @Test
+    public void testOAS2RemoteRefNotGatedWhenPolicyNotConfigured() throws Exception {
+        // Backwards compatibility: with the policy disabled, the OAS2 gate must not engage even with a block list
+        // present, so the legacy parser resolves refs as before; the .invalid fixture host makes the fetch fail fast.
+        String def = IOUtils.toString(getClass().getClassLoader().getResourceAsStream(
+                "definitions/oas2/ref_backcompat_invalidhost.json"), "UTF-8");
+        OASParserOptions opts = new OASParserOptions();
+        opts.setRemoteRefBlockList(Arrays.asList("blocked.invalid"));
+        // networkAccessControlEnabled deliberately left false (its default).
+
+        APIDefinitionValidationResponse resp = OASParserUtil.validateAPIDefinition(def, true, opts);
+
+        boolean rejectedByPolicy = resp.getErrorItems().stream().anyMatch(e -> e.getErrorDescription() != null
+                && e.getErrorDescription().contains("not permitted by the network access control policy"));
+        Assert.assertFalse("The remote-ref gate must not engage when no policy is configured", rejectedByPolicy);
+    }
+
+    @Test
+    public void testOAS2NestedRemoteRefIsRejected() throws Exception {
+        // Nested-ref case: an OAS2 top-level $ref to an allowed host whose document carries a nested $ref to a
+        // blocked host; the safe resolver validates every ref it crawls, so the nested block must be rejected.
+        com.sun.net.httpserver.HttpServer server =
+                com.sun.net.httpserver.HttpServer.create(new java.net.InetSocketAddress("127.0.0.1", 0), 0);
+        String outerBody = "{\"definitions\":{\"Nested\":{\"$ref\":\"http://169.254.169.254/latest/meta-data\"}}}";
+        server.createContext("/outer.json", exchange -> {
+            byte[] body = outerBody.getBytes(java.nio.charset.StandardCharsets.UTF_8);
+            exchange.sendResponseHeaders(200, body.length);
+            exchange.getResponseBody().write(body);
+            exchange.close();
+        });
+        server.start();
+        try {
+            int port = server.getAddress().getPort();
+            String def = "{\"swagger\":\"2.0\",\"info\":{\"title\":\"t\",\"version\":\"1.0.0\"},"
+                    + "\"paths\":{\"/x\":{\"get\":{\"responses\":{\"200\":{\"description\":\"ok\","
+                    + "\"schema\":{\"$ref\":\"http://127.0.0.1:" + port + "/outer.json#/definitions/Nested\"}}}}}}}";
+            OASParserOptions opts = new OASParserOptions();
+            opts.setNetworkAccessControlEnabled(true);
+            opts.setRemoteRefAllowList(Arrays.asList("127.0.0.1"));
+            opts.setRemoteRefBlockList(Arrays.asList("169.254.169.254"));
+            try {
+                OASParserUtil.validateAPIDefinition(def, true, opts);
+                Assert.fail("A nested remote $ref to a blocked host must be rejected");
+            } catch (APIManagementException e) {
+                Assert.assertEquals("A nested blocked remote $ref must surface as UNTRUSTED_URL_IN_DEFINITION",
+                        ExceptionCodes.UNTRUSTED_URL_IN_DEFINITION.getErrorCode(), e.getErrorHandler().getErrorCode());
+            }
+        } finally {
+            server.stop(0);
+        }
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.spec.parser/src/test/java/org/wso2/carbon/apimgt/spec/parser/definitions/OASParserUtilArchiveRefTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.spec.parser/src/test/java/org/wso2/carbon/apimgt/spec/parser/definitions/OASParserUtilArchiveRefTest.java
@@ -1,0 +1,186 @@
+/*
+ *   Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
+ *
+ *   WSO2 LLC. licenses this file to you under the Apache License,
+ *   Version 2.0 (the "License"); you may not use this file except
+ *   in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ *
+ */
+
+package org.wso2.carbon.apimgt.spec.parser.definitions;
+
+import com.sun.net.httpserver.HttpServer;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.wso2.carbon.apimgt.api.APIDefinitionValidationResponse;
+import org.wso2.carbon.apimgt.api.APIManagementException;
+import org.wso2.carbon.apimgt.api.ExceptionCodes;
+import org.wso2.carbon.apimgt.api.model.OASParserOptions;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+/**
+ * Tests that {@link OASParserUtil#extractAndValidateOpenAPIArchive} routes embedded remote {@code $ref}s in the
+ * archive master document through the network access-control safe URL resolver for OAS 3 archives, so a blocked
+ * remote reference is never fetched, while local sibling references inside the archive still resolve.
+ */
+public class OASParserUtilArchiveRefTest {
+
+    private HttpServer server;
+    private int serverPort;
+    private final AtomicInteger requestCount = new AtomicInteger(0);
+
+    private static final String FRAGMENT_SCHEMA =
+            "type: object\n"
+            + "properties:\n"
+            + "  name:\n"
+            + "    type: string\n";
+
+    @Before
+    public void startServer() throws IOException {
+        requestCount.set(0);
+        server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        // Bind the root context so ANY request path to the loopback server is counted.
+        server.createContext("/", exchange -> {
+            requestCount.incrementAndGet();
+            byte[] body = FRAGMENT_SCHEMA.getBytes(StandardCharsets.UTF_8);
+            exchange.sendResponseHeaders(200, body.length);
+            try (OutputStream os = exchange.getResponseBody()) {
+                os.write(body);
+            }
+        });
+        server.start();
+        serverPort = server.getAddress().getPort();
+    }
+
+    @After
+    public void stopServer() {
+        if (server != null) {
+            server.stop(0);
+        }
+    }
+
+    /**
+     * A network access-control policy that mirrors the safe-resolver setup used by the inline/URL OAS3 tests:
+     * access control enabled and the loopback host explicitly blocked.
+     */
+    private OASParserOptions blockLoopbackOptions() {
+        OASParserOptions options = new OASParserOptions();
+        options.setNetworkAccessControlEnabled(true);
+        options.setRemoteRefBlockList(Arrays.asList("127.0.0.1"));
+        return options;
+    }
+
+    private byte[] buildZip(Map<String, String> entries) throws IOException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (ZipOutputStream zos = new ZipOutputStream(baos)) {
+            for (Map.Entry<String, String> entry : entries.entrySet()) {
+                zos.putNextEntry(new ZipEntry(entry.getKey()));
+                zos.write(entry.getValue().getBytes(StandardCharsets.UTF_8));
+                zos.closeEntry();
+            }
+        }
+        return baos.toByteArray();
+    }
+
+    @Test
+    public void testArchiveRemoteRefIsBlockedAndNotFetched() throws Exception {
+        String master =
+                "openapi: 3.0.0\n"
+                + "info:\n"
+                + "  title: Archive Remote Ref API\n"
+                + "  version: 1.0.0\n"
+                + "paths:\n"
+                + "  /pets:\n"
+                + "    get:\n"
+                + "      summary: list\n"
+                + "      responses:\n"
+                + "        '200':\n"
+                + "          description: OK\n"
+                + "          content:\n"
+                + "            application/json:\n"
+                + "              schema:\n"
+                + "                $ref: 'http://127.0.0.1:" + serverPort + "/fragment.yaml'\n";
+
+        Map<String, String> entries = new LinkedHashMap<>();
+        // Single root folder as required by the extractor.
+        entries.put("archive/swagger.yaml", master);
+        byte[] zipBytes = buildZip(entries);
+
+        try {
+            OASParserUtil.extractAndValidateOpenAPIArchive(
+                    new ByteArrayInputStream(zipBytes), false, blockLoopbackOptions());
+            Assert.fail("An archive whose master carries a blocked remote $ref must be rejected");
+        } catch (APIManagementException e) {
+            Assert.assertEquals("A blocked remote $ref must surface as UNTRUSTED_URL_IN_DEFINITION",
+                    ExceptionCodes.UNTRUSTED_URL_IN_DEFINITION.getErrorCode(), e.getErrorHandler().getErrorCode());
+        }
+
+        Assert.assertEquals("A blocked remote $ref in an archived OpenAPI master must NOT be fetched "
+                        + "(zero HTTP requests expected against the loopback server)", 0, requestCount.get());
+    }
+
+    @Test
+    public void testArchiveLocalSiblingRefStillResolves() throws Exception {
+        String master =
+                "openapi: 3.0.0\n"
+                + "info:\n"
+                + "  title: Archive Local Ref API\n"
+                + "  version: 1.0.0\n"
+                + "paths:\n"
+                + "  /pets:\n"
+                + "    get:\n"
+                + "      summary: list\n"
+                + "      responses:\n"
+                + "        '200':\n"
+                + "          description: OK\n"
+                + "          content:\n"
+                + "            application/json:\n"
+                + "              schema:\n"
+                + "                $ref: './definitions.yaml#/Pet'\n";
+        String definitions =
+                "Pet:\n"
+                + "  type: object\n"
+                + "  properties:\n"
+                + "    id:\n"
+                + "      type: integer\n"
+                + "    name:\n"
+                + "      type: string\n";
+
+        Map<String, String> entries = new LinkedHashMap<>();
+        entries.put("archive/swagger.yaml", master);
+        entries.put("archive/definitions.yaml", definitions);
+        byte[] zipBytes = buildZip(entries);
+
+        APIDefinitionValidationResponse response = OASParserUtil.extractAndValidateOpenAPIArchive(
+                new ByteArrayInputStream(zipBytes), false, blockLoopbackOptions());
+
+        Assert.assertEquals("A local sibling $ref inside the archive must resolve from disk without any HTTP fetch",
+                0, requestCount.get());
+        Assert.assertTrue("A multi-file archive whose master references a local sibling file must still validate",
+                response.isValid());
+    }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.spec.parser/src/test/resources/definitions/oas2/ref_backcompat_invalidhost.json
+++ b/components/apimgt/org.wso2.carbon.apimgt.spec.parser/src/test/resources/definitions/oas2/ref_backcompat_invalidhost.json
@@ -1,0 +1,17 @@
+{
+  "swagger": "2.0",
+  "info": { "title": "backcompat-ref", "version": "1.0.0" },
+  "basePath": "/backcompat-ref/1.0.0",
+  "paths": {
+    "/x": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "ok",
+            "schema": { "$ref": "http://blocked.invalid/x.json#/X" }
+          }
+        }
+      }
+    }
+  }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.spec.parser/src/test/resources/definitions/oas2/ref_blocked_loopback.json
+++ b/components/apimgt/org.wso2.carbon.apimgt.spec.parser/src/test/resources/definitions/oas2/ref_blocked_loopback.json
@@ -1,0 +1,17 @@
+{
+  "swagger": "2.0",
+  "info": { "title": "blocked-ref", "version": "1.0.0" },
+  "basePath": "/blocked-ref/1.0.0",
+  "paths": {
+    "/x": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "ok",
+            "schema": { "$ref": "http://169.254.169.254/x.json#/X" }
+          }
+        }
+      }
+    }
+  }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.spec.parser/src/test/resources/definitions/oas2/ref_blocked_loopback.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.spec.parser/src/test/resources/definitions/oas2/ref_blocked_loopback.yaml
@@ -1,0 +1,15 @@
+# Swagger 2.0 definition (YAML) with a disallowed remote $ref. Regression fixture: a YAML OAS2 body must be
+# scanned for remote $refs by the network access control gate, not only a JSON one.
+swagger: "2.0"
+info:
+  title: blocked-ref-yaml
+  version: 1.0.0
+basePath: /blocked-ref-yaml/1.0.0
+paths:
+  /x:
+    get:
+      responses:
+        '200':
+          description: ok
+          schema:
+            $ref: 'http://169.254.169.254/x.json#/X'

--- a/components/apimgt/org.wso2.carbon.apimgt.spec.parser/src/test/resources/definitions/oas2/ref_clean_no_remote.json
+++ b/components/apimgt/org.wso2.carbon.apimgt.spec.parser/src/test/resources/definitions/oas2/ref_clean_no_remote.json
@@ -1,0 +1,25 @@
+{
+  "swagger": "2.0",
+  "info": { "title": "clean-no-remote-ref", "version": "1.0.0" },
+  "basePath": "/clean-no-remote-ref/1.0.0",
+  "paths": {
+    "/x": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "ok",
+            "schema": { "$ref": "#/definitions/X" }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "X": {
+      "type": "object",
+      "properties": {
+        "id": { "type": "string" }
+      }
+    }
+  }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.spec.parser/src/test/resources/definitions/oas3/ref_blocked_loopback.json
+++ b/components/apimgt/org.wso2.carbon.apimgt.spec.parser/src/test/resources/definitions/oas3/ref_blocked_loopback.json
@@ -1,0 +1,20 @@
+{
+  "openapi": "3.0.1",
+  "info": { "title": "blocked-ref", "version": "1.0.0" },
+  "paths": {
+    "/x": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "ok",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "http://169.254.169.254/x.yaml#/X" }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Purpose

Enforces the platform network access-control policy on the remaining publisher-side outbound fetches a user-supplied API definition can trigger, so a malicious spec or WSDL cannot make the server fetch attacker-controlled URLs (SSRF), read local files (LFI), or traverse outside an uploaded archive. All gates are **no-ops when no policy is configured** (backwards-compatible).

## What changed

### 1. OpenAPI / Swagger remote `$ref`
Uses swagger-parser's **built-in safe URL resolver** — no manual crawl. `OAS3Parser` enables `setSafelyResolveURL(...)` and receives allow/block host lists built from the policy by `APIUtil.buildRefResolutionOptions(...)` (mapped onto `OASParserOptions`). Wired at every OpenAPI validate / import / updateSwagger entry point, plus MCP-server validation and service-catalog import. Covers OAS 2.0 / 3.0 / 3.1. A blocked `$ref` fails validation with a neutral, non-leaking message.

### 2. WSDL schema / import fetches
- **WSDL 2.0 (Apache Woden):** `AccessControlledUriResolver` gates nested `wsdl:import`/`include` remote refs; a blocked ref redirects to a bundled fail-closed stub and surfaces `URL is not trusted`.
- **SOAP-to-REST (WSDL 1.1):** the namespace→`.xsd` fetch in `WSDL11SOAPOperationExtractor` is gated via `APIUtil.validateRemoteURL` before any connection.
- **WSDL 1.1 nested schema-import (`xsd:import`/`include`/`redefine`):** a new `AccessControlledWSDLLocator` is installed on all three read paths (`initPath`, `init(byte[])`, `init(URL)`) via the `readWSDL(WSDLLocator, Element)` overload (keeps the XXE-hardened root DOM). Remote refs are gated through the policy and fetched by `PolicyGatedSchemaFetcher`; local refs are resolved **relative to the referring document** and **contained to the archive root** via `APIFileUtil.resolveFilePath`. Escapes / absolute / untrusted-remote refs → `URL is not trusted` (900405); genuine fetch failures → `CANNOT_PROCESS_WSDL_CONTENT` (900676). Schema content is **not** disabled, so SOAP-to-REST is unaffected. `importDocuments=false` is unchanged (it never gated `xsd:import`).

## Configuration
`[apim.network_security.access_control]` in `deployment.toml` (platform) and `NetworkSecurityAccessControl` in `tenant-conf.json` (tenant).

## Testing
- ~40 unit/integration tests across the OAS parser, the WSDL locator/fetcher, and the processor wiring (locator classification/containment/chaining, scheme-smuggling, sibling independence, multi-file archives, WSDL 2.0 non-reachability regression).
- The WSDL 1.1 gate was **live-verified end-to-end** on an assembled pack: a clean nested-subdirectory archive resolves; malicious remote and traversal `xsd:import` refs are blocked with `URL is not trusted`, with zero outbound requests to the blocked host.

## Relationship to #13893
Supersedes **#13893** (`feature/nw-access-control-remote-fetches`), which is now closed. This branch was rebuilt fresh from `feature_nw_access_control`, so it shares no commits with #13893 above the base. Differences:
- **OpenAPI `$ref`:** reimplemented on swagger-parser's built-in safe resolver (removes the manual-crawl surface).
- **Added:** WSDL 2.0 / 1.1 + SOAP-to-REST gating.
- **Not included:** the gateway XSD/DTD (`XMLSchemaValidator`) line that #13893 carried — descoped on this branch line.
