### PR TITLE
Fix SQL constants to correct average calculation

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/constants/SQLConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/constants/SQLConstants.java
@@ -1014,7 +1014,7 @@ public class SQLConstants {
 
     public static final String GET_API_AVERAGE_RATING_SQL =
             " SELECT " +
-            "   AVG(RATING) AS RATING " +
+            "   CAST(AVG(RATING) AS DECIMAL(10,3)) AS RATING " +
             " FROM " +
             "   AM_API_RATINGS " +
             " WHERE " +

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/constants/SQLConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/constants/SQLConstants.java
@@ -1014,7 +1014,7 @@ public class SQLConstants {
 
     public static final String GET_API_AVERAGE_RATING_SQL =
             " SELECT " +
-            "   CAST(AVG(RATING) AS DECIMAL) AS RATING " +
+            "   AVG(CAST(RATING AS DECIMAL(10,3))) AS RATING " +
             " FROM " +
             "   AM_API_RATINGS " +
             " WHERE " +

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/constants/SQLConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/constants/SQLConstants.java
@@ -1014,7 +1014,7 @@ public class SQLConstants {
 
     public static final String GET_API_AVERAGE_RATING_SQL =
             " SELECT " +
-            "   CAST( SUM(RATING) AS DECIMAL)/COUNT(RATING) AS RATING " +
+            "   AVG(RATING) AS RATING " +
             " FROM " +
             "   AM_API_RATINGS " +
             " WHERE " +

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/constants/SQLConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/constants/SQLConstants.java
@@ -1014,7 +1014,7 @@ public class SQLConstants {
 
     public static final String GET_API_AVERAGE_RATING_SQL =
             " SELECT " +
-            "   CAST(AVG(RATING) AS DECIMAL(10,3)) AS RATING " +
+            "   CAST(AVG(RATING) AS DECIMAL) AS RATING " +
             " FROM " +
             "   AM_API_RATINGS " +
             " WHERE " +


### PR DESCRIPTION
Fixes: Issue 02 of https://github.com/wso2/api-manager/issues/4543

This pull request makes a small change to the SQL used for calculating the average API rating. Instead of manually summing and dividing ratings, it now uses the SQL AVG() function for better clarity and efficiency.

Replaced manual average calculation (CAST( SUM(RATING) AS DECIMAL)/COUNT(RATING)) with the SQL AVG(RATING) function in the GET_API_AVERAGE_RATING_SQL constant in SQLConstants.java.

After Fix:
<img width="1512" height="832" alt="avg_ui_fix" src="https://github.com/user-attachments/assets/ce0b700f-189d-43f6-979d-dbb3581c1cb8" />
