### PR TITLE
 Increase maxLength for API Product context

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.common/src/main/resources/publisher-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.common/src/main/resources/publisher-api.yaml
@@ -15420,7 +15420,7 @@ components:
           type: string
           example: Pizza Shack API Product
         context:
-          maxLength: 60
+          maxLength: 232
           minLength: 1
           type: string
           example: pizzaproduct

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/dto/APIProductDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/dto/APIProductDTO.java
@@ -271,7 +271,7 @@ return null;
   
   @ApiModelProperty(example = "pizzaproduct", value = "")
   @JsonProperty("context")
- @Size(min=1,max=60)  public String getContext() {
+ @Size(min=1,max=232)  public String getContext() {
     return context;
   }
   public void setContext(String context) {

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/resources/publisher-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/resources/publisher-api.yaml
@@ -15420,7 +15420,7 @@ components:
           type: string
           example: Pizza Shack API Product
         context:
-          maxLength: 60
+          maxLength: 232
           minLength: 1
           type: string
           example: pizzaproduct

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.util/src/main/resources/publisher-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.util/src/main/resources/publisher-api.yaml
@@ -12637,7 +12637,7 @@ components:
           description: Name of the API Product
           example: PizzaShackAPIProduct
         context:
-          maxLength: 60
+          maxLength: 232
           minLength: 1
           type: string
           example: pizzaproduct


### PR DESCRIPTION
## Purpose

Fixes https://github.com/wso2/api-manager/issues/5137

`APIProductDTO.getContext()` is validated with `@Size(min=1,max=60)`, while the equivalent `APIDTO.getContext()` for plain APIs already allows `max=232`. Since the effective deployed context for a tenant is `/t/<tenant-domain>/<context>`, a context that passes UI validation (up to 200 chars) combined with a tenant domain can exceed 60 characters. This causes API Product creation/update to fail with:

```
{
    "code": 400,
    "message": "Bad Request",
    "description": "Validation Error",
    "moreInfo": "",
    "error": [
        {
            "code": "400_context",
            "message": "context: size must be between 1 and 60",
            "description": null
        }
    ]
}
```

This PR aligns the limit with `APIDTO` (232) in the generated DTO and the corresponding `publisher-api.yaml` schema definitions.

## Approach

Bumped the `context` max length 60 → 232 in:
- `APIProductDTO.java` (`@Size` annotation)
- `org.wso2.carbon.apimgt.rest.api.common/src/main/resources/publisher-api.yaml`
- `org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/resources/publisher-api.yaml`

Pure validation-limit change, no behavioral/migration impact.