### PR TITLE
Request/Response body support for Moesif analytics (gateway side)

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/analytics/AnalyticsMetricsHandler.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/analytics/AnalyticsMetricsHandler.java
@@ -65,7 +65,6 @@ public class AnalyticsMetricsHandler extends AbstractExtendedSynapseHandler {
 
     @Override
     public boolean handleRequestOutFlow(MessageContext messageContext) {
-        messageContext.setProperty(Constants.BACKEND_START_TIME_PROPERTY, System.currentTimeMillis());
         // Capture the request payload here (request-out flow), the last point before the backend send
         // where the request envelope is still current. Gated by the send_payloads analytics property.
         // Building here sets MESSAGE_BUILDER_INVOKED before the pass-through sender reads it, so the
@@ -83,6 +82,9 @@ public class AnalyticsMetricsHandler extends AbstractExtendedSynapseHandler {
                 }
             }
         }
+        // Mark backend-start after payload capture so the request build/serialization time counts as
+        // request-mediation latency rather than backend latency.
+        messageContext.setProperty(Constants.BACKEND_START_TIME_PROPERTY, System.currentTimeMillis());
         return true;
     }
 
@@ -99,7 +101,7 @@ public class AnalyticsMetricsHandler extends AbstractExtendedSynapseHandler {
             return false;
         }
         Object skipPublishMetrics = messageContext.getProperty(Constants.SKIP_METRICS_PUBLISHING);
