### PR TITLE
Fix application info getting as anonymous in apim_metrics logs with 3rd party KMs

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/analytics/SynapseAnalyticsDataProvider.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/analytics/SynapseAnalyticsDataProvider.java
@@ -18,6 +18,7 @@
 package org.wso2.carbon.apimgt.gateway.handlers.analytics;
 
 import com.google.gson.Gson;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.axiom.soap.SOAPBody;
 import org.apache.axiom.soap.SOAPEnvelope;
 import org.apache.commons.logging.Log;
@@ -142,7 +143,8 @@ public class SynapseAnalyticsDataProvider implements AnalyticsDataProvider {
     public boolean isAnonymous() {
 
         AuthenticationContext authContext = APISecurityUtils.getAuthenticationContext(messageContext);
-        return isAuthenticated() && APIConstants.END_USER_ANONYMOUS.equalsIgnoreCase(authContext.getUsername());
+        return isAuthenticated() && APIConstants.END_USER_ANONYMOUS.equalsIgnoreCase(authContext.getUsername())
+                && StringUtils.isEmpty(authContext.getApplicationUUID());
     }
 
     @Override

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/streaming/websocket/WebSocketAnalyticsDataProvider.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/streaming/websocket/WebSocketAnalyticsDataProvider.java
@@ -19,6 +19,7 @@
 package org.wso2.carbon.apimgt.gateway.handlers.streaming.websocket;
 
 import io.netty.channel.ChannelHandlerContext;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.synapse.SynapseConstants;
@@ -109,7 +110,8 @@ public class WebSocketAnalyticsDataProvider implements AnalyticsDataProvider {
     @Override
     public boolean isAnonymous() {
         AuthenticationContext authContext = getAuthenticationContext();
-        return isAuthenticated() && APIConstants.END_USER_ANONYMOUS.equalsIgnoreCase(authContext.getUsername());
+        return isAuthenticated() && APIConstants.END_USER_ANONYMOUS.equalsIgnoreCase(authContext.getUsername())
+                && StringUtils.isEmpty(authContext.getApplicationUUID());
     }
 
     @Override

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/test/java/org/wso2/carbon/apimgt/gateway/handlers/analytics/SynapseAnalyticsDataProviderTestCase.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/test/java/org/wso2/carbon/apimgt/gateway/handlers/analytics/SynapseAnalyticsDataProviderTestCase.java
@@ -33,6 +33,8 @@ import org.wso2.carbon.apimgt.common.analytics.publishers.dto.Application;
 import org.wso2.carbon.apimgt.common.analytics.publishers.dto.enums.EventCategory;
 import org.wso2.carbon.apimgt.common.analytics.publishers.dto.enums.FaultCategory;
 import org.wso2.carbon.apimgt.gateway.APIMgtGatewayConstants;
+import org.wso2.carbon.apimgt.gateway.handlers.security.APISecurityUtils;
+import org.wso2.carbon.apimgt.gateway.handlers.security.AuthenticationContext;
 import org.wso2.carbon.apimgt.gateway.mcp.request.Params;
 import org.wso2.carbon.apimgt.impl.APIConstants;
 
@@ -413,5 +415,45 @@ public class SynapseAnalyticsDataProviderTestCase {
         Field field = SynapseAnalyticsDataProvider.class.getDeclaredField("buildResponseMessage");
         field.setAccessible(true);
         field.set(provider, value);
+    }
+
+    /**
+     * Client Credentials grant: username is "anonymous" but applicationUUID is populated because
+     * subscription validation succeeded. isAnonymous() must return false so that real app fields
+     * are not overwritten with "anonymous" in analytics.
+     */
+    @Test
+    public void testIsAnonymousReturnsFalseForClientCredentialsGrantWithPopulatedApplicationUUID() {
+        AuthenticationContext authContext = new AuthenticationContext();
+        authContext.setAuthenticated(true);
+        authContext.setUsername(APIConstants.END_USER_ANONYMOUS);
+        authContext.setApplicationUUID("550e8400-e29b-41d4-a716-446655440000");
+
+        Axis2MessageContext messageContext = mockAxis2MessageContext(Collections.emptyMap(), Collections.emptyMap());
+        Mockito.when(messageContext.getProperty(APISecurityUtils.API_AUTH_CONTEXT)).thenReturn(authContext);
+
+        SynapseAnalyticsDataProvider provider = new SynapseAnalyticsDataProvider(messageContext);
+
+        Assert.assertFalse(provider.isAnonymous());
+    }
+
+    /**
+     * Open/unsecured API: username is "anonymous" and applicationUUID is null because
+     * APIAuthenticationHandler never sets it. isAnonymous() must return true so that
+     * analytics correctly reports "anonymous".
+     */
+    @Test
+    public void testIsAnonymousReturnsTrueForOpenApiWithNullApplicationUUID() {
+        AuthenticationContext authContext = new AuthenticationContext();
+        authContext.setAuthenticated(true);
+        authContext.setUsername(APIConstants.END_USER_ANONYMOUS);
+        authContext.setApplicationUUID(null);
+
+        Axis2MessageContext messageContext = mockAxis2MessageContext(Collections.emptyMap(), Collections.emptyMap());
+        Mockito.when(messageContext.getProperty(APISecurityUtils.API_AUTH_CONTEXT)).thenReturn(authContext);
+
+        SynapseAnalyticsDataProvider provider = new SynapseAnalyticsDataProvider(messageContext);
+
+        Assert.assertTrue(provider.isAnonymous());
     }
 }


### PR DESCRIPTION
### Purpose

Application related fields in the apim_metrics logs were showing 'anonymous' when the API is invoked using opaque tokens with client credentials grant generated via a third-party Key Manager. This is fixed by adding an additional check to the logic determining whether the provider is anonymous.

Fixes: https://github.com/wso2/api-manager/issues/5134