### PR TITLE
Fix NullPointerException when creating MCP Server from an existing OpenAPI v2  API

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/PublisherCommonUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/PublisherCommonUtils.java
@@ -2438,7 +2438,7 @@ public class PublisherCommonUtils {
                 if (APIConstants.API_SUBTYPE_EXISTING_API.equals(apiToAdd.getSubtype())
                         && !apiToAdd.getUriTemplates().isEmpty()) {
                     Set<URITemplate> updatedTemplates = resolveExistingMCPBackendAPI(apiToAdd, apiProvider,
-                            organization, oasParser);
+                            organization);
                     apiToAdd.setUriTemplates(updatedTemplates);
                 }
                 apiDefinition = new OAS3Parser().generateAPIDefinition(swaggerData);
@@ -2505,12 +2505,11 @@ public class PublisherCommonUtils {
      * @param apiToAdd     API being added
      * @param apiProvider  APIProvider instance
      * @param organization Tenant domain
-     * @param oasParser    OpenAPI parser
      * @return updated set of URI templates
      * @throws APIManagementException if reference API not found or other processing errors occur
      */
     private static Set<URITemplate> resolveExistingMCPBackendAPI(API apiToAdd, APIProvider apiProvider,
-                                                                 String organization, APIDefinition oasParser)
+                                                                 String organization)
             throws APIManagementException {
 
         URITemplate template = apiToAdd.getUriTemplates().iterator().next();
@@ -2542,6 +2541,7 @@ public class PublisherCommonUtils {
             log.error(error);
             throw new APIManagementException(error, ExceptionCodes.INVALID_REFERENCE_API);
         }
+        APIDefinition oasParser = OASParserUtil.getOASParser(refApi.getSwaggerDefinition());
         return generateMCPFeatures(apiToAdd.getSubtype(), refApi.getSwaggerDefinition(),
                 apiToAdd.getUriTemplates(), refApi.getId(), oasParser);
     }


### PR DESCRIPTION
## Description 
### Problem
Creating an MCP Server from an existing REST API whose definition is Swagger 2.0 (OpenAPI v2) fails with a 500 error

### Root cause
In `PublisherCommonUtils.resolveExistingMCPBackendAPI`, the parser used to read the referenced backend API's definition was selected from the request's `openAPIVersion` query param (default `v3`) instead of the backend's actual definition version. A v3 parser reading a Swagger 2.0 document returns `null`, which then NPEs in
`generateMCPTools`.

### Fix
Select the parser from the referenced backend API's own definition using `OASParserUtil.getOASParser(...)`, so v2 and v3 backends are both parsed correctly regardless of the requested output version. The now-unused `oasParser` parameter is removed from the private method. This aligns the existing-API path with the direct-backend and import flows, which already auto-detect the version from the definition.

 **Related issue** - https://github.com/wso2/api-manager/issues/5127