-        if (skipPublishMetrics != null && (Boolean) skipPublishMetrics) {
+        if (Boolean.TRUE.equals(skipPublishMetrics)) {
             return false;
         }
         return !GatewayUtils.checkForFileBasedApiContexts(ApiUtils.getFullRequestPath(messageContext),

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/analytics/AnalyticsMetricsHandler.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/analytics/AnalyticsMetricsHandler.java
@@ -66,7 +66,44 @@ public class AnalyticsMetricsHandler extends AbstractExtendedSynapseHandler {
     @Override
     public boolean handleRequestOutFlow(MessageContext messageContext) {
         messageContext.setProperty(Constants.BACKEND_START_TIME_PROPERTY, System.currentTimeMillis());
+        // Capture the request payload here (request-out flow), the last point before the backend send
+        // where the request envelope is still current. Gated by the send_payloads analytics property.
+        // Building here sets MESSAGE_BUILDER_INVOKED before the pass-through sender reads it, so the
+        // engine re-serializes the built message to the backend (forwarding is preserved); doing this
+        // at request-in instead would run addressing before dispatch and break the send.
+        if (shouldCaptureRequestPayload(messageContext)) {
+            AnalyticsPayloadUtil.CapturedBody requestBody =
+                    AnalyticsPayloadUtil.extractPayload(messageContext,
+                            AnalyticsPayloadUtil.getPayloadSizeLimit(), "request");
+            if (requestBody != null && requestBody.getBody() != null) {
+                messageContext.setProperty(Constants.REQUEST_BODY, requestBody.getBody());
+                if (requestBody.getTransferEncoding() != null) {
+                    messageContext.setProperty(Constants.REQUEST_BODY_TRANSFER_ENCODING,
+                            requestBody.getTransferEncoding());
+                }
+            }
+        }
         return true;
+    }
+
+    /**
+     * Whether the request payload should be captured (and the message therefore built) on the
+     * request-out flow. Mirrors the skip conditions {@code handleResponseOutFlow} applies so we never
+     * build/re-serialize a request for a call that will not publish an analytics event: websocket
+     * subscriptions, file-based API contexts, and requests explicitly flagged {@code SKIP_METRICS_PUBLISHING}.
+     * Cheap checks are evaluated first and the file-based-context lookup last.
+     */
+    private boolean shouldCaptureRequestPayload(MessageContext messageContext) {
+        if (messageContext.getPropertyKeySet().contains(InboundWebsocketConstants.WEBSOCKET_SUBSCRIBER_PATH)
+                || !AnalyticsPayloadUtil.shouldSendPayloads()) {
+            return false;
+        }
+        Object skipPublishMetrics = messageContext.getProperty(Constants.SKIP_METRICS_PUBLISHING);
+        if (skipPublishMetrics != null && (Boolean) skipPublishMetrics) {
+            return false;
+        }
+        return !GatewayUtils.checkForFileBasedApiContexts(ApiUtils.getFullRequestPath(messageContext),
+                GatewayUtils.getTenantDomain());
     }
 
     @Override

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/analytics/AnalyticsMetricsHandler.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/analytics/AnalyticsMetricsHandler.java
@@ -75,9 +75,9 @@ public class AnalyticsMetricsHandler extends AbstractExtendedSynapseHandler {
                     AnalyticsPayloadUtil.extractPayload(messageContext,
                             AnalyticsPayloadUtil.getPayloadSizeLimit(), "request");
             if (requestBody != null && requestBody.getBody() != null) {
-                messageContext.setProperty(Constants.REQUEST_BODY, requestBody.getBody());
+                messageContext.setProperty(Constants.REQUEST_BODY_PROPERTY, requestBody.getBody());
                 if (requestBody.getTransferEncoding() != null) {
-                    messageContext.setProperty(Constants.REQUEST_BODY_TRANSFER_ENCODING,
+                    messageContext.setProperty(Constants.REQUEST_BODY_TRANSFER_ENCODING_PROPERTY,
                             requestBody.getTransferEncoding());
                 }
             }

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/analytics/AnalyticsPayloadUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/analytics/AnalyticsPayloadUtil.java
@@ -33,6 +33,7 @@ import org.apache.synapse.transport.passthru.util.RelayUtils;
 import org.wso2.carbon.apimgt.impl.APIManagerConfiguration;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Locale;
 import java.util.Map;
 
@@ -55,6 +56,10 @@ import static org.apache.axis2.context.MessageContext.TRANSPORT_HEADERS;
 public class AnalyticsPayloadUtil {
 
     private static final Log log = LogFactory.getLog(AnalyticsPayloadUtil.class);
+
+    // Guards the invalid-payload_size_limit warning so a misconfigured value is logged once rather than
+    // on every capture attempt (getPayloadSizeLimit is called per request/response).
+    private static volatile boolean invalidLimitWarned = false;
 
     private AnalyticsPayloadUtil() {
     }
@@ -105,18 +110,51 @@ public class AnalyticsPayloadUtil {
             try {
                 int limit = Integer.parseInt(configs.get(Constants.PAYLOAD_SIZE_LIMIT));
                 if (limit > 0) {
+                    invalidLimitWarned = false;
                     return limit;
                 }
                 // A non-positive limit would silently drop every body (and break size math), so treat
                 // it as invalid rather than honouring it.
-                log.warn("Non-positive " + Constants.PAYLOAD_SIZE_LIMIT + " analytics property value. Using default "
-                        + Constants.DEFAULT_PAYLOAD_SIZE_LIMIT);
+                warnInvalidLimitOnce("Non-positive " + Constants.PAYLOAD_SIZE_LIMIT
+                        + " analytics property value. Using default " + Constants.DEFAULT_PAYLOAD_SIZE_LIMIT);
             } catch (NumberFormatException e) {
-                log.warn("Invalid " + Constants.PAYLOAD_SIZE_LIMIT + " analytics property value. Using default "
-                        + Constants.DEFAULT_PAYLOAD_SIZE_LIMIT);
+                warnInvalidLimitOnce("Invalid " + Constants.PAYLOAD_SIZE_LIMIT
+                        + " analytics property value. Using default " + Constants.DEFAULT_PAYLOAD_SIZE_LIMIT);
             }
         }
         return Constants.DEFAULT_PAYLOAD_SIZE_LIMIT;
+    }
+
+    /**
+     * Logs the invalid-{@code payload_size_limit} warning at most once per stretch of misconfiguration,
+     * so a bad value does not flood the logs on every per-request/response capture attempt. The flag is
+     * reset once a valid limit is read again, so a later re-misconfiguration is warned about afresh.
+     */
+    private static void warnInvalidLimitOnce(String message) {
+        if (!invalidLimitWarned) {
+            invalidLimitWarned = true;
+            log.warn(message);
+        }
+    }
+
+    /**
+     * Whether to capture payloads that do not declare a {@code Content-Length} (e.g. chunked
+     * transfer-encoding), read from the {@code capture_payloads_without_content_length} analytics
+     * property. Defaults to {@code false}.
+     *
+     * <p>Such a body cannot be size-checked before {@link RelayUtils#buildMessage} materializes it in
+     * full, so capturing a large chunked body would buffer the whole thing into memory (an OOM risk
+     * under load) only to drop it afterwards if it exceeds {@code payload_size_limit}. It is therefore
+     * off by default: with the flag off these bodies are skipped (never built), so the default
+     * configuration is memory-safe. An operator who needs them and has headroom can opt in, accepting
+     * the memory cost. Applies symmetrically to request and response capture.</p>
+     *
+     * @return true if bodies without a declared Content-Length should be captured
+     */
+    public static boolean shouldCapturePayloadsWithoutContentLength() {
+        Map<String, String> configs = APIManagerConfiguration.getAnalyticsProperties();
+        return configs != null
+                && Boolean.parseBoolean(configs.get(Constants.CAPTURE_PAYLOADS_WITHOUT_CONTENT_LENGTH));
     }
 
     /**
@@ -129,8 +167,11 @@ public class AnalyticsPayloadUtil {
      * truncated, so the publisher never has to deal with a partial/invalid body. Where the payload
      * advertises its size via a {@code Content-Length} header the check is applied <b>before</b>
      * {@link RelayUtils#buildMessage} so an oversized body is never buffered into memory or
-     * re-serialized. A chunked body with no {@code Content-Length} is still built and then dropped
-     * (the size is unknowable without reading it).</p>
+     * re-serialized. A body with no {@code Content-Length} (e.g. chunked transfer-encoding) cannot be
+     * size-checked before building, so by default it is <b>skipped</b> (never built) to keep the
+     * default configuration memory-safe; set {@code capture_payloads_without_content_length=true} to
+     * capture it anyway (it is then built in full and dropped afterwards if it exceeds the limit,
+     * accepting the memory cost). See {@link #shouldCapturePayloadsWithoutContentLength()}.</p>
      *
      * <p>Works for both the request (called from {@code handleRequestOutFlow}, just before the backend
      * send) and the response (called at event-collection time). When a body is captured,
@@ -139,8 +180,9 @@ public class AnalyticsPayloadUtil {
      * read-only build pattern used by the AI mediator and the threat-protection/schema validators.
      * Requests with no entity body (GET/DELETE) are skipped so they are left byte-identical.</p>
      *
-     * <p>The limit is compared against bytes for the pre-build {@code Content-Length} gate and the
-     * binary path, and against {@link String#length()} (characters) for text/JSON/XML.</p>
+     * <p>The limit is compared against bytes throughout: the declared {@code Content-Length} for the
+     * pre-build gate, the decoded byte count for the binary path, and the UTF-8 encoded byte length
+     * for text/JSON/XML.</p>
      *
      * <p>When {@code send_payloads} is enabled but a body is nonetheless skipped or dropped, the reason
      * is logged at debug level (keyed by {@code direction}) so operators are not left wondering why a
@@ -182,6 +224,20 @@ public class AnalyticsPayloadUtil {
                     log.debug("Dropping " + direction + " body from analytics: declared Content-Length "
                             + declaredLength + " bytes exceeds " + Constants.PAYLOAD_SIZE_LIMIT + " of " + sizeLimit
                             + "; body not built. Increase " + Constants.PAYLOAD_SIZE_LIMIT + " to capture it.");
+                }
+                return null;
+            }
+
+            // No declared Content-Length (e.g. chunked transfer-encoding): the size cannot be bounded
+            // before building, so building here would materialize the whole body in memory (an OOM risk
+            // under load). Skip it unless the operator has explicitly opted in. Off by default keeps the
+            // default configuration memory-safe; applies symmetrically to request and response.
+            if (declaredLength < 0 && !shouldCapturePayloadsWithoutContentLength()) {
+                if (log.isDebugEnabled()) {
+                    log.debug("No " + direction + " body captured for analytics: no Content-Length header "
+                            + "(e.g. chunked transfer-encoding), so the body size cannot be bounded before "
+                            + "building. Set " + Constants.CAPTURE_PAYLOADS_WITHOUT_CONTENT_LENGTH
+                            + "=true to capture it (materializes the full body in memory).");
                 }
                 return null;
             }
@@ -241,19 +297,23 @@ public class AnalyticsPayloadUtil {
     }
 
     /**
-     * Wraps a text/JSON/XML payload, dropping it (returning {@code null}) when it exceeds
-     * {@code sizeLimit} characters so only a whole body is ever published. A drop is logged at debug
-     * level (keyed by {@code direction}/{@code kind}) so a missing body can be explained.
+     * Wraps a text/JSON/XML payload, dropping it (returning {@code null}) when its UTF-8 encoded size
+     * exceeds {@code sizeLimit} bytes so only a whole body is ever published. Measuring bytes (not
+     * {@link String#length()}, which counts UTF-16 code units) keeps this consistent with the
+     * byte-based pre-build {@code Content-Length} gate and binary path, and with the byte semantics of
+     * {@code payload_size_limit}. A drop is logged at debug level (keyed by {@code direction}/
+     * {@code kind}) so a missing body can be explained.
      */
     private static CapturedBody capture(String payload, int sizeLimit, String transferEncoding,
                                         String direction, String kind) {
         if (payload == null) {
             return null;
         }
-        if (payload.length() > sizeLimit) {
+        int byteLength = payload.getBytes(StandardCharsets.UTF_8).length;
+        if (byteLength > sizeLimit) {
             if (log.isDebugEnabled()) {
-                log.debug("Dropping " + direction + " " + kind + " body from analytics: " + payload.length()
-                        + " characters exceeds " + Constants.PAYLOAD_SIZE_LIMIT + " of " + sizeLimit
+                log.debug("Dropping " + direction + " " + kind + " body from analytics: " + byteLength
+                        + " bytes exceeds " + Constants.PAYLOAD_SIZE_LIMIT + " of " + sizeLimit
                         + ". Increase " + Constants.PAYLOAD_SIZE_LIMIT + " to capture it.");
             }
             return null;

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/analytics/AnalyticsPayloadUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/analytics/AnalyticsPayloadUtil.java
@@ -1,0 +1,307 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package org.wso2.carbon.apimgt.gateway.handlers.analytics;
+
+import org.apache.axiom.om.OMElement;
+import org.apache.axiom.soap.SOAPBody;
+import org.apache.axiom.soap.SOAPEnvelope;
+import org.apache.axis2.transport.base.BaseConstants;
+import org.apache.commons.codec.binary.Base64;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.http.HttpHeaders;
+import org.apache.synapse.MessageContext;
+import org.apache.synapse.commons.json.JsonUtil;
+import org.apache.synapse.core.axis2.Axis2MessageContext;
+import org.apache.synapse.transport.passthru.PassThroughConstants;
+import org.apache.synapse.transport.passthru.util.RelayUtils;
+import org.wso2.carbon.apimgt.impl.APIManagerConfiguration;
+
+import java.io.IOException;
+import java.util.Locale;
+import java.util.Map;
+
+import javax.xml.stream.XMLStreamException;
+
+import static org.apache.axis2.context.MessageContext.TRANSPORT_HEADERS;
+
+/**
+ * Utility for capturing the request/response payload (body) for analytics publishing.
+ *
+ * <p>Body capture is an opt-in feature (gated by the {@code send_payloads} analytics property) because it
+ * forces the pass-through message to be built into memory and captures potentially sensitive data.
+ * All content types are captured except streaming ({@code text/event-stream}) and {@code multipart/*},
+ * which have no single materializable body. JSON and text payloads are captured as-is; binary payloads
+ * are Base64-encoded (mirroring the Moesif standard, where the publisher tags them
+ * {@code transferEncoding=base64}). A payload larger than the configurable size limit is dropped
+ * (not truncated) so the publisher only ever receives a whole, valid body or nothing; the backend
+ * always receives the full body regardless.</p>
+ */
+public class AnalyticsPayloadUtil {
+
+    private static final Log log = LogFactory.getLog(AnalyticsPayloadUtil.class);
+
+    private AnalyticsPayloadUtil() {
+    }
+
+    /**
+     * Holds a captured body together with its Moesif transfer-encoding hint.
+     * {@code transferEncoding} is {@code "base64"} for pre-encoded binary payloads and {@code null}
+     * for JSON/text (the publisher decides JSON-vs-base64 for those via Moesif's {@code BodyParser}).
+     */
+    public static class CapturedBody {
+        private final String body;
+        private final String transferEncoding;
+
+        CapturedBody(String body, String transferEncoding) {
+            this.body = body;
+            this.transferEncoding = transferEncoding;
+        }
+
+        public String getBody() {
+            return body;
+        }
+
+        public String getTransferEncoding() {
+            return transferEncoding;
+        }
+    }
+
+    /**
+     * Whether request/response body capture is enabled via the {@code send_payloads} analytics property
+     * (named to match the sibling {@code send_headers} option). Defaults to {@code false}.
+     *
+     * @return true if body capture is enabled
+     */
+    public static boolean shouldSendPayloads() {
+        Map<String, String> configs = APIManagerConfiguration.getAnalyticsProperties();
+        return configs != null && Boolean.parseBoolean(configs.get(Constants.SEND_PAYLOAD));
+    }
+
+    /**
+     * Maximum number of bytes/characters captured per body, read from the {@code payload_size_limit}
+     * analytics property. Falls back to {@link Constants#DEFAULT_PAYLOAD_SIZE_LIMIT} when unset or invalid.
+     *
+     * @return the payload size limit
+     */
+    public static int getPayloadSizeLimit() {
+        Map<String, String> configs = APIManagerConfiguration.getAnalyticsProperties();
+        if (configs != null && configs.get(Constants.PAYLOAD_SIZE_LIMIT) != null) {
+            try {
+                int limit = Integer.parseInt(configs.get(Constants.PAYLOAD_SIZE_LIMIT));
+                if (limit > 0) {
+                    return limit;
+                }
+                // A non-positive limit would silently drop every body (and break size math), so treat
+                // it as invalid rather than honouring it.
+                log.warn("Non-positive " + Constants.PAYLOAD_SIZE_LIMIT + " analytics property value. Using default "
+                        + Constants.DEFAULT_PAYLOAD_SIZE_LIMIT);
+            } catch (NumberFormatException e) {
+                log.warn("Invalid " + Constants.PAYLOAD_SIZE_LIMIT + " analytics property value. Using default "
+                        + Constants.DEFAULT_PAYLOAD_SIZE_LIMIT);
+            }
+        }
+        return Constants.DEFAULT_PAYLOAD_SIZE_LIMIT;
+    }
+
+    /**
+     * Builds the message (materializing the pass-through stream) and returns the captured body along
+     * with its transfer-encoding hint. Streaming ({@code text/event-stream}) and {@code multipart/*}
+     * payloads are skipped. JSON and text are returned verbatim with a {@code null} encoding; binary
+     * payloads are Base64-encoded with encoding {@code "base64"}.
+     *
+     * <p>A body larger than {@code sizeLimit} is <b>dropped</b> (returns {@code null}) rather than
+     * truncated, so the publisher never has to deal with a partial/invalid body. Where the payload
+     * advertises its size via a {@code Content-Length} header the check is applied <b>before</b>
+     * {@link RelayUtils#buildMessage} so an oversized body is never buffered into memory or
+     * re-serialized. A chunked body with no {@code Content-Length} is still built and then dropped
+     * (the size is unknowable without reading it).</p>
+     *
+     * <p>Works for both the request (called from {@code handleRequestOutFlow}, just before the backend
+     * send) and the response (called at event-collection time). When a body is captured,
+     * {@link RelayUtils#buildMessage} sets {@code MESSAGE_BUILDER_INVOKED}, so the pass-through sender
+     * re-serializes the built envelope to the backend — forwarding is preserved. This is the same
+     * read-only build pattern used by the AI mediator and the threat-protection/schema validators.
+     * Requests with no entity body (GET/DELETE) are skipped so they are left byte-identical.</p>
+     *
+     * <p>The limit is compared against bytes for the pre-build {@code Content-Length} gate and the
+     * binary path, and against {@link String#length()} (characters) for text/JSON/XML.</p>
+     *
+     * <p>When {@code send_payloads} is enabled but a body is nonetheless skipped or dropped, the reason
+     * is logged at debug level (keyed by {@code direction}) so operators are not left wondering why a
+     * body is missing from Moesif.</p>
+     *
+     * @param messageContext the Synapse message context (request or response)
+     * @param sizeLimit      maximum number of characters (text) or bytes (binary) to capture
+     * @param direction      {@code "request"} or {@code "response"}, used only for debug log messages
+     * @return the captured body, or {@code null} if there is nothing capturable or it exceeds the limit
+     */
+    public static CapturedBody extractPayload(MessageContext messageContext, int sizeLimit, String direction) {
+        try {
+            org.apache.axis2.context.MessageContext axis2MC =
+                    ((Axis2MessageContext) messageContext).getAxis2MessageContext();
+
+            // Nothing to capture (and nothing to build) for entity-less requests such as GET/DELETE.
+            if (Boolean.TRUE.equals(axis2MC.getProperty(PassThroughConstants.NO_ENTITY_BODY))) {
+                if (log.isDebugEnabled()) {
+                    log.debug("No " + direction + " body captured for analytics: message has no entity body "
+                            + "(e.g. GET/DELETE).");
+                }
+                return null;
+            }
+
+            String contentType = getContentType(axis2MC);
+            if (isExcludedContentType(contentType)) {
+                if (log.isDebugEnabled()) {
+                    log.debug("No " + direction + " body captured for analytics: content type '" + contentType
+                            + "' is excluded (streaming/multipart bodies are never captured).");
+                }
+                return null;
+            }
+
+            // Pre-build gate: if the payload advertises its size and it exceeds the limit, drop it now
+            // without building — so an oversized body is never buffered into memory or re-serialized.
+            long declaredLength = getDeclaredContentLength(axis2MC);
+            if (declaredLength > sizeLimit) {
+                if (log.isDebugEnabled()) {
+                    log.debug("Dropping " + direction + " body from analytics: declared Content-Length "
+                            + declaredLength + " bytes exceeds " + Constants.PAYLOAD_SIZE_LIMIT + " of " + sizeLimit
+                            + "; body not built. Increase " + Constants.PAYLOAD_SIZE_LIMIT + " to capture it.");
+                }
+                return null;
+            }
+
+            RelayUtils.buildMessage(axis2MC);
+
+            // JSON: return the text as-is; the publisher's BodyParser renders it as a structured object.
+            if (JsonUtil.hasAJsonPayload(axis2MC)) {
+                return capture(JsonUtil.jsonPayloadToString(axis2MC), sizeLimit, null, direction, "JSON");
+            }
+
+            SOAPEnvelope env = axis2MC.getEnvelope();
+            if (env == null || env.getBody() == null) {
+                if (log.isDebugEnabled()) {
+                    log.debug("No " + direction + " body captured for analytics: message has no SOAP body.");
+                }
+                return null;
+            }
+            SOAPBody soapBody = env.getBody();
+            OMElement firstElement = soapBody.getFirstElement();
+            if (firstElement == null) {
+                if (log.isDebugEnabled()) {
+                    log.debug("No " + direction + " body captured for analytics: message body is empty.");
+                }
+                return null;
+            }
+            env.buildWithAttachments();
+
+            if (BaseConstants.DEFAULT_BINARY_WRAPPER.equals(firstElement.getQName())) {
+                // Binary payload: the wrapper's text is the Base64 of the raw bytes. Decode, and drop
+                // the whole body if the raw bytes exceed the limit; otherwise pass the bytes through.
+                byte[] bytes = Base64.decodeBase64(firstElement.getText());
+                if (bytes.length > sizeLimit) {
+                    if (log.isDebugEnabled()) {
+                        log.debug("Dropping " + direction + " binary body from analytics: " + bytes.length
+                                + " bytes exceeds " + Constants.PAYLOAD_SIZE_LIMIT + " of " + sizeLimit
+                                + ". Increase " + Constants.PAYLOAD_SIZE_LIMIT + " to capture it.");
+                    }
+                    return null;
+                }
+                return new CapturedBody(Base64.encodeBase64String(bytes), Constants.TRANSFER_ENCODING_BASE64);
+            } else if (BaseConstants.DEFAULT_TEXT_WRAPPER.equals(firstElement.getQName())) {
+                // Plain text payload.
+                return capture(firstElement.getText(), sizeLimit, null, direction, "text");
+            } else {
+                // XML / SOAP payload.
+                return capture(firstElement.toString(), sizeLimit, null, direction, "XML/SOAP");
+            }
+        } catch (IOException | XMLStreamException e) {
+            log.error("Error occurred while capturing the " + direction + " message payload for analytics", e);
+            return null;
+        } catch (RuntimeException e) {
+            // Fail safe: payload capture must never disrupt the request/response flow.
+            log.error("Unexpected error while capturing the " + direction + " message payload for analytics", e);
+            return null;
+        }
+    }
+
+    /**
+     * Wraps a text/JSON/XML payload, dropping it (returning {@code null}) when it exceeds
+     * {@code sizeLimit} characters so only a whole body is ever published. A drop is logged at debug
+     * level (keyed by {@code direction}/{@code kind}) so a missing body can be explained.
+     */
+    private static CapturedBody capture(String payload, int sizeLimit, String transferEncoding,
+                                        String direction, String kind) {
+        if (payload == null) {
+            return null;
+        }
+        if (payload.length() > sizeLimit) {
+            if (log.isDebugEnabled()) {
+                log.debug("Dropping " + direction + " " + kind + " body from analytics: " + payload.length()
+                        + " characters exceeds " + Constants.PAYLOAD_SIZE_LIMIT + " of " + sizeLimit
+                        + ". Increase " + Constants.PAYLOAD_SIZE_LIMIT + " to capture it.");
+            }
+            return null;
+        }
+        return new CapturedBody(payload, transferEncoding);
+    }
+
+    /**
+     * The declared body size from the {@code Content-Length} transport header, or {@code -1} when it is
+     * absent (e.g. chunked transfer-encoding) or unparseable. Read before building so an oversized body
+     * can be skipped without buffering it. The transport-headers map is case-insensitive, matching the
+     * exact-case lookup idiom used elsewhere (e.g. {@code getRequestSize}/{@code getResponseSize}).
+     */
+    private static long getDeclaredContentLength(org.apache.axis2.context.MessageContext axis2MC) {
+        Object headersObj = axis2MC.getProperty(TRANSPORT_HEADERS);
+        if (headersObj instanceof Map) {
+            Object contentLength = ((Map) headersObj).get(HttpHeaders.CONTENT_LENGTH);
+            if (contentLength != null) {
+                try {
+                    return Long.parseLong(contentLength.toString().trim());
+                } catch (NumberFormatException e) {
+                    return -1;
+                }
+            }
+        }
+        return -1;
+    }
+
+    private static String getContentType(org.apache.axis2.context.MessageContext axis2MC) {
+        Object headersObj = axis2MC.getProperty(TRANSPORT_HEADERS);
+        if (headersObj instanceof Map) {
+            Object contentType = ((Map) headersObj).get(HttpHeaders.CONTENT_TYPE);
+            if (contentType != null) {
+                return contentType.toString();
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Streaming (SSE) and multipart payloads have no single materializable body and must never be
+     * captured (building/buffering them would be incorrect or disruptive).
+     */
+    private static boolean isExcludedContentType(String contentType) {
+        if (contentType == null) {
+            return false;
+        }
+        String lower = contentType.toLowerCase(Locale.ROOT);
+        return lower.contains("event-stream") || lower.startsWith("multipart/");
+    }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/analytics/AnalyticsPayloadUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/analytics/AnalyticsPayloadUtil.java
@@ -31,9 +31,11 @@ import org.apache.synapse.core.axis2.Axis2MessageContext;
 import org.apache.synapse.transport.passthru.PassThroughConstants;
 import org.apache.synapse.transport.passthru.util.RelayUtils;
 import org.wso2.carbon.apimgt.impl.APIManagerConfiguration;
+import org.wso2.carbon.apimgt.impl.utils.APIUtil;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.Iterator;
 import java.util.Locale;
 import java.util.Map;
 
@@ -46,14 +48,15 @@ import static org.apache.axis2.context.MessageContext.TRANSPORT_HEADERS;
  *
  * <p>Body capture is an opt-in feature (gated by the {@code send_payloads} analytics property) because it
  * forces the pass-through message to be built into memory and captures potentially sensitive data.
- * All content types are captured except streaming ({@code text/event-stream}) and {@code multipart/*},
- * which have no single materializable body. JSON and text payloads are captured as-is; binary payloads
+ * All content types are captured except those excluded by {@link #isExcludedContentType} — streaming
+ * ({@code text/event-stream}), {@code multipart/*}, and {@code application/x-www-form-urlencoded}.
+ * JSON and text payloads are captured as-is; binary payloads
  * are Base64-encoded (mirroring the Moesif standard, where the publisher tags them
  * {@code transferEncoding=base64}). A payload larger than the configurable size limit is dropped
  * (not truncated) so the publisher only ever receives a whole, valid body or nothing; the backend
  * always receives the full body regardless.</p>
  */
-public class AnalyticsPayloadUtil {
+public final class AnalyticsPayloadUtil {
 
     private static final Log log = LogFactory.getLog(AnalyticsPayloadUtil.class);
 
@@ -89,20 +92,25 @@ public class AnalyticsPayloadUtil {
 
     /**
      * Whether request/response body capture is enabled via the {@code send_payloads} analytics property
-     * (named to match the sibling {@code send_headers} option). Defaults to {@code false}.
+     * (named to match the sibling {@code send_headers} option). Requires analytics to be enabled — when
+     * analytics is off nothing is published, so capturing (and building) a payload would be pure waste.
+     * Defaults to {@code false}.
      *
      * @return true if body capture is enabled
      */
     public static boolean shouldSendPayloads() {
+        if (!APIUtil.isAnalyticsEnabled()) {
+            return false;
+        }
         Map<String, String> configs = APIManagerConfiguration.getAnalyticsProperties();
         return configs != null && Boolean.parseBoolean(configs.get(Constants.SEND_PAYLOAD));
     }
 
     /**
-     * Maximum number of bytes/characters captured per body, read from the {@code payload_size_limit}
-     * analytics property. Falls back to {@link Constants#DEFAULT_PAYLOAD_SIZE_LIMIT} when unset or invalid.
+     * Maximum number of bytes captured per body, read from the {@code payload_size_limit} analytics
+     * property. Falls back to {@link Constants#DEFAULT_PAYLOAD_SIZE_LIMIT_BYTES} when unset or invalid.
      *
-     * @return the payload size limit
+     * @return the payload size limit in bytes
      */
     public static int getPayloadSizeLimit() {
         Map<String, String> configs = APIManagerConfiguration.getAnalyticsProperties();
@@ -110,19 +118,21 @@ public class AnalyticsPayloadUtil {
             try {
                 int limit = Integer.parseInt(configs.get(Constants.PAYLOAD_SIZE_LIMIT));
                 if (limit > 0) {
-                    invalidLimitWarned = false;
+                    if (invalidLimitWarned) {
+                        invalidLimitWarned = false;
+                    }
                     return limit;
                 }
                 // A non-positive limit would silently drop every body (and break size math), so treat
                 // it as invalid rather than honouring it.
                 warnInvalidLimitOnce("Non-positive " + Constants.PAYLOAD_SIZE_LIMIT
-                        + " analytics property value. Using default " + Constants.DEFAULT_PAYLOAD_SIZE_LIMIT);
+                        + " analytics property value. Using default " + Constants.DEFAULT_PAYLOAD_SIZE_LIMIT_BYTES);
             } catch (NumberFormatException e) {
                 warnInvalidLimitOnce("Invalid " + Constants.PAYLOAD_SIZE_LIMIT
-                        + " analytics property value. Using default " + Constants.DEFAULT_PAYLOAD_SIZE_LIMIT);
+                        + " analytics property value. Using default " + Constants.DEFAULT_PAYLOAD_SIZE_LIMIT_BYTES);
             }
         }
-        return Constants.DEFAULT_PAYLOAD_SIZE_LIMIT;
+        return Constants.DEFAULT_PAYLOAD_SIZE_LIMIT_BYTES;
     }
 
     /**
@@ -189,7 +199,7 @@ public class AnalyticsPayloadUtil {
      * body is missing from Moesif.</p>
      *
      * @param messageContext the Synapse message context (request or response)
-     * @param sizeLimit      maximum number of characters (text) or bytes (binary) to capture
+     * @param sizeLimit      maximum number of bytes to capture
      * @param direction      {@code "request"} or {@code "response"}, used only for debug log messages
      * @return the captured body, or {@code null} if there is nothing capturable or it exceeds the limit
      */
@@ -230,9 +240,14 @@ public class AnalyticsPayloadUtil {
 
             // No declared Content-Length (e.g. chunked transfer-encoding): the size cannot be bounded
             // before building, so building here would materialize the whole body in memory (an OOM risk
-            // under load). Skip it unless the operator has explicitly opted in. Off by default keeps the
-            // default configuration memory-safe; applies symmetrically to request and response.
-            if (declaredLength < 0 && !shouldCapturePayloadsWithoutContentLength()) {
+            // under load). Skip it unless the operator has explicitly opted in — UNLESS the message was
+            // already built earlier in the flow (a content-aware mediator, or getResponseSize with
+            // build_response_message=true). In that case the memory has already been spent, so skipping
+            // would only drop the body for free; capture it. Off by default keeps the default
+            // configuration memory-safe; applies symmetrically to request and response.
+            boolean alreadyBuilt =
+                    Boolean.TRUE.equals(axis2MC.getProperty(PassThroughConstants.MESSAGE_BUILDER_INVOKED));
+            if (declaredLength < 0 && !alreadyBuilt && !shouldCapturePayloadsWithoutContentLength()) {
                 if (log.isDebugEnabled()) {
                     log.debug("No " + direction + " body captured for analytics: no Content-Length header "
                             + "(e.g. chunked transfer-encoding), so the body size cannot be bounded before "
@@ -246,7 +261,7 @@ public class AnalyticsPayloadUtil {
 
             // JSON: return the text as-is; the publisher's BodyParser renders it as a structured object.
             if (JsonUtil.hasAJsonPayload(axis2MC)) {
-                return capture(JsonUtil.jsonPayloadToString(axis2MC), sizeLimit, null, direction, "JSON");
+                return capture(JsonUtil.jsonPayloadToString(axis2MC), sizeLimit, direction, "JSON");
             }
 
             SOAPEnvelope env = axis2MC.getEnvelope();
@@ -281,10 +296,18 @@ public class AnalyticsPayloadUtil {
                 return new CapturedBody(Base64.encodeBase64String(bytes), Constants.TRANSFER_ENCODING_BASE64);
             } else if (BaseConstants.DEFAULT_TEXT_WRAPPER.equals(firstElement.getQName())) {
                 // Plain text payload.
-                return capture(firstElement.getText(), sizeLimit, null, direction, "text");
+                return capture(firstElement.getText(), sizeLimit, direction, "text");
             } else {
-                // XML / SOAP payload.
-                return capture(firstElement.toString(), sizeLimit, null, direction, "XML/SOAP");
+                // XML / SOAP payload: serialise every child element of the body so a multi-element body
+                // is not silently truncated to its first element. For the common single-element REST XML
+                // body this is identical to the first element's serialisation. Deliberately not
+                // soapBody.toString(), which would wrap the content in a synthetic <soapenv:Body>.
+                StringBuilder xml = new StringBuilder();
+                Iterator<OMElement> childElements = soapBody.getChildElements();
+                while (childElements.hasNext()) {
+                    xml.append(childElements.next().toString());
+                }
+                return capture(xml.toString(), sizeLimit, direction, "XML/SOAP");
             }
         } catch (IOException | XMLStreamException e) {
             log.error("Error occurred while capturing the " + direction + " message payload for analytics", e);
@@ -304,8 +327,7 @@ public class AnalyticsPayloadUtil {
      * {@code payload_size_limit}. A drop is logged at debug level (keyed by {@code direction}/
      * {@code kind}) so a missing body can be explained.
      */
-    private static CapturedBody capture(String payload, int sizeLimit, String transferEncoding,
-                                        String direction, String kind) {
+    private static CapturedBody capture(String payload, int sizeLimit, String direction, String kind) {
         if (payload == null) {
             return null;
         }
@@ -318,7 +340,7 @@ public class AnalyticsPayloadUtil {
             }
             return null;
         }
-        return new CapturedBody(payload, transferEncoding);
+        return new CapturedBody(payload, null);
     }
 
     /**
@@ -354,14 +376,22 @@ public class AnalyticsPayloadUtil {
     }
 
     /**
-     * Streaming (SSE) and multipart payloads have no single materializable body and must never be
-     * captured (building/buffering them would be incorrect or disruptive).
+     * Content types that must never be captured, left to stream through untouched:
+     * <ul>
+     *   <li>{@code text/event-stream} (SSE) and {@code multipart/*} — no single materializable body.</li>
+     *   <li>{@code application/x-www-form-urlencoded} — Axis2 materializes this into an operation-named
+     *       XML tree (not a text/binary wrapper), so it would be published as XML whose representation
+     *       disagrees with its {@code Content-Type}; building it also re-serializes the form to the
+     *       backend via the form formatter (a forwarding risk). Excluded on both counts.</li>
+     * </ul>
      */
     private static boolean isExcludedContentType(String contentType) {
         if (contentType == null) {
             return false;
         }
         String lower = contentType.toLowerCase(Locale.ROOT);
-        return lower.contains("event-stream") || lower.startsWith("multipart/");
+        return lower.startsWith("text/event-stream")
+                || lower.startsWith("multipart/")
+                || lower.startsWith("application/x-www-form-urlencoded");
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/analytics/Constants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/analytics/Constants.java
@@ -98,6 +98,7 @@ public class Constants {
     public static final String TRANSFER_ENCODING_BASE64 = "base64";
     public static final String PAYLOAD_SIZE_LIMIT = "payload_size_limit";
     public static final int DEFAULT_PAYLOAD_SIZE_LIMIT = 100000;
+    public static final String CAPTURE_PAYLOADS_WITHOUT_CONTENT_LENGTH = "capture_payloads_without_content_length";
     public static final String REQUEST_CONTENT_TYPE = "requestContentType";
 
     public static final String AI_METADATA = "aiMetadata";

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/analytics/Constants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/analytics/Constants.java
@@ -90,6 +90,16 @@ public class Constants {
     public static final String REQUEST_HEADER_MASK = "request_headers";
     public static final String MASK_VALUE = "*****";
 
+    public static final String SEND_PAYLOAD = "send_payloads";
+    public static final String REQUEST_BODY = "requestBody";
+    public static final String RESPONSE_BODY = "responseBody";
+    public static final String REQUEST_BODY_TRANSFER_ENCODING = "requestBodyTransferEncoding";
+    public static final String RESPONSE_BODY_TRANSFER_ENCODING = "responseBodyTransferEncoding";
+    public static final String TRANSFER_ENCODING_BASE64 = "base64";
+    public static final String PAYLOAD_SIZE_LIMIT = "payload_size_limit";
+    public static final int DEFAULT_PAYLOAD_SIZE_LIMIT = 100000;
+    public static final String REQUEST_CONTENT_TYPE = "requestContentType";
+
     public static final String AI_METADATA = "aiMetadata";
     public static final String AI_VENDOR_NAME = "vendorName";
     public static final String AI_VENDOR_VERSION = "vendorVersion";

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/analytics/Constants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/analytics/Constants.java
@@ -97,9 +97,16 @@ public class Constants {
     public static final String RESPONSE_BODY_TRANSFER_ENCODING = "responseBodyTransferEncoding";
     public static final String TRANSFER_ENCODING_BASE64 = "base64";
     public static final String PAYLOAD_SIZE_LIMIT = "payload_size_limit";
-    public static final int DEFAULT_PAYLOAD_SIZE_LIMIT = 100000;
+    public static final int DEFAULT_PAYLOAD_SIZE_LIMIT_BYTES = 100000;
     public static final String CAPTURE_PAYLOADS_WITHOUT_CONTENT_LENGTH = "capture_payloads_without_content_length";
     public static final String REQUEST_CONTENT_TYPE = "requestContentType";
+    // Internal message-context property keys used to stash the captured request body between the
+    // request-out flow and event collection. Namespaced (apim.analytics.*) like every other analytics
+    // message-context property so a user policy's <property name="requestBody"/> cannot collide with
+    // them. Distinct from the wire keys above (REQUEST_BODY / REQUEST_BODY_TRANSFER_ENCODING), which
+    // remain the publisher contract in the event properties map.
+    public static final String REQUEST_BODY_PROPERTY = "apim.analytics.request.body";
+    public static final String REQUEST_BODY_TRANSFER_ENCODING_PROPERTY = "apim.analytics.request.body.encoding";
 
     public static final String AI_METADATA = "aiMetadata";
     public static final String AI_VENDOR_NAME = "vendorName";

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/analytics/SynapseAnalyticsDataProvider.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/analytics/SynapseAnalyticsDataProvider.java
@@ -514,6 +514,36 @@ public class SynapseAnalyticsDataProvider implements AnalyticsDataProvider {
             }
         }
 
+        // Request/response body (optional)
+        if (AnalyticsPayloadUtil.shouldSendPayloads()) {
+            log.debug("Including request/response body in analytics event");
+            int sizeLimit = AnalyticsPayloadUtil.getPayloadSizeLimit();
+            // Request body was captured in the request flow and stashed on the message context.
+            Object requestBody = messageContext.getProperty(Constants.REQUEST_BODY);
+            if (requestBody instanceof String) {
+                custom.put(Constants.REQUEST_BODY, requestBody);
+                Object reqEncoding = messageContext.getProperty(Constants.REQUEST_BODY_TRANSFER_ENCODING);
+                if (reqEncoding instanceof String) {
+                    custom.put(Constants.REQUEST_BODY_TRANSFER_ENCODING, reqEncoding);
+                }
+                // Convey the request Content-Type so Moesif can label/parse the body even when
+                // send_headers is off. (The response Content-Type already rides as responseContentType.)
+                String reqContentType = getRequestContentType();
+                if (reqContentType != null) {
+                    custom.put(Constants.REQUEST_CONTENT_TYPE, reqContentType);
+                }
+            }
+            // Response body is built and read here, at event-collection time.
+            AnalyticsPayloadUtil.CapturedBody responseBody =
+                    AnalyticsPayloadUtil.extractPayload(messageContext, sizeLimit, "response");
+            if (responseBody != null && responseBody.getBody() != null) {
+                custom.put(Constants.RESPONSE_BODY, responseBody.getBody());
+                if (responseBody.getTransferEncoding() != null) {
+                    custom.put(Constants.RESPONSE_BODY_TRANSFER_ENCODING, responseBody.getTransferEncoding());
+                }
+            }
+        }
+
         // API attributes (egress/subtype)
         Object apiObj = messageContext.getProperty(API_OBJECT);
         if (apiObj instanceof org.wso2.carbon.apimgt.keymgt.model.entity.API) {
@@ -845,6 +875,33 @@ public class SynapseAnalyticsDataProvider implements AnalyticsDataProvider {
             return headers.get(HttpHeaders.CONTENT_TYPE).toString();
         }
         return UNKNOWN_VALUE;
+    }
+
+    /**
+     * The request Content-Type, read case-insensitively from the request headers stashed as analytics
+     * metadata during the request-in flow ({@code REQUEST_HEADERS}). Used to convey the request body's
+     * media type to Moesif independently of {@code send_headers}.
+     *
+     * @return the request Content-Type, or {@code null} if unavailable
+     */
+    @SuppressWarnings("unchecked")
+    private String getRequestContentType() {
+        if (!(messageContext instanceof Axis2MessageContext)) {
+            return null;
+        }
+        Map<String, Object> analyticsMeta = ((Axis2MessageContext) messageContext).getAnalyticsMetadata();
+        if (analyticsMeta == null) {
+            return null;
+        }
+        Object reqHeadersObj = analyticsMeta.get(REQUEST_HEADERS);
+        if (reqHeadersObj instanceof Map) {
+            for (Map.Entry<String, Object> e : ((Map<String, Object>) reqHeadersObj).entrySet()) {
+                if (HttpHeaders.CONTENT_TYPE.equalsIgnoreCase(String.valueOf(e.getKey())) && e.getValue() != null) {
+                    return e.getValue().toString();
+                }
+            }
+        }
+        return null;
     }
 
     private String getCommonName() {

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/analytics/SynapseAnalyticsDataProvider.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/analytics/SynapseAnalyticsDataProvider.java
@@ -518,11 +518,12 @@ public class SynapseAnalyticsDataProvider implements AnalyticsDataProvider {
         if (AnalyticsPayloadUtil.shouldSendPayloads()) {
             log.debug("Including request/response body in analytics event");
             int sizeLimit = AnalyticsPayloadUtil.getPayloadSizeLimit();
-            // Request body was captured in the request flow and stashed on the message context.
-            Object requestBody = messageContext.getProperty(Constants.REQUEST_BODY);
+            // Request body was captured in the request flow and stashed on the message context under
+            // internal (namespaced) property keys; it is published under the wire keys.
+            Object requestBody = messageContext.getProperty(Constants.REQUEST_BODY_PROPERTY);
             if (requestBody instanceof String) {
                 custom.put(Constants.REQUEST_BODY, requestBody);
-                Object reqEncoding = messageContext.getProperty(Constants.REQUEST_BODY_TRANSFER_ENCODING);
+                Object reqEncoding = messageContext.getProperty(Constants.REQUEST_BODY_TRANSFER_ENCODING_PROPERTY);
                 if (reqEncoding instanceof String) {
                     custom.put(Constants.REQUEST_BODY_TRANSFER_ENCODING, reqEncoding);
                 }

--- a/pom.xml
+++ b/pom.xml
@@ -2350,7 +2350,7 @@
         <version.checkstyle>8.34</version.checkstyle>
         <org.wso2.orbit.org.mapstruct.version>1.4.1.wso2v1</org.wso2.orbit.org.mapstruct.version>
         <org.mapstruct.version>1.4.1.Final</org.mapstruct.version>
-        <analytics.event.publisher.client.version>1.2.36</analytics.event.publisher.client.version>
+        <analytics.event.publisher.client.version>1.2.38</analytics.event.publisher.client.version>
         <analytics.event.publisher.client.version.range>[1.0.0,2.0.0)</analytics.event.publisher.client.version.range>
         <org.wso2.orbit.atlassian.oai.version>2.46.1.wso2v1</org.wso2.orbit.atlassian.oai.version>
         <maven.spotbugsplugin.exclude.file>${project.parent.basedir}/../../spotbugs-exclude.xml</maven.spotbugsplugin.exclude.file>


### PR DESCRIPTION
## Purpose

- **Related issue:** https://github.com/wso2/api-manager/issues/5128
- **Companion PR (publisher mapping side, `apim-analytics-publisher`):** https://github.com/wso2/apim-analytics-publisher/pull/168

> This is one half of a **two-repo** change. This PR captures the body into the analytics
> event `properties`; the companion PR maps those properties onto the Moesif SDK event.

### Problem

The WSO2 APIM Moesif plugin is not able to capture request and response body/payload data in Moesif.

### Root cause (gateway side)

The gateway never captured the request/response payload. Headers reach Moesif precisely because
they are placed in `properties` (`requestHeaders`/`responseHeaders`); nothing similar existed for
the body.

### Intended outcome

When explicitly enabled, capture the request and response bodies and place them in the event
`properties` so the publisher can forward them to Moesif, without disrupting the proxied request/response.

## Goals

### Functional goals

- Capture the request and response body (opt-in) into the event `properties`.
- Convey a per-body **transfer-encoding hint** and the body's **`Content-Type`** so the publisher
  can render it correctly independent of `send_headers`.
- **Opt-in, off by default**. Zero cost when disabled.

### Constraints & non-goals

- **Property-key contract:** the `properties` key strings must match the publisher
  (`apim-analytics-publisher`) exactly (see the table under *Approach*).
- WebSocket/async APIs do not capture bodies.
- **Bounded:**  size-capped; oversized bodies must not be buffered/re-serialized.
- **Memory-safe by default:** a body whose size cannot be bounded before building (no `Content-Length`,
  e.g. chunked) is skipped by default; capturing it is a separate, explicit opt-in.
- **Explainable:** when enabled but a body is dropped, the reason is observable.

## Approach

### What changed

| File | Change |
|------|--------|
| `analytics/AnalyticsPayloadUtil.java` **(new)** | Single body-extraction utility for both request and response. |
| `analytics/AnalyticsMetricsHandler.java` | Capture the request body in `handleRequestOutFlow`, gated by `shouldCaptureRequestPayload()`. |
| `analytics/SynapseAnalyticsDataProvider.java` | Add request/response bodies (+ encodings + `requestContentType`) to event `properties`; capture the response body at event-collection time. |
| `analytics/Constants.java` | New constants (`send_payloads`, `payload_size_limit`, `capture_payloads_without_content_length`, body/encoding/content-type keys). |
| `pom.xml` | Bump `analytics.event.publisher.client.version` to the release carrying the publisher-side body support. |

### Capture rules: `AnalyticsPayloadUtil.extractPayload(...)`

| Case | Behavior |
|------|----------|
| No entity body (`NO_ENTITY_BODY`, e.g. GET/DELETE) | Skipped: no build, left byte-identical |
| `text/event-stream` (SSE), `multipart/*` | Excluded: no single materializable body |
| JSON | Captured verbatim, `transferEncoding=null` (publisher renders as structured object) |
| Text / XML / SOAP | Captured as string, `transferEncoding=null` |
| Binary | Base64-encoded, `transferEncoding="base64"` |
| Body larger than `payload_size_limit` | **Dropped**: publisher only ever gets a whole, valid body |
| No `Content-Length` (e.g. chunked) | **Skipped by default** (memory-safe); captured only when `capture_payloads_without_content_length=true` |

### Pre-build gate for Oversize handling:

```java
// If the payload advertises its size and it exceeds the limit, drop it now WITHOUT building —
// so an oversized body is never buffered into memory or re-serialized.
long declaredLength = getDeclaredContentLength(axis2MC);
if (declaredLength > sizeLimit) {
    return null;
}

// No declared Content-Length (e.g. chunked): the size cannot be bounded before building, so building
// here would materialize the whole body in memory (an OOM risk under load). Skip unless the operator
// has explicitly opted in. Applies symmetrically to request and response.
if (declaredLength < 0 && !shouldCapturePayloadsWithoutContentLength()) {
    return null;
}
RelayUtils.buildMessage(axis2MC);
```

**Why the no-`Content-Length` skip is default-off.** A body advertising a `Content-Length` over the
limit is dropped *before* building, so peak memory is bounded by `payload_size_limit`. A body with no
declared length (chunked transfer-encoding) can only be sized *after* `RelayUtils.buildMessage`
materializes it in full, so building a large chunked body purely to drop it is a real OOM/memory-pressure risk under load. So the safe choice is: **skip these bodies by default** (they are never built, and the
call still proxies normally via streaming), and expose an explicit opt-in for operators who need them
and have the headroom.

### Request-capture skip guards

`handleRequestOutFlow` gates capture on `shouldCaptureRequestPayload()`, mirroring the skips `handleResponseOutFlow` already applies, so no request is built/re-serialized for a call that will not publish an event:

| Condition | Skips capture |
|-----------|---------------|
| WebSocket subscriber path | ✅ |
| `send_payloads` set to **false** | ✅ |
| `SKIP_METRICS_PUBLISHING` set to **true** | ✅ |
| File-based API context | ✅ |

Additionally, `extractPayload` itself skips (without building) any body with no declared
`Content-Length` unless `capture_payloads_without_content_length=true`. So the default configuration
never materializes an unbounded chunked body, for either direction.

### Observability (Why is a body missing?)

When `send_payloads` is on but a body is skipped/dropped, the reason is logged at **debug** level, keyed by request/response. For example:

```
Dropping request body from analytics: declared Content-Length 250000 bytes exceeds
payload_size_limit of 100000; body not built. Increase payload_size_limit to capture it.

No response body captured for analytics: content type 'text/event-stream' is excluded
(streaming/multipart bodies are never captured).
```

### Configuration (`deployment.toml`)

```toml
[apim.analytics]
enable = true
type = "moesif"

[apim.analytics.properties]
moesifKey = "<Moesif Collector Application Id>"
send_payloads = "true"                            # opt-in; default false
payload_size_limit = "100000"                     # optional; default 100000 (bytes per captured body)
capture_payloads_without_content_length = "false" # optional; default false (memory-safe)
```

`payload_size_limit` is validated: a non-positive or non-numeric value falls back to the default
`100000` (with a warning) instead of silently dropping every body.

`capture_payloads_without_content_length` (default `false`) governs bodies that do not declare a
`Content-Length` (e.g. chunked transfer-encoding). When off, they are skipped (never built) so the default
configuration is memory-safe. Set it `true` to capture them, accepting that each such body is
materialized in full before it can be size-checked. Applies symmetrically to request and response.

### Design decisions & rationale

- **Where the request body is captured: `handleRequestOutFlow`.** The last safe point before the
  backend send; building there sets `MESSAGE_BUILDER_INVOKED` before the sender checks it, so the
  engine re-serializes the built message to the backend (forwarding preserved).
- **`Content-Type` conveyed independent of `send_headers`** so the publisher can label/parse the
  body even when header logging is off.
- **Memory safety is default-on; unbounded capture is a deliberate opt-in.** Bodies with a
  `Content-Length` are bounded by the pre-build gate; bodies without one are skipped by default
  because sizing them requires a full in-memory build. `capture_payloads_without_content_length`
  lets operators re-enable that capture where they have the headroom.