### PR TITLE
Implement http protocol support for OLTP

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/APIMgtGatewayConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/APIMgtGatewayConstants.java
@@ -188,6 +188,9 @@ public class APIMgtGatewayConstants {
     public static final String SPAN_HTTP_RESPONSE_STATUS_CODE = "span.http.response.status.code";
     public static final String SPAN_HTTP_RESPONSE_STATUS_CODE_DESCRIPTION =
             "span.http.response.status.code.description";
+    public static final String HTTP_METHOD_ATTRIBUTE = "http.method";
+    public static final String HTTP_URL_ATTRIBUTE = "http.url";
+    public static final String HTTP_STATUS_CODE_ATTRIBUTE = "http.status_code";
 
     public static final String INTERNAL_KEY = "Internal-Key";
 

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/analytics/APIMgtGoogleAnalyticsTrackingHandler.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/analytics/APIMgtGoogleAnalyticsTrackingHandler.java
@@ -34,6 +34,7 @@ import org.wso2.carbon.apimgt.gateway.handlers.security.APISecurityUtils;
 import org.wso2.carbon.apimgt.gateway.handlers.security.AuthenticationContext;
 import org.wso2.carbon.apimgt.gateway.internal.ServiceReferenceHolder;
 import org.wso2.carbon.apimgt.gateway.utils.APIMgtGoogleAnalyticsUtils;
+import org.wso2.carbon.apimgt.gateway.utils.GatewayUtils;
 import org.wso2.carbon.apimgt.tracing.TracingSpan;
 import org.wso2.carbon.apimgt.tracing.TracingTracer;
 import org.wso2.carbon.apimgt.tracing.Util;
@@ -92,6 +93,7 @@ public class APIMgtGoogleAnalyticsTrackingHandler extends AbstractHandler {
             tracer = ServiceReferenceHolder.getInstance().getTelemetryTracer();
             span = TelemetryUtil.startSpan(APIMgtGatewayConstants.GOOGLE_ANALYTICS_HANDLER, responseLatencySpan,
                     tracer);
+            GatewayUtils.setCommonHTTPAttributes(span, msgCtx);
         } else if (Util.tracingEnabled()) {
             TracingSpan responseLatencySpan =
                     (TracingSpan) msgCtx.getProperty(APIMgtGatewayConstants.RESOURCE_SPAN);

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/common/APIMgtLatencyStatsHandler.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/common/APIMgtLatencyStatsHandler.java
@@ -35,6 +35,7 @@ import org.apache.synapse.rest.AbstractHandler;
 import org.jetbrains.annotations.NotNull;
 import org.wso2.carbon.apimgt.gateway.APIMgtGatewayConstants;
 import org.wso2.carbon.apimgt.gateway.internal.ServiceReferenceHolder;
+import org.wso2.carbon.apimgt.gateway.utils.GatewayUtils;
 import org.wso2.carbon.apimgt.impl.utils.APIUtil;
 import org.wso2.carbon.apimgt.tracing.TracingSpan;
 import org.wso2.carbon.apimgt.tracing.TracingTracer;
@@ -70,6 +71,7 @@ public class APIMgtLatencyStatsHandler extends AbstractHandler {
             TelemetryTracer tracer = ServiceReferenceHolder.getInstance().getTelemetryTracer();
             TelemetrySpan span = TelemetryUtil.startSpan(APIMgtGatewayConstants.RESOURCE_SPAN, responseLatencySpan,
                     tracer);
+            GatewayUtils.setCommonHTTPAttributes(span, messageContext);
             messageContext.setProperty(APIMgtGatewayConstants.RESOURCE_SPAN, span);
         } else if (Util.tracingEnabled()) {
             TracingSpan responseLatencySpan =

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/common/APIMgtLatencySynapseHandler.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/common/APIMgtLatencySynapseHandler.java
@@ -60,6 +60,7 @@ public class APIMgtLatencySynapseHandler extends AbstractSynapseHandler {
 
                 TelemetrySpan responseLatencySpan = TelemetryUtil.startSpan(APIMgtGatewayConstants.RESPONSE_LATENCY,
                         spanContext, telemetryTracer);
+                GatewayUtils.setCommonHTTPAttributes(responseLatencySpan, messageContext);
                 GatewayUtils.setRequestRelatedTags(responseLatencySpan, messageContext);
                 messageContext.setProperty(APIMgtGatewayConstants.RESPONSE_LATENCY, responseLatencySpan);
             }
@@ -98,6 +99,7 @@ public class APIMgtLatencySynapseHandler extends AbstractSynapseHandler {
                         (TelemetrySpan) messageContext.getProperty(APIMgtGatewayConstants.RESOURCE_SPAN);
                 TelemetrySpan backendLatencySpan = TelemetryUtil.startSpan(APIMgtGatewayConstants.BACKEND_LATENCY_SPAN,
                         parentSpan, telemetryTracer);
+                GatewayUtils.setCommonHTTPAttributes(backendLatencySpan, messageContext);
                 messageContext.setProperty(APIMgtGatewayConstants.BACKEND_LATENCY_SPAN, backendLatencySpan);
                 TelemetryUtil.inject(backendLatencySpan, tracerSpecificCarrier);
             }
@@ -118,6 +120,7 @@ public class APIMgtLatencySynapseHandler extends AbstractSynapseHandler {
             TelemetrySpan backendLatencySpan =
                     (TelemetrySpan) messageContext.getProperty(APIMgtGatewayConstants.BACKEND_LATENCY_SPAN);
             if (backendLatencySpan != null) {
+                GatewayUtils.setCommonHTTPAttributes(backendLatencySpan, messageContext);
                 GatewayUtils.setEndpointRelatedInformation(backendLatencySpan, messageContext);
                 TelemetryUtil.finishSpan(backendLatencySpan);
             }
@@ -137,12 +140,14 @@ public class APIMgtLatencySynapseHandler extends AbstractSynapseHandler {
         if (TelemetryUtil.telemetryEnabled()) {
             Object resourceSpanObject = messageContext.getProperty(APIMgtGatewayConstants.RESOURCE_SPAN);
             if (resourceSpanObject != null) {
+                GatewayUtils.setCommonHTTPAttributes((TelemetrySpan) resourceSpanObject, messageContext);
                 GatewayUtils.setAPIResource((TelemetrySpan) resourceSpanObject, messageContext);
                 TelemetryUtil.finishSpan((TelemetrySpan) resourceSpanObject);
             }
             TelemetrySpan responseLatencySpan =
                     (TelemetrySpan) messageContext.getProperty(APIMgtGatewayConstants.RESPONSE_LATENCY);
             if (responseLatencySpan != null) {
+                GatewayUtils.setCommonHTTPAttributes(responseLatencySpan, messageContext);
                 GatewayUtils.setAPIRelatedTags(responseLatencySpan, messageContext);
                 API api = GatewayUtils.getAPI(messageContext);
                 String tenantDomain = (String) messageContext.getProperty(APIMgtGatewayConstants.TENANT_DOMAIN);

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/ext/APIManagerExtensionHandler.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/ext/APIManagerExtensionHandler.java
@@ -29,6 +29,7 @@ import org.apache.synapse.rest.RESTConstants;
 import org.wso2.carbon.apimgt.gateway.APIMgtGatewayConstants;
 import org.wso2.carbon.apimgt.gateway.MethodStats;
 import org.wso2.carbon.apimgt.gateway.internal.ServiceReferenceHolder;
+import org.wso2.carbon.apimgt.gateway.utils.GatewayUtils;
 import org.wso2.carbon.apimgt.impl.APIConstants;
 import org.wso2.carbon.apimgt.tracing.TracingSpan;
 import org.wso2.carbon.apimgt.tracing.TracingTracer;
@@ -112,6 +113,7 @@ public class APIManagerExtensionHandler extends AbstractHandler {
             TelemetryTracer tracer = ServiceReferenceHolder.getInstance().getTelemetryTracer();
             requestMediationSpan = TelemetryUtil.startSpan(APIMgtGatewayConstants.REQUEST_MEDIATION,
                     responseLatencySpan, tracer);
+            GatewayUtils.setCommonHTTPAttributes(requestMediationSpan, messageContext);
         } else if (Util.tracingEnabled()) {
             TracingSpan responseLatencySpan =
                     (TracingSpan) messageContext.getProperty(APIMgtGatewayConstants.RESOURCE_SPAN);
@@ -167,6 +169,7 @@ public class APIManagerExtensionHandler extends AbstractHandler {
             TelemetryTracer tracer = ServiceReferenceHolder.getInstance().getTelemetryTracer();
             responseMediationSpan =
                     TelemetryUtil.startSpan(APIMgtGatewayConstants.RESPONSE_MEDIATION, responseLatencySpan, tracer);
+            GatewayUtils.setCommonHTTPAttributes(responseMediationSpan, messageContext);
         } else if (Util.tracingEnabled()) {
             TracingSpan responseLatencySpan =
                     (TracingSpan) messageContext.getProperty(APIMgtGatewayConstants.RESOURCE_SPAN);

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/APIAuthenticationHandler.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/APIAuthenticationHandler.java
@@ -419,6 +419,7 @@ public class APIAuthenticationHandler extends AbstractHandler implements Managed
                     (TelemetrySpan) messageContext.getProperty(APIMgtGatewayConstants.RESOURCE_SPAN);
             TelemetryTracer tracer = ServiceReferenceHolder.getInstance().getTelemetryTracer();
             keySpan = TelemetryUtil.startSpan(APIMgtGatewayConstants.KEY_VALIDATION, responseLatencySpan, tracer);
+            GatewayUtils.setCommonHTTPAttributes(keySpan, messageContext);
             messageContext.setProperty(APIMgtGatewayConstants.KEY_VALIDATION, keySpan);
             org.apache.axis2.context.MessageContext axis2MC =
                     ((Axis2MessageContext) messageContext).getAxis2MessageContext();

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/CORSRequestHandler.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/CORSRequestHandler.java
@@ -36,6 +36,7 @@ import org.wso2.carbon.apimgt.gateway.MethodStats;
 import org.wso2.carbon.apimgt.gateway.handlers.LogsHandler;
 import org.wso2.carbon.apimgt.gateway.handlers.Utils;
 import org.wso2.carbon.apimgt.gateway.internal.ServiceReferenceHolder;
+import org.wso2.carbon.apimgt.gateway.utils.GatewayUtils;
 import org.wso2.carbon.apimgt.impl.APIConstants;
 import org.wso2.carbon.apimgt.impl.APIManagerConfigurationService;
 import org.wso2.carbon.apimgt.impl.utils.APIUtil;
@@ -140,6 +141,7 @@ public class CORSRequestHandler extends AbstractHandler implements ManagedLifecy
             TelemetryTracer tracer = ServiceReferenceHolder.getInstance().getTelemetryTracer();
             corsRequestHandlerSpan =
                     TelemetryUtil.startSpan(APIMgtGatewayConstants.CORS_REQUEST_HANDLER, responseLatencySpan, tracer);
+            GatewayUtils.setCommonHTTPAttributes(corsRequestHandlerSpan, messageContext);
         } else if (Util.tracingEnabled()) {
             TracingSpan responseLatencySpan =
                     (TracingSpan) messageContext.getProperty(APIMgtGatewayConstants.RESOURCE_SPAN);

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/throttling/APIThrottleHandler.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/throttling/APIThrottleHandler.java
@@ -173,6 +173,7 @@ public class APIThrottleHandler extends AbstractHandler {
             TelemetryTracer tracer = ServiceReferenceHolder.getInstance().getTelemetryTracer();
             throttlingLatencySpan = TelemetryUtil.startSpan(APIMgtGatewayConstants.THROTTLE_LATENCY,
                     responseLatencySpan, tracer);
+            GatewayUtils.setCommonHTTPAttributes(throttlingLatencySpan, messageContext);
         } else if (Util.tracingEnabled()) {
             TracingSpan responseLatencySpan =
                     (TracingSpan) messageContext.getProperty(APIMgtGatewayConstants.RESOURCE_SPAN);

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/throttling/ThrottleHandler.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/throttling/ThrottleHandler.java
@@ -651,6 +651,7 @@ public class ThrottleHandler extends AbstractHandler implements ManagedLifecycle
             TelemetryTracer tracer = ServiceReferenceHolder.getInstance().getTelemetryTracer();
             throttleLatencySpan = TelemetryUtil.startSpan(APIMgtGatewayConstants.THROTTLE_LATENCY,
                         responseLatencySpan, tracer);
+            GatewayUtils.setCommonHTTPAttributes(throttleLatencySpan, messageContext);
         } else if (Util.tracingEnabled()) {
             TracingSpan responseLatencySpan =
                     (TracingSpan) messageContext.getProperty(APIMgtGatewayConstants.RESOURCE_SPAN);
@@ -713,6 +714,7 @@ public class ThrottleHandler extends AbstractHandler implements ManagedLifecycle
                 TelemetryTracer tracer = ServiceReferenceHolder.getInstance().getTelemetryTracer();
                 throttleLatencySpan = TelemetryUtil.startSpan(APIMgtGatewayConstants.THROTTLE_LATENCY,
                         responseLatencySpan, tracer);
+                GatewayUtils.setCommonHTTPAttributes(throttleLatencySpan, messageContext);
             } else if (Util.tracingEnabled()) {
                 TracingSpan responseLatencySpan =
                         (TracingSpan) messageContext.getProperty(APIMgtGatewayConstants.RESOURCE_SPAN);

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/utils/GatewayUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/utils/GatewayUtils.java
@@ -47,6 +47,7 @@ import org.apache.http.HttpHeaders;
 import org.apache.http.HttpStatus;
 import org.apache.synapse.Mediator;
 import org.apache.synapse.SynapseConstants;
+import org.apache.synapse.api.ApiUtils;
 import org.apache.synapse.commons.json.JsonUtil;
 import org.apache.synapse.core.axis2.Axis2MessageContext;
 import org.apache.synapse.rest.RESTConstants;
@@ -1230,6 +1231,37 @@ public class GatewayUtils {
         if (consumerKey != null) {
             Util.setTag(tracingSpan, APIMgtGatewayConstants.SPAN_APPLICATION_CONSUMER_KEY,
                     (String) consumerKey);
+        }
+    }
+
+    // Sets common HTTP attributes (method, URL, status code) on an OpenTelemetry span.
+    // Best-effort instrumentation: any failure is logged and swallowed so tracing never breaks the request flow.
+    public static void setCommonHTTPAttributes(TelemetrySpan tracingSpan,
+                                               org.apache.synapse.MessageContext messageContext) {
+
+        try {
+            org.apache.axis2.context.MessageContext axis2MessageContext =
+                    ((Axis2MessageContext) messageContext).getAxis2MessageContext();
+            String httpMethod = (String) axis2MessageContext.getProperty(Constants.Configuration.HTTP_METHOD);
+            if (StringUtils.isEmpty(httpMethod)) {
+                httpMethod = (String) messageContext.getProperty(RESTConstants.REST_METHOD);
+            }
+            if (StringUtils.isNotEmpty(httpMethod)) {
+                TelemetryUtil.setTag(tracingSpan, APIMgtGatewayConstants.HTTP_METHOD_ATTRIBUTE, httpMethod);
+            }
+
+            String fullRequestPath = ApiUtils.getFullRequestPath(messageContext);
+            if (StringUtils.isNotEmpty(fullRequestPath)) {
+                TelemetryUtil.setTag(tracingSpan, APIMgtGatewayConstants.HTTP_URL_ATTRIBUTE, fullRequestPath);
+            }
+
+            Object httpStatusCode = axis2MessageContext.getProperty(HTTP_SC);
+            if (httpStatusCode != null) {
+                TelemetryUtil.setTag(tracingSpan, APIMgtGatewayConstants.HTTP_STATUS_CODE_ATTRIBUTE,
+                        httpStatusCode.toString());
+            }
+        } catch (Exception e) {
+            log.error("Error while setting common HTTP attributes on the tracing span.", e);
         }
     }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.tracing/src/main/java/org/wso2/carbon/apimgt/tracing/telemetry/OTLPTelemetry.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.tracing/src/main/java/org/wso2/carbon/apimgt/tracing/telemetry/OTLPTelemetry.java
@@ -22,11 +22,14 @@ import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator;
 import io.opentelemetry.context.propagation.ContextPropagators;
+import io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporter;
+import io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporterBuilder;
 import io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporter;
 import io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporterBuilder;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
 import io.opentelemetry.sdk.trace.export.BatchSpanProcessor;
+import io.opentelemetry.sdk.trace.export.SpanExporter;
 import io.opentelemetry.sdk.trace.samplers.Sampler;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
@@ -53,7 +56,9 @@ public class OTLPTelemetry implements APIMOpenTelemetry {
         String headerKey = null;
         String headerValue = null;
 
-
+        String otlpProtocol = configuration.getFirstProperty(TelemetryConstants.OTLP_CONFIG_PROTOCOL) != null ?
+                configuration.getFirstProperty(TelemetryConstants.OTLP_CONFIG_PROTOCOL) :
+                TelemetryConstants.GRPC_PROTOCOL;
         String headerProperty = getHeaderKeyProperty();
         String endPointURL = configuration.getFirstProperty(TelemetryConstants.OTLP_CONFIG_URL) != null ?
                 configuration.getFirstProperty(TelemetryConstants.OTLP_CONFIG_URL) : null;
@@ -64,29 +69,21 @@ public class OTLPTelemetry implements APIMOpenTelemetry {
                     configuration.getFirstProperty(headerProperty) : null;
         }
 
-        if (StringUtils.isNotEmpty(endPointURL)) {
-            OtlpGrpcSpanExporterBuilder otlpGrpcSpanExporterBuilder = null;
-            if (headerKey != null && headerValue != null) {
-                otlpGrpcSpanExporterBuilder = OtlpGrpcSpanExporter.builder()
-                        .setEndpoint(endPointURL)
-                        .setCompression("gzip")
-                        .addHeader(headerKey, headerValue);
-            } else {
-                otlpGrpcSpanExporterBuilder = OtlpGrpcSpanExporter.builder()
-                        .setEndpoint(endPointURL)
-                        .setCompression("gzip");
-                if (log.isDebugEnabled()) {
-                    log.debug("OTLP exporter: " + otlpGrpcSpanExporterBuilder + " is configured at " + endPointURL +
-                            " without headers.");
-                }
-            }
+        boolean useHttp;
+        if (TelemetryConstants.HTTP_PROTOCOL.equalsIgnoreCase(otlpProtocol)) {
+            useHttp = true;
+        } else if (TelemetryConstants.GRPC_PROTOCOL.equalsIgnoreCase(otlpProtocol)) {
+            useHttp = false;
+        } else {
+            log.warn("OTLP protocol '" + otlpProtocol + "' is invalid. Defaulting to gRPC.");
+            useHttp = false;
+        }
 
-            if (log.isDebugEnabled()) {
-                log.debug("OTLP exporter: " + otlpGrpcSpanExporterBuilder + " is configured at " + endPointURL);
-            }
+        if (StringUtils.isNotEmpty(endPointURL)) {
+            SpanExporter spanExporter = buildSpanExporter(useHttp, endPointURL, headerKey, headerValue);
 
             sdkTracerProvider = SdkTracerProvider.builder()
-                    .addSpanProcessor(BatchSpanProcessor.builder(otlpGrpcSpanExporterBuilder.build()).build())
+                    .addSpanProcessor(BatchSpanProcessor.builder(spanExporter).build())
                     .setResource(TelemetryUtil.getTracerProviderResource(serviceName))
                     .setSampler(getConfiguredSampler())
                     .build();
@@ -129,6 +126,41 @@ public class OTLPTelemetry implements APIMOpenTelemetry {
         if (sdkTracerProvider != null) {
             sdkTracerProvider.close();
         }
+    }
+
+    /**
+     * Builds the OTLP span exporter for the configured protocol (HTTP or gRPC).
+     *
+     * @param useHttp     whether to use the OTLP/HTTP exporter instead of OTLP/gRPC.
+     * @param endPointURL the OTLP endpoint URL.
+     * @param headerKey   optional authentication header name (may be {@code null}).
+     * @param headerValue optional authentication header value (may be {@code null}).
+     * @return the configured {@link SpanExporter}.
+     */
+    private SpanExporter buildSpanExporter(boolean useHttp, String endPointURL, String headerKey, String headerValue) {
+
+        boolean hasHeader = headerKey != null && headerValue != null;
+        SpanExporter spanExporter;
+        if (useHttp) {
+            OtlpHttpSpanExporterBuilder builder =
+                    OtlpHttpSpanExporter.builder().setEndpoint(endPointURL).setCompression("gzip");
+            if (hasHeader) {
+                builder.addHeader(headerKey, headerValue);
+            }
+            spanExporter = builder.build();
+        } else {
+            OtlpGrpcSpanExporterBuilder builder =
+                    OtlpGrpcSpanExporter.builder().setEndpoint(endPointURL).setCompression("gzip");
+            if (hasHeader) {
+                builder.addHeader(headerKey, headerValue);
+            }
+            spanExporter = builder.build();
+        }
+        if (log.isDebugEnabled()) {
+            log.debug("OTLP " + (useHttp ? "HTTP" : "gRPC") + " exporter is configured at " + endPointURL +
+                    (hasHeader ? " with header: " + headerKey : " without headers."));
+        }
+        return spanExporter;
     }
 
     /**

--- a/components/apimgt/org.wso2.carbon.apimgt.tracing/src/main/java/org/wso2/carbon/apimgt/tracing/telemetry/TelemetryConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.tracing/src/main/java/org/wso2/carbon/apimgt/tracing/telemetry/TelemetryConstants.java
@@ -64,6 +64,9 @@ public class TelemetryConstants {
      */
     static final String OTLP_CONFIG_URL = "OpenTelemetry.RemoteTracer.Url";
     static final String OPENTELEMETRY_PROPERTIES_PREFIX = "OpenTelemetry.RemoteTracer.Properties.";
+    static final String OTLP_CONFIG_PROTOCOL = "OpenTelemetry.RemoteTracer.Protocol";
+    static final String HTTP_PROTOCOL = "http";
+    static final String GRPC_PROTOCOL = "grpc";
 
     /**
      * Sampler Constants.


### PR DESCRIPTION
This pull request adds and standardizes the setting of common HTTP attributes (method, URL, status code) to OpenTelemetry spans throughout the API Gateway codebase. This improves the observability and traceability of HTTP requests in distributed tracing systems. The main changes include introducing a utility method for setting these attributes, updating multiple handlers to use this method, and adding related constants.

**Tracing and Observability Improvements:**

* Added a new utility method `GatewayUtils.setCommonHTTPAttributes` to set HTTP method, URL, and status code on OpenTelemetry spans, with best-effort error handling.
* Updated multiple handlers (`APIMgtGoogleAnalyticsTrackingHandler`, `APIMgtLatencyStatsHandler`, `APIMgtLatencySynapseHandler`, `APIManagerExtensionHandler`, `APIAuthenticationHandler`, `CORSRequestHandler`, `APIThrottleHandler`, `ThrottleHandler`) to call `GatewayUtils.setCommonHTTPAttributes` after starting relevant spans. [[1]](diffhunk://#diff-53dc17b96c5c19dc6e907e350bc00b2d05aa08c17ab9b3708c781e273b604158R96) [[2]](diffhunk://#diff-9239cf060d586c7678baaf71aa32740b12f3fb15f8793f54feda054ea45e6cf6R74) [[3]](diffhunk://#diff-4b855a6b00716158073357b65fdf100d70edcba0c4649729ae5a092074618023R63) [[4]](diffhunk://#diff-4b855a6b00716158073357b65fdf100d70edcba0c4649729ae5a092074618023R102) [[5]](diffhunk://#diff-4b855a6b00716158073357b65fdf100d70edcba0c4649729ae5a092074618023R123) [[6]](diffhunk://#diff-4b855a6b00716158073357b65fdf100d70edcba0c4649729ae5a092074618023R143-R150) [[7]](diffhunk://#diff-4b855a6b00716158073357b65fdf100d70edcba0c4649729ae5a092074618023R143-R150) [[8]](diffhunk://#diff-a88ba7070865fa4e0a81e46ab52ccabbc134fbdb40c31813d5b5edd35f32769cR116) [[9]](diffhunk://#diff-a88ba7070865fa4e0a81e46ab52ccabbc134fbdb40c31813d5b5edd35f32769cR172) [[10]](diffhunk://#diff-76280f3d637e984ee109a298fd3c91ce6594d144617d93104ef756bbd2f3358cR422) [[11]](diffhunk://#diff-014764be89089ec9162adcff559701faad8cb4e0c4f70a31160f868df3300842R144) [[12]](diffhunk://#diff-764de9bf75769a25514501dfbb5f2a3a7f999e5bc338c045420a709ad7032427R176) [[13]](diffhunk://#diff-04ae424ed0b342e684b343d19d156c22a697dbb495e1a401ea47cb38fddd6545R654) [[14]](diffhunk://#diff-04ae424ed0b342e684b343d19d156c22a697dbb495e1a401ea47cb38fddd6545R717)

**Constants and Imports:**

* Added new constants to `APIMgtGatewayConstants` for HTTP method, URL, and status code attribute keys.
* Updated imports in several files to include `GatewayUtils` and other required classes. [[1]](diffhunk://#diff-53dc17b96c5c19dc6e907e350bc00b2d05aa08c17ab9b3708c781e273b604158R37) [[2]](diffhunk://#diff-9239cf060d586c7678baaf71aa32740b12f3fb15f8793f54feda054ea45e6cf6R38) [[3]](diffhunk://#diff-a88ba7070865fa4e0a81e46ab52ccabbc134fbdb40c31813d5b5edd35f32769cR32) [[4]](diffhunk://#diff-014764be89089ec9162adcff559701faad8cb4e0c4f70a31160f868df3300842R39) [[5]](diffhunk://#diff-422cae94f248bce357fbabb8ece7f8aa0d989be7579cdb164f4d68123709f0caR50)

**OpenTelemetry Protocol Support:**

* Added logic in `OTLPTelemetry` to support configuring the OTLP protocol (gRPC or HTTP) via configuration, defaulting to gRPC if not specified. [[1]](diffhunk://#diff-d5ea50e91d2bc7d01200d6c97993a253591efc87c7e725254d1d00eccce8270fL56-R61) [[2]](diffhunk://#diff-d5ea50e91d2bc7d01200d6c97993a253591efc87c7e725254d1d00eccce8270fR25-R32)

These changes collectively enhance distributed tracing by ensuring that all relevant HTTP metadata is consistently attached to tracing spans across the API Gateway.