### PR TITLE
Improve client certificate parsing from header and honor validation-disabled flag

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/Utils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/Utils.java
@@ -503,6 +503,16 @@ public class Utils {
             }
 
             if (!isClientCertificateEncoded()) {
+                // Discard any characters (e.g. trailing spaces, \r, \n, [\r], [\n]) that load balancers may
+                // append outside the BEGIN/END markers before restructuring the certificate.
+                if (certificate.contains(APIConstants.BEGIN_CERTIFICATE_STRING)
+                        && certificate.contains(APIConstants.END_CERTIFICATE_STRING)) {
+                    certificate = APIConstants.BEGIN_CERTIFICATE_STRING
+                            + certificate.substring(certificate.indexOf(APIConstants.BEGIN_CERTIFICATE_STRING)
+                                    + APIConstants.BEGIN_CERTIFICATE_STRING.length(),
+                            certificate.indexOf(APIConstants.END_CERTIFICATE_STRING))
+                            + APIConstants.END_CERTIFICATE_STRING;
+                }
                 // Remove invalid characters, restructure line separators, and reconstruct the certificate
                 certificate = certificate
                         .replaceAll(APIConstants.BEGIN_CERTIFICATE_STRING.concat(System.lineSeparator()), "")
@@ -511,6 +521,8 @@ public class Utils {
                         .replaceAll(System.lineSeparator().concat(APIConstants.END_CERTIFICATE_STRING), "")
                         .replaceAll("\n".concat(APIConstants.END_CERTIFICATE_STRING), "")
                         .replaceAll(APIConstants.END_CERTIFICATE_STRING, "")
+                        // remove illegal characters such as \r, \n, [\r], [\n] injected by load balancers
+                        .replaceAll("\\\\r|\\\\n|\\[|]", "")
                         .trim()
                         .replaceAll(" ", System.lineSeparator())
                         .trim();
@@ -543,7 +555,7 @@ public class Utils {
         return null;
     }
 
-    private static boolean isClientCertificateValidationEnabled() {
+    public static boolean isClientCertificateValidationEnabled() {
 
         APIManagerConfiguration apiManagerConfiguration =
                 ServiceReferenceHolder.getInstance().getAPIManagerConfiguration();

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/authenticator/MutualSSLAuthenticator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/authenticator/MutualSSLAuthenticator.java
@@ -111,7 +111,8 @@ public class MutualSSLAuthenticator implements Authenticator {
         Certificate sslCertObject;
         try {
             sslCertObject = Utils.getClientCertificate(axis2MessageContext);
-            if (!APIUtil.isCertificateExistsInListenerTrustStore(sslCertObject)) {
+            if (Utils.isClientCertificateValidationEnabled()
+                    && !APIUtil.isCertificateExistsInListenerTrustStore(sslCertObject)) {
                 log.debug("Certificate in Header didn't exist in truststore");
                 sslCertObject = null;
             }

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/test/java/org/wso2/carbon/apimgt/gateway/handlers/UtilsTestCase.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/test/java/org/wso2/carbon/apimgt/gateway/handlers/UtilsTestCase.java
@@ -11,6 +11,7 @@ import org.apache.axiom.soap.SOAPHeaderBlock;
 import org.apache.axiom.soap.impl.dom.SOAPHeaderBlockImpl;
 import org.apache.axiom.soap.impl.dom.SOAPHeaderImpl;
 import org.apache.axis2.addressing.EndpointReference;
+import org.apache.commons.io.IOUtils;
 import org.apache.synapse.MessageContext;
 import org.apache.synapse.core.axis2.Axis2MessageContext;
 import org.apache.synapse.core.axis2.Axis2Sender;
@@ -23,11 +24,18 @@ import org.mockito.Mockito;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
+import org.wso2.carbon.apimgt.api.APIManagementException;
 import org.wso2.carbon.apimgt.gateway.APIMgtGatewayConstants;
 import org.wso2.carbon.apimgt.gateway.internal.ServiceReferenceHolder;
+import org.wso2.carbon.apimgt.impl.APIConstants;
 import org.wso2.carbon.apimgt.impl.APIManagerConfiguration;
 import org.wso2.carbon.apimgt.impl.dto.APIKeyValidationInfoDTO;
 
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 
@@ -161,5 +169,43 @@ public class UtilsTestCase {
         Utils.setSOAPFault(messageContext, "", "code", "detail");
         Assert.assertTrue(true);  // No error has occurred. hence test passes.
 
+    }
+
+    @Test
+    public void testGetClientCertificateWithIllegalCharacters() throws IOException, APIManagementException {
+        final String clientCertificate = IOUtils.toString(
+                new FileInputStream("src/test/resources/cnf/certificate.pem"), StandardCharsets.UTF_8);
+        // characters some load balancers append to the end of the certificate string
+        final String illegalCharacters = " [\\r][\\n]";
+
+        Map<String, Object> headersMap = new HashMap<>();
+        headersMap.put(Utils.getClientCertificateHeader(), clientCertificate + illegalCharacters);
+        Mockito.when(axis2MsgCntxt.getProperty(org.apache.axis2.context.MessageContext.TRANSPORT_HEADERS))
+                .thenReturn(headersMap);
+
+        Assert.assertNotNull(Utils.getClientCertificate(axis2MsgCntxt));
+    }
+
+    @Test
+    public void testGetClientCertificateWithURLEncodedCertificate() throws IOException, APIManagementException {
+        ServiceReferenceHolder serviceReferenceHolder = Mockito.mock(ServiceReferenceHolder.class);
+        APIManagerConfiguration apiManagerConfiguration = Mockito.mock(APIManagerConfiguration.class);
+        Mockito.when(apiManagerConfiguration.getFirstProperty(APIConstants.MutualSSL.CLIENT_CERTIFICATE_ENCODE))
+                .thenReturn(Boolean.TRUE.toString());
+        PowerMockito.when(ServiceReferenceHolder.getInstance()).thenReturn(serviceReferenceHolder);
+        PowerMockito.when(serviceReferenceHolder.getAPIManagerConfiguration()).thenReturn(apiManagerConfiguration);
+
+        final String clientCertificate = IOUtils.toString(
+                new FileInputStream("src/test/resources/cnf/certificate.pem"), StandardCharsets.UTF_8);
+        // characters some load balancers append to the end of the certificate string
+        final String illegalCharacters = "%0A[\\r][\\n]";
+
+        Map<String, Object> headersMap = new HashMap<>();
+        headersMap.put(Utils.getClientCertificateHeader(),
+                URLEncoder.encode(clientCertificate, StandardCharsets.UTF_8.name()) + illegalCharacters);
+        Mockito.when(axis2MsgCntxt.getProperty(org.apache.axis2.context.MessageContext.TRANSPORT_HEADERS))
+                .thenReturn(headersMap);
+
+        Assert.assertNotNull(Utils.getClientCertificate(axis2MsgCntxt));
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
@@ -10356,8 +10356,18 @@ public final class APIUtil {
 
     @UsedByMigrationClient
     public static String getX509certificateContent(String certificate) {
+        if (certificate.contains(APIConstants.BEGIN_CERTIFICATE_STRING)
+                && certificate.contains(APIConstants.END_CERTIFICATE_STRING)) {
+            // Extract only the content between the BEGIN/END markers, discarding any characters
+            // (e.g. trailing spaces, \r, \n, [\r], [\n]) that load balancers may append outside them.
+            certificate = certificate.substring(certificate.indexOf(APIConstants.BEGIN_CERTIFICATE_STRING)
+                            + APIConstants.BEGIN_CERTIFICATE_STRING.length(),
+                    certificate.indexOf(APIConstants.END_CERTIFICATE_STRING));
+        }
         String content = certificate.replaceAll(APIConstants.BEGIN_CERTIFICATE_STRING, "")
-                .replaceAll(APIConstants.END_CERTIFICATE_STRING, "");
+                .replaceAll(APIConstants.END_CERTIFICATE_STRING, "")
+                // remove illegal base64 characters such as spaces, \r, \n, [\r], [\n]
+                .replaceAll("\\\\r|\\\\n|\\r|\\n|\\[|]| ", "");
 
         return content.trim();
     }


### PR DESCRIPTION
## Related issue
Fixes wso2/product-apim#11467

## Cause

When a client certificate is sent to the gateway via a request header (rather than at the transport/mTLS level), some load balancers append extra characters to the end of the certificate string — spaces, real `\r`/`\n` bytes, and even literal bracket-notation text like `[\r]`/`[\n]`. The gateway's existing cleanup logic only stripped the `BEGIN`/`END` PEM markers and trimmed real leading/trailing whitespace; it never accounted for:

- Non-whitespace trailing garbage (literal `[\r]`, `[\n]`) that some load balancers inject.
- Garbage appended *after* the `-----END CERTIFICATE-----` marker, which survived the old `replaceAll` (which only deletes the marker text itself, not anything that follows it) and got baked into the reconstructed PEM, breaking `CertificateFactory` parsing.

Separately, `MutualSSLAuthenticator.authenticate()` unconditionally re-validated the header-derived certificate against the listener trust store via `APIUtil.isCertificateExistsInListenerTrustStore(...)`, regardless of whether client certificate validation (`MutualSSL.EnableClientCertificateValidation`) was disabled in configuration. So disabling that setting did not actually skip the trust-store check, contrary to its intent.

## Fix

- **`APIUtil.getX509certificateContent()`**: when both `BEGIN`/`END` markers are present, bound-extract only the content between them (discarding anything a load balancer appended outside the markers), then additionally strip illegal characters (`\r`, `\n`, literal `\r`/`\n` text, `[`, `]`, spaces) from what remains.
- **`Utils.getClientCertificateFromHeader()`**: apply the same bound-extraction before the existing PEM reconstruction logic in the non-encoded path, plus the same illegal-character stripping as a safety net for junk that lands inside the markers.
- **`MutualSSLAuthenticator.authenticate()`**: gate the trust-store re-check on `Utils.isClientCertificateValidationEnabled()` (now made `public` for cross-package use), so the trust-store lookup is skipped entirely when client certificate validation is disabled — matching the behavior already used correctly in `Utils.getClientCertificatesChain()`.

## Test plan

- Added `UtilsTestCase#testGetClientCertificateWithIllegalCharacters` — verifies a PEM certificate with trailing `" [\r][\n]"` garbage (non-encoded header path) still parses successfully.
- Added `UtilsTestCase#testGetClientCertificateWithURLEncodedCertificate` — verifies the same for the URL-encoded header path with `%0A[\r][\n]` garbage appended.
- Verified `APIUtil.java`, `Utils.java`, and `MutualSSLAuthenticator.java` compile cleanly together against the module's resolved dependency classpath.