### PR TITLE
Fix pagination boundary logic in getPaginatedSubscribedAPIsByApplication

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/ApiMgtDAO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/ApiMgtDAO.java
@@ -23020,35 +23020,33 @@ public class ApiMgtDAO {
             try (ResultSet result = ps.executeQuery()) {
                 int index = 0;
                 while (result.next()) {
-                    if (index >= offset && index < (limit + offset)) {
-                        String apiType = result.getString("TYPE");
-
-                        if (APIConstants.API_PRODUCT.equalsIgnoreCase(apiType)) {
-                            APIProductIdentifier identifier = new APIProductIdentifier(
-                                    APIUtil.replaceEmailDomain(result.getString("API_PROVIDER")),
-                                    result.getString("API_NAME"), result.getString("API_VERSION"));
-                            identifier.setUuid(result.getString("API_UUID"));
-                            SubscribedAPI subscribedAPI = new SubscribedAPI(application.getSubscriber(), identifier);
-                            subscribedAPI.setApplication(application);
-                            initSubscribedAPI(subscribedAPI, result);
-                            subscribedAPIs.add(subscribedAPI);
-                        } else {
-                            APIIdentifier identifier = new APIIdentifier(APIUtil.replaceEmailDomain(result.getString
-                                    ("API_PROVIDER")), result.getString("API_NAME"),
-                                    result.getString("API_VERSION"));
-                            identifier.setUuid(result.getString("API_UUID"));
-                            SubscribedAPI subscribedAPI = new SubscribedAPI(application.getSubscriber(), identifier);
-                            subscribedAPI.setApplication(application);
-                            initSubscribedAPI(subscribedAPI, result);
-                            subscribedAPIs.add(subscribedAPI);
-                        }
-
-                        if (index == limit + offset - 1) {
-                            break;
-                        }
+                    if (index++ < offset) {
+                        continue;
                     }
-                    index++;
+                    if (subscribedAPIs.size() >= limit) {
+                        break;
+                    }
+                    String apiType = result.getString("TYPE");
 
+                    if (APIConstants.API_PRODUCT.equalsIgnoreCase(apiType)) {
+                        APIProductIdentifier identifier = new APIProductIdentifier(
+                                APIUtil.replaceEmailDomain(result.getString("API_PROVIDER")),
+                                result.getString("API_NAME"), result.getString("API_VERSION"));
+                        identifier.setUuid(result.getString("API_UUID"));
+                        SubscribedAPI subscribedAPI = new SubscribedAPI(application.getSubscriber(), identifier);
+                        subscribedAPI.setApplication(application);
+                        initSubscribedAPI(subscribedAPI, result);
+                        subscribedAPIs.add(subscribedAPI);
+                    } else {
+                        APIIdentifier identifier = new APIIdentifier(APIUtil.replaceEmailDomain(result.getString
+                                ("API_PROVIDER")), result.getString("API_NAME"),
+                                result.getString("API_VERSION"));
+                        identifier.setUuid(result.getString("API_UUID"));
+                        SubscribedAPI subscribedAPI = new SubscribedAPI(application.getSubscriber(), identifier);
+                        subscribedAPI.setApplication(application);
+                        initSubscribedAPI(subscribedAPI, result);
+                        subscribedAPIs.add(subscribedAPI);
+                    }
                 }
             }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/ApiMgtDAO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/ApiMgtDAO.java
@@ -23010,6 +23010,7 @@ public class ApiMgtDAO {
     public Set<SubscribedAPI> getPaginatedSubscribedAPIsByApplication(Application application, Integer offset,
                                                                       Integer limit, String organization)
             throws APIManagementException {
+                
         Set<SubscribedAPI> subscribedAPIs = new LinkedHashSet<>();
 
         try (Connection connection = APIMgtDBUtil.getConnection();


### PR DESCRIPTION
## Summary
- Fixes an off-by-one/boundary bug in `ApiMgtDAO.getPaginatedSubscribedAPIsByApplication` where the loop condition and break condition used `limit` instead of `limit + offset`, causing incorrect pagination of an application's subscriptions (e.g. `offset=2&limit=2` did not return the expected page).
- Reworks the loop to skip rows before `offset` and stop once `limit` items have been collected, which is simpler and correct regardless of `offset`.

## Source fix
https://github.com/wso2-support/carbon-apimgt/pull/8332

## Tracking issue
https://github.com/wso2/api-manager/issues/5082