### PR TITLE
Recursively resolve nested schema imports in WSDL SOAP-to-REST conversion

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/wsdl/WSDL11SOAPOperationExtractor.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/wsdl/WSDL11SOAPOperationExtractor.java
@@ -230,44 +230,9 @@ public class WSDL11SOAPOperationExtractor extends WSDL11ProcessorImpl {
                     Element schemaElement = schema.getElement();
                     NodeList schemaNodes = schemaElement.getChildNodes();
                     schemaNodeList.addAll(SOAPOperationBindingUtils.list(schemaNodes));
-                    //gets types from imported schemas from the parent wsdl. Nested schemas will not be imported.
+                    //gets types from imported schemas from the parent wsdl, including nested schema imports.
                     if (importedSchemas != null) {
-                        for (Object importedSchemaObj : importedSchemas.keySet()) {
-                            String schemaUrl = (String) importedSchemaObj;
-                            if (importedSchemas.get(schemaUrl) != null) {
-                                Vector vector = (Vector) importedSchemas.get(schemaUrl);
-                                for (Object schemaVector : vector) {
-                                    if (schemaVector instanceof SchemaImport) {
-                                        Schema referencedSchema = ((SchemaImport) schemaVector)
-                                                .getReferencedSchema();
-                                        if (referencedSchema != null && referencedSchema.getElement() != null) {
-                                            if (referencedSchema.getElement().hasChildNodes()) {
-                                                schemaNodeList.addAll(SOAPOperationBindingUtils
-                                                        .list(referencedSchema.getElement().getChildNodes()));
-                                            } else {
-                                                log.warn("The referenced schema : " + schemaUrl
-                                                        + " doesn't have any defined types");
-                                            }
-                                        } else {
-                                            boolean isInlineSchema = false;
-                                            for (Object aSchema : typeList) {
-                                                if (schemaUrl.equalsIgnoreCase(
-                                                        ((Schema) aSchema).getElement()
-                                                                .getAttribute(TARGET_NAMESPACE_ATTRIBUTE))) {
-                                                    isInlineSchema = true;
-                                                    break;
-                                                }
-                                            }
-                                            if (isInlineSchema) {
-                                                log.debug(schemaUrl + " is already defined inline. Hence continue.");
-                                            } else {
-                                                log.warn("Cannot access referenced schema for the schema defined at: " + schemaUrl);
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
+                        resolveImportedXSDs(importedSchemas);
                     } else {
                         log.info("No any imported schemas found in the given wsdl.");
                     }
@@ -324,6 +289,53 @@ public class WSDL11SOAPOperationExtractor extends WSDL11ProcessorImpl {
                     + " with a single WSDL.");
         }
         return canProcess;
+    }
+
+    /**
+     * Recursively resolve imported schemas, including schemas imported by an already-imported schema.
+     *
+     * @param importedSchemas schemas imported from the definition or a referenced schema
+     */
+    private void resolveImportedXSDs(Map importedSchemas) {
+
+        for (Object importedSchemaObj : importedSchemas.keySet()) {
+            String schemaUrl = (String) importedSchemaObj;
+            if (importedSchemas.get(schemaUrl) == null) {
+                continue;
+            }
+            Vector vector = (Vector) importedSchemas.get(schemaUrl);
+            for (Object schemaVector : vector) {
+                if (!(schemaVector instanceof SchemaImport)) {
+                    continue;
+                }
+                Schema referencedSchema = ((SchemaImport) schemaVector).getReferencedSchema();
+                if (referencedSchema != null && referencedSchema.getElement() != null) {
+                    if (referencedSchema.getImports() != null) {
+                        resolveImportedXSDs(referencedSchema.getImports());
+                    }
+                    if (referencedSchema.getElement().hasChildNodes()) {
+                        schemaNodeList.addAll(SOAPOperationBindingUtils
+                                .list(referencedSchema.getElement().getChildNodes()));
+                    } else {
+                        log.warn("The referenced schema : " + schemaUrl + " doesn't have any defined types");
+                    }
+                } else {
+                    boolean isInlineSchema = false;
+                    for (Object aSchema : typeList) {
+                        if (schemaUrl.equalsIgnoreCase(
+                                ((Schema) aSchema).getElement().getAttribute(TARGET_NAMESPACE_ATTRIBUTE))) {
+                            isInlineSchema = true;
+                            break;
+                        }
+                    }
+                    if (isInlineSchema) {
+                        log.debug(schemaUrl + " is already defined inline. Hence continue.");
+                    } else {
+                        log.warn("Cannot access referenced schema for the schema defined at: " + schemaUrl);
+                    }
+                }
+            }
+        }
     }
 
     public WSDLInfo getWsdlInfo() throws APIMgtWSDLException {

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/wsdl/WSDL11SOAPOperationExtractor.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/wsdl/WSDL11SOAPOperationExtractor.java
@@ -297,10 +297,21 @@ public class WSDL11SOAPOperationExtractor extends WSDL11ProcessorImpl {
      * @param importedSchemas schemas imported from the definition or a referenced schema
      */
     private void resolveImportedXSDs(Map importedSchemas) {
+        resolveImportedXSDs(importedSchemas, new HashSet<String>());
+    }
+
+    /**
+     * Recursively resolve imported schemas, including schemas imported by an already-imported schema, guarding
+     * against cyclic and diamond imports by tracking schema URLs that have already been visited.
+     *
+     * @param importedSchemas schemas imported from the definition or a referenced schema
+     * @param visitedSchemas  schema URLs that have already been processed in this resolution chain
+     */
+    private void resolveImportedXSDs(Map importedSchemas, Set<String> visitedSchemas) {
 
         for (Object importedSchemaObj : importedSchemas.keySet()) {
             String schemaUrl = (String) importedSchemaObj;
-            if (importedSchemas.get(schemaUrl) == null) {
+            if (importedSchemas.get(schemaUrl) == null || !visitedSchemas.add(schemaUrl)) {
                 continue;
             }
             Vector vector = (Vector) importedSchemas.get(schemaUrl);
@@ -311,7 +322,7 @@ public class WSDL11SOAPOperationExtractor extends WSDL11ProcessorImpl {
                 Schema referencedSchema = ((SchemaImport) schemaVector).getReferencedSchema();
                 if (referencedSchema != null && referencedSchema.getElement() != null) {
                     if (referencedSchema.getImports() != null) {
-                        resolveImportedXSDs(referencedSchema.getImports());
+                        resolveImportedXSDs(referencedSchema.getImports(), visitedSchemas);
                     }
                     if (referencedSchema.getElement().hasChildNodes()) {
                         schemaNodeList.addAll(SOAPOperationBindingUtils


### PR DESCRIPTION
### Problem

Fixes #70 (https://github.com/wso2/api-manager/issues/70)

When an API is created from a WSDL file/archive whose schema imports another schema, which in turn imports further schemas (nested/transitive schema imports), the generated REST resource model is incomplete. `WSDL11SOAPOperationExtractor` only resolved imported schemas one level deep, so complex types defined in a schema that was imported by an already-imported schema never had their child elements/properties added to the model.

This surfaces to end users as errors in the Developer Portal (Store) API console when invoking resources of a SOAP-derived API — the request/response schema is missing properties for any type that came from a nested import, since the "sub properties" for those types were never generated.

### Root cause

In `initModels()`, the inline loop over `schema.getImports()` fetched the referenced schema's child nodes but never checked whether that referenced schema itself had further imports (`referencedSchema.getImports()`), so imports were only resolved to a depth of 1.

### Fix

Extracted the imported-schema handling into a new recursive method, `resolveImportedXSDs(Map importedSchemas)`, which now recurses into `referencedSchema.getImports()` before collecting the schema's child nodes. This walks the full import chain regardless of nesting depth, matching the intended behavior.

### Testing

- Verified this mirrors the approach used in the equivalent (already-released) patch for the 2.6.0 line, which resolved this exact issue for the same root cause.
- IDE diagnostics confirm the new method compiles cleanly with no unresolved references; only pre-existing raw-type warnings remain, consistent with the rest of this legacy file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)