### PR TITLE
Fix unnecessary growth of binary/byte format examples during OpenAPI serialization

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.spec.parser/src/main/java/org/wso2/carbon/apimgt/spec/parser/definitions/OAS3Parser.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.spec.parser/src/main/java/org/wso2/carbon/apimgt/spec/parser/definitions/OAS3Parser.java
@@ -2724,6 +2724,9 @@ public class OAS3Parser extends APIDefinition {
                     }
                 }
             }
+            // This path bypasses OASParserUtil.convertOAStoJSON, so the binary/byte-example guard has to
+            // be applied here explicitly as well - see stripBinaryFormatExamples for why this matters.
+            OASParserUtil.stripBinaryFormatExamples(openAPI);
             return Yaml.pretty().writeValueAsString(openAPI);
         } catch (JsonProcessingException e) {
             throw new APIManagementException("Error while removing examples from OpenAPI definition", e,

--- a/components/apimgt/org.wso2.carbon.apimgt.spec.parser/src/main/java/org/wso2/carbon/apimgt/spec/parser/definitions/OASParserUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.spec.parser/src/main/java/org/wso2/carbon/apimgt/spec/parser/definitions/OASParserUtil.java
@@ -47,7 +47,6 @@ import io.swagger.v3.oas.models.Paths;
 import io.swagger.v3.oas.models.examples.Example;
 import io.swagger.v3.oas.models.headers.Header;
 import io.swagger.v3.oas.models.info.License;
-import io.swagger.v3.oas.models.media.ComposedSchema;
 import io.swagger.v3.oas.models.media.Content;
 import io.swagger.v3.oas.models.media.MediaType;
 import io.swagger.v3.oas.models.media.Schema;
@@ -903,9 +902,30 @@ public class OASParserUtil {
             return;
         }
         Set<Schema<?>> visited = Collections.newSetFromMap(new IdentityHashMap<>());
-        if (openAPI.getComponents() != null && openAPI.getComponents().getSchemas() != null) {
-            for (Object schema : openAPI.getComponents().getSchemas().values()) {
-                stripBinaryFormatExamplesFromSchema((Schema<?>) schema, visited);
+        Components components = openAPI.getComponents();
+        if (components != null) {
+            if (components.getSchemas() != null) {
+                for (Object schema : components.getSchemas().values()) {
+                    stripBinaryFormatExamplesFromSchema((Schema<?>) schema, visited);
+                }
+            }
+            if (components.getRequestBodies() != null) {
+                for (RequestBody requestBody : components.getRequestBodies().values()) {
+                    stripBinaryFormatExamplesFromRequestBody(requestBody, visited);
+                }
+            }
+            if (components.getResponses() != null) {
+                for (ApiResponse response : components.getResponses().values()) {
+                    stripBinaryFormatExamplesFromResponse(response, visited);
+                }
+            }
+            if (components.getParameters() != null) {
+                for (Parameter parameter : components.getParameters().values()) {
+                    stripBinaryFormatExamplesFromParameter(parameter, visited);
+                }
+            }
+            if (components.getHeaders() != null) {
+                stripBinaryFormatExamplesFromHeaders(components.getHeaders(), visited);
             }
         }
         if (openAPI.getPaths() == null) {
@@ -913,21 +933,54 @@ public class OASParserUtil {
         }
         for (PathItem pathItem : openAPI.getPaths().values()) {
             for (Operation operation : pathItem.readOperations()) {
-                if (operation.getRequestBody() != null) {
-                    stripBinaryFormatExamplesFromContent(operation.getRequestBody().getContent(), visited);
-                }
+                stripBinaryFormatExamplesFromRequestBody(operation.getRequestBody(), visited);
                 if (operation.getResponses() != null) {
                     for (ApiResponse response : operation.getResponses().values()) {
-                        stripBinaryFormatExamplesFromContent(response.getContent(), visited);
+                        stripBinaryFormatExamplesFromResponse(response, visited);
                     }
                 }
                 if (operation.getParameters() != null) {
                     for (Parameter parameter : operation.getParameters()) {
-                        stripBinaryFormatExamplesFromSchema(parameter.getSchema(), visited);
-                        stripBinaryFormatExamplesFromContent(parameter.getContent(), visited);
+                        stripBinaryFormatExamplesFromParameter(parameter, visited);
                     }
                 }
             }
+        }
+    }
+
+    private static void stripBinaryFormatExamplesFromRequestBody(RequestBody requestBody, Set<Schema<?>> visited) {
+        if (requestBody == null) {
+            return;
+        }
+        stripBinaryFormatExamplesFromContent(requestBody.getContent(), visited);
+    }
+
+    private static void stripBinaryFormatExamplesFromResponse(ApiResponse response, Set<Schema<?>> visited) {
+        if (response == null) {
+            return;
+        }
+        stripBinaryFormatExamplesFromContent(response.getContent(), visited);
+        stripBinaryFormatExamplesFromHeaders(response.getHeaders(), visited);
+    }
+
+    private static void stripBinaryFormatExamplesFromParameter(Parameter parameter, Set<Schema<?>> visited) {
+        if (parameter == null) {
+            return;
+        }
+        stripBinaryFormatExamplesFromSchema(parameter.getSchema(), visited);
+        stripBinaryFormatExamplesFromContent(parameter.getContent(), visited);
+    }
+
+    private static void stripBinaryFormatExamplesFromHeaders(Map<String, Header> headers, Set<Schema<?>> visited) {
+        if (headers == null) {
+            return;
+        }
+        for (Header header : headers.values()) {
+            if (header == null) {
+                continue;
+            }
+            stripBinaryFormatExamplesFromSchema(header.getSchema(), visited);
+            stripBinaryFormatExamplesFromContent(header.getContent(), visited);
         }
     }
 
@@ -958,11 +1011,11 @@ public class OASParserUtil {
         if (schema.getAdditionalProperties() instanceof Schema) {
             stripBinaryFormatExamplesFromSchema((Schema<?>) schema.getAdditionalProperties(), visited);
         }
-        if (schema instanceof ComposedSchema) {
-            ComposedSchema composedSchema = (ComposedSchema) schema;
-            stripBinaryFormatExamplesFromSchemaList(composedSchema.getAllOf(), visited);
-            stripBinaryFormatExamplesFromSchemaList(composedSchema.getAnyOf(), visited);
-            stripBinaryFormatExamplesFromSchemaList(composedSchema.getOneOf(), visited);
+        stripBinaryFormatExamplesFromSchemaList(schema.getAllOf(), visited);
+        stripBinaryFormatExamplesFromSchemaList(schema.getAnyOf(), visited);
+        stripBinaryFormatExamplesFromSchemaList(schema.getOneOf(), visited);
+        if (schema.getNot() != null) {
+            stripBinaryFormatExamplesFromSchema(schema.getNot(), visited);
         }
     }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.spec.parser/src/main/java/org/wso2/carbon/apimgt/spec/parser/definitions/OASParserUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.spec.parser/src/main/java/org/wso2/carbon/apimgt/spec/parser/definitions/OASParserUtil.java
@@ -47,6 +47,7 @@ import io.swagger.v3.oas.models.Paths;
 import io.swagger.v3.oas.models.examples.Example;
 import io.swagger.v3.oas.models.headers.Header;
 import io.swagger.v3.oas.models.info.License;
+import io.swagger.v3.oas.models.media.ComposedSchema;
 import io.swagger.v3.oas.models.media.Content;
 import io.swagger.v3.oas.models.media.MediaType;
 import io.swagger.v3.oas.models.media.Schema;
@@ -104,9 +105,11 @@ import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.IdentityHashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -880,6 +883,99 @@ public class OASParserUtil {
     }
 
     /**
+     * Strip {@code example} values from any schema declared with {@code format: binary} or
+     * {@code format: byte}.
+     * <p>
+     * The bundled OpenAPI parser base64-encodes examples on these two formats during
+     * serialization but does not reliably decode them back on the next parse (verified
+     * empirically against the bundled swagger-parser version - both formats reproduce the
+     * same growth, not just {@code format: binary} as in earlier analyses of older parser
+     * versions). Since APIM fully round-trips (parse then re-serialize) the OpenAPI
+     * definition on every Publisher import/update, an example left on such a property gets
+     * re-encoded on top of itself on every cycle and grows unboundedly until the definition
+     * can no longer be parsed. Binary/byte content was never usable as a meaningful inline
+     * example to begin with, so dropping it is safe.
+     *
+     * @param openAPI OpenAPI object to sanitize in place
+     */
+    public static void stripBinaryFormatExamples(OpenAPI openAPI) {
+        if (openAPI == null) {
+            return;
+        }
+        Set<Schema<?>> visited = Collections.newSetFromMap(new IdentityHashMap<>());
+        if (openAPI.getComponents() != null && openAPI.getComponents().getSchemas() != null) {
+            for (Object schema : openAPI.getComponents().getSchemas().values()) {
+                stripBinaryFormatExamplesFromSchema((Schema<?>) schema, visited);
+            }
+        }
+        if (openAPI.getPaths() == null) {
+            return;
+        }
+        for (PathItem pathItem : openAPI.getPaths().values()) {
+            for (Operation operation : pathItem.readOperations()) {
+                if (operation.getRequestBody() != null) {
+                    stripBinaryFormatExamplesFromContent(operation.getRequestBody().getContent(), visited);
+                }
+                if (operation.getResponses() != null) {
+                    for (ApiResponse response : operation.getResponses().values()) {
+                        stripBinaryFormatExamplesFromContent(response.getContent(), visited);
+                    }
+                }
+                if (operation.getParameters() != null) {
+                    for (Parameter parameter : operation.getParameters()) {
+                        stripBinaryFormatExamplesFromSchema(parameter.getSchema(), visited);
+                        stripBinaryFormatExamplesFromContent(parameter.getContent(), visited);
+                    }
+                }
+            }
+        }
+    }
+
+    private static void stripBinaryFormatExamplesFromContent(Content content, Set<Schema<?>> visited) {
+        if (content == null) {
+            return;
+        }
+        for (MediaType mediaType : content.values()) {
+            stripBinaryFormatExamplesFromSchema(mediaType.getSchema(), visited);
+        }
+    }
+
+    private static void stripBinaryFormatExamplesFromSchema(Schema<?> schema, Set<Schema<?>> visited) {
+        if (schema == null || !visited.add(schema)) {
+            return;
+        }
+        if (("binary".equals(schema.getFormat()) || "byte".equals(schema.getFormat())) && schema.getExample() != null) {
+            schema.setExample(null);
+        }
+        if (schema.getProperties() != null) {
+            for (Object propertySchema : schema.getProperties().values()) {
+                stripBinaryFormatExamplesFromSchema((Schema<?>) propertySchema, visited);
+            }
+        }
+        if (schema.getItems() != null) {
+            stripBinaryFormatExamplesFromSchema(schema.getItems(), visited);
+        }
+        if (schema.getAdditionalProperties() instanceof Schema) {
+            stripBinaryFormatExamplesFromSchema((Schema<?>) schema.getAdditionalProperties(), visited);
+        }
+        if (schema instanceof ComposedSchema) {
+            ComposedSchema composedSchema = (ComposedSchema) schema;
+            stripBinaryFormatExamplesFromSchemaList(composedSchema.getAllOf(), visited);
+            stripBinaryFormatExamplesFromSchemaList(composedSchema.getAnyOf(), visited);
+            stripBinaryFormatExamplesFromSchemaList(composedSchema.getOneOf(), visited);
+        }
+    }
+
+    private static void stripBinaryFormatExamplesFromSchemaList(List<Schema> schemas, Set<Schema<?>> visited) {
+        if (schemas == null) {
+            return;
+        }
+        for (Schema<?> nestedSchema : schemas) {
+            stripBinaryFormatExamplesFromSchema(nestedSchema, visited);
+        }
+    }
+
+    /**
      * Convert the OpenAPI 3.x Schema<T> format accordingly to the current Schema's OpenAPI version and resulting
      * API product OpenAPI version. This method picks the correct SchemaProcessor to do the conversion and hand over
      * the Schema object for that.
@@ -1033,6 +1129,11 @@ public class OASParserUtil {
     public static String convertOAStoJSON(OpenAPI oasDefinition) {
 
         String jsonString = null;
+        // Binary/byte-format examples are re-encoded on every parse/serialize round trip without ever
+        // being decoded back, so they grow unboundedly across repeated updates. Strip them here, at the
+        // single shared serialization entry point, so every caller (prettifyOAS3ToJson and its ~12 call
+        // sites, plus the direct callers of this method) is covered regardless of how the definition was parsed.
+        stripBinaryFormatExamples(oasDefinition);
         //Custom json mapper to parse OAS 3.1 definitions as the default parser drops mandatory licence.identifier field
         if (isOpenAPIVersion31(oasDefinition)) {
             ObjectMapper mapper = Json31.mapper().copy();

--- a/components/apimgt/org.wso2.carbon.apimgt.spec.parser/src/main/java/org/wso2/carbon/apimgt/spec/parser/definitions/OASParserUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.spec.parser/src/main/java/org/wso2/carbon/apimgt/spec/parser/definitions/OASParserUtil.java
@@ -44,6 +44,7 @@ import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.Operation;
 import io.swagger.v3.oas.models.PathItem;
 import io.swagger.v3.oas.models.Paths;
+import io.swagger.v3.oas.models.callbacks.Callback;
 import io.swagger.v3.oas.models.examples.Example;
 import io.swagger.v3.oas.models.headers.Header;
 import io.swagger.v3.oas.models.info.License;
@@ -927,24 +928,71 @@ public class OASParserUtil {
             if (components.getHeaders() != null) {
                 stripBinaryFormatExamplesFromHeaders(components.getHeaders(), visited);
             }
-        }
-        if (openAPI.getPaths() == null) {
-            return;
-        }
-        for (PathItem pathItem : openAPI.getPaths().values()) {
-            for (Operation operation : pathItem.readOperations()) {
-                stripBinaryFormatExamplesFromRequestBody(operation.getRequestBody(), visited);
-                if (operation.getResponses() != null) {
-                    for (ApiResponse response : operation.getResponses().values()) {
-                        stripBinaryFormatExamplesFromResponse(response, visited);
-                    }
-                }
-                if (operation.getParameters() != null) {
-                    for (Parameter parameter : operation.getParameters()) {
-                        stripBinaryFormatExamplesFromParameter(parameter, visited);
-                    }
+            if (components.getPathItems() != null) {
+                for (PathItem pathItem : components.getPathItems().values()) {
+                    stripBinaryFormatExamplesFromPathItem(pathItem, visited);
                 }
             }
+            if (components.getCallbacks() != null) {
+                for (Callback callback : components.getCallbacks().values()) {
+                    stripBinaryFormatExamplesFromCallback(callback, visited);
+                }
+            }
+        }
+        if (openAPI.getPaths() != null) {
+            for (PathItem pathItem : openAPI.getPaths().values()) {
+                stripBinaryFormatExamplesFromPathItem(pathItem, visited);
+            }
+        }
+        if (openAPI.getWebhooks() != null) {
+            for (PathItem pathItem : openAPI.getWebhooks().values()) {
+                stripBinaryFormatExamplesFromPathItem(pathItem, visited);
+            }
+        }
+    }
+
+    private static void stripBinaryFormatExamplesFromPathItem(PathItem pathItem, Set<Schema<?>> visited) {
+        if (pathItem == null) {
+            return;
+        }
+        if (pathItem.getParameters() != null) {
+            for (Parameter parameter : pathItem.getParameters()) {
+                stripBinaryFormatExamplesFromParameter(parameter, visited);
+            }
+        }
+        for (Operation operation : pathItem.readOperations()) {
+            stripBinaryFormatExamplesFromOperation(operation, visited);
+        }
+    }
+
+    private static void stripBinaryFormatExamplesFromOperation(Operation operation, Set<Schema<?>> visited) {
+        if (operation == null) {
+            return;
+        }
+        stripBinaryFormatExamplesFromRequestBody(operation.getRequestBody(), visited);
+        if (operation.getResponses() != null) {
+            for (ApiResponse response : operation.getResponses().values()) {
+                stripBinaryFormatExamplesFromResponse(response, visited);
+            }
+        }
+        if (operation.getParameters() != null) {
+            for (Parameter parameter : operation.getParameters()) {
+                stripBinaryFormatExamplesFromParameter(parameter, visited);
+            }
+        }
+        if (operation.getCallbacks() != null) {
+            for (Callback callback : operation.getCallbacks().values()) {
+                stripBinaryFormatExamplesFromCallback(callback, visited);
+            }
+        }
+    }
+
+    private static void stripBinaryFormatExamplesFromCallback(Callback callback, Set<Schema<?>> visited) {
+        if (callback == null) {
+            return;
+        }
+        for (PathItem pathItem : callback.values()) {
+            stripBinaryFormatExamplesFromPathItem(pathItem, visited);
         }
     }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.spec.parser/src/test/java/org/wso2/carbon/apimgt/spec/parser/definitions/OAS3ParserTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.spec.parser/src/test/java/org/wso2/carbon/apimgt/spec/parser/definitions/OAS3ParserTest.java
@@ -551,4 +551,51 @@ public class OAS3ParserTest extends OASTestBase {
         apiScopes.add(petLocalScope);
         return apiScopes;
     }
+
+    /**
+     * Regression test for the unbounded growth bug where {@code format: binary} / {@code format: byte}
+     * schema examples get re-encoded on every parse-then-serialize round trip (mirrors what APIM does
+     * on every Publisher import/update via prettifyOAS3ToJson -> OASParserUtil.convertOAStoJSON).
+     * Without the fix, the example on each affected property grows a little larger every cycle until
+     * the definition eventually exceeds Jackson's StreamReadConstraints.maxStringLength and can no
+     * longer be parsed at all.
+     */
+    @Test
+    public void testBinaryAndByteFormatExamplesDoNotGrowOnRepeatedUpdates() throws Exception {
+        String definition = "{\"openapi\":\"3.0.1\",\"info\":{\"title\":\"T\",\"version\":\"1.0.0\"},"
+                + "\"paths\":{\"/docs\":{\"post\":{\"requestBody\":{\"content\":{\"application/json\":"
+                + "{\"schema\":{\"$ref\":\"#/components/schemas/Req\"}}}},"
+                + "\"responses\":{\"200\":{\"description\":\"ok\"}}}}},"
+                + "\"components\":{\"schemas\":{\"Req\":{\"type\":\"object\",\"properties\":{"
+                + "\"documentContent\":{\"type\":\"string\",\"format\":\"binary\","
+                + "\"example\":\"<binary PDF content>\"},"
+                + "\"checksum\":{\"type\":\"string\",\"format\":\"byte\",\"example\":\"aGVsbG8=\"},"
+                + "\"label\":{\"type\":\"string\",\"example\":\"hello world\"}"
+                + "}}}}}";
+
+        String current = definition;
+        int stableLength = -1;
+        for (int cycle = 0; cycle <= 5; cycle++) {
+            OpenAPI openAPI = oas3Parser.getOpenAPI(current);
+            current = oas3Parser.prettifyOAS3ToJson(openAPI);
+
+            if (cycle == 0) {
+                stableLength = current.length();
+            } else {
+                // The definition must stop changing size after the first update cycle - if this
+                // assertion ever fails, the binary/byte example growth bug has resurfaced.
+                Assert.assertEquals("Definition size changed on cycle " + cycle
+                        + " - binary/byte example growth bug may have resurfaced.", stableLength, current.length());
+            }
+        }
+
+        OpenAPI finalApi = oas3Parser.getOpenAPI(current);
+        Map<String, io.swagger.v3.oas.models.media.Schema> properties =
+                finalApi.getComponents().getSchemas().get("Req").getProperties();
+
+        Assert.assertNull("format: binary example should be stripped", properties.get("documentContent").getExample());
+        Assert.assertNull("format: byte example should be stripped", properties.get("checksum").getExample());
+        Assert.assertEquals("plain string example must be left untouched", "hello world",
+                properties.get("label").getExample());
+    }
 }


### PR DESCRIPTION
### Problem

When a schema property is declared as format: binary or format: byte with an example value, that example gets re-encoded every time the definition is parsed and re-serialized, which happens on every Publisher import and update. The example grows a little more each cycle and never resets, so frequently updated APIs can grow from a few hundred lines to tens of megabytes within a day. Once the value crosses Jackson's string length limit, the definition can no longer be parsed, and even the API's details page in the Publisher starts failing with a 500 error.

> [tomcat_9.0.118.wso2v1.jar:?]\n\tat java.lang.Thread.run(Thread.java:1583) [?:?]\nCaused by: com.fasterxml.jackson.core.exc.StreamConstraintsException: String value length (20054016) exceeds the maximum allowed (20000000, from `StreamReadConstraints.getMaxStringLength()`)\n\tat com.fasterxml.jackson.core.StreamReadConstraints._constructException(StreamReadConstraints.java:663) ~[com.fasterxml.jackson.core.jackson-core_2.21.2.jar:?]\n\tat com.fasterxml.jackson.core.StreamReadConstraints.validateStringLength(StreamReadConstraints.java:598) ~[com.fasterxml.jackson.core.jackson-core_2.21.2.jar:?]\n\tat com.fasterxml.jackson.core.util.ReadConstrainedTextBuffer.validateStringLength(ReadConstrainedTextBuffer.java:27) ~[com.fasterxml.jackson.core.jackson-core_2.21.2.jar:?]\n\tat com.fasterxml.jackson.core.util.TextBuffer.finishCurrentSegment(TextBuffer.java:1017) ~[com.fasterxml.jackson.core.jackson-core_2.21.2.jar:?]\n\tat com.fasterxml.jackson.core.json.UTF8StreamJsonParser._finishString2(UTF8StreamJsonParser.java:2638) ~[com.fasterxml.jackson.core.jackson-core_2.21.2.jar:?]\n\tat com.fasterxml.jackson.core.json.UTF8StreamJsonParser._finishAndReturnString(UTF8StreamJsonParser.java:2614) ~[com.fasterxml.jackson.core.jackson-core_2.21.2.
> …..

### Root Cause

The bundled OpenAPI parser base64 encodes examples on these two formats when serializing, but does not decode them back on the next parse, so each cycle encodes the already encoded value again.

### Fix

This fix adds OASParserUtil.stripBinaryFormatExamples(), which walks the OpenAPI definition and clears the example value on any schema where the format is binary or byte, covering schema properties, arrays, nested objects, composed schemas, and request, response, and parameter schemas. It is called from OASParserUtil.convertOAStoJSON(), the shared serialization point used by all save and update paths, plus one additional call site that serializes independently. Other example types are left untouched.

### Testing

For testing, I added a regression test, OAS3ParserTest#testBinaryAndByteFormatExamplesDoNotGrowOnRepeatedUpdates, that runs a definition through several update cycles and checks that the size stays constant and that binary and byte examples are stripped while a plain string example is kept. I also ran the full existing test suite for the module and everything passed with no regressions. On top of that, I manually verified this against a real API definition that had previously triggered the growth issue, and confirmed the size stabilizes after the first update cycle and stays flat from then on, where before it kept growing without limit.