### PR TITLE
Fix WebSocket API application level throttling to be user bounded

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/inbound/websocket/utils/InboundWebsocketProcessorUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/inbound/websocket/utils/InboundWebsocketProcessorUtil.java
@@ -208,12 +208,7 @@ public class InboundWebsocketProcessorUtil {
                 : infoDTO.getApiTier();
         String subscriptionLevelTier = infoDTO.getTier();
         String resourceLevelTier;
-        String authorizedUser;
-        if (MultitenantConstants.SUPER_TENANT_DOMAIN_NAME.equalsIgnoreCase(infoDTO.getSubscriberTenantDomain())) {
-            authorizedUser = infoDTO.getEndUserName() + "@" + infoDTO.getSubscriberTenantDomain();
-        } else {
-            authorizedUser = infoDTO.getEndUserName();
-        }
+        String authorizedUser = infoDTO.getEndUserName();
         String apiName = infoDTO.getApiName();
         String apiVersion = inboundMessageContext.getVersion();
         String appTenant = infoDTO.getSubscriberTenantDomain();

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/inbound/websocket/utils/InboundWebsocketProcessorUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/inbound/websocket/utils/InboundWebsocketProcessorUtil.java
@@ -210,9 +210,9 @@ public class InboundWebsocketProcessorUtil {
         String resourceLevelTier;
         String authorizedUser;
         if (MultitenantConstants.SUPER_TENANT_DOMAIN_NAME.equalsIgnoreCase(infoDTO.getSubscriberTenantDomain())) {
-            authorizedUser = infoDTO.getSubscriber() + "@" + infoDTO.getSubscriberTenantDomain();
+            authorizedUser = infoDTO.getEndUserName() + "@" + infoDTO.getSubscriberTenantDomain();
         } else {
-            authorizedUser = infoDTO.getSubscriber();
+            authorizedUser = infoDTO.getEndUserName();
         }
         String apiName = infoDTO.getApiName();
         String apiVersion = inboundMessageContext.getVersion();

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/test/java/org/wso2/carbon/apimgt/gateway/inbound/websocket/utils/InboundWebsocketProcessorUtilTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/test/java/org/wso2/carbon/apimgt/gateway/inbound/websocket/utils/InboundWebsocketProcessorUtilTest.java
@@ -155,13 +155,16 @@ public class InboundWebsocketProcessorUtilTest {
         String subscriptionLevelThrottleKey = apiKeyValidationInfoDTO.getApplicationId() + ":"
                 + inboundMessageContext.getApiContext() + ":" + inboundMessageContext.getVersion();
         String applicationLevelThrottleKey = apiKeyValidationInfoDTO.getApplicationId() + ":"
-                + apiKeyValidationInfoDTO.getEndUserName() + "@" + apiKeyValidationInfoDTO.getSubscriberTenantDomain();
+                + apiKeyValidationInfoDTO.getEndUserName();
         PowerMockito.when(WebsocketUtil.getThrottleStatus(verbInfoDTO.getRequestKey(), subscriptionLevelThrottleKey,
                 applicationLevelThrottleKey)).thenReturn(null);
         Mockito.when(dataPublisher.tryPublish(Mockito.anyObject())).thenReturn(true);
         InboundProcessorResponseDTO inboundProcessorResponseDTO =
                 InboundWebsocketProcessorUtil.doThrottleForGraphQL(msgSize, verbInfoDTO, inboundMessageContext,
                         operationId);
+        PowerMockito.verifyStatic(WebsocketUtil.class);
+        WebsocketUtil.getThrottleStatus(verbInfoDTO.getRequestKey(), subscriptionLevelThrottleKey,
+                applicationLevelThrottleKey);
         Assert.assertFalse(inboundProcessorResponseDTO.isError());
         Assert.assertNull(inboundProcessorResponseDTO.getErrorMessage());
         Assert.assertFalse(inboundProcessorResponseDTO.isCloseConnection());
@@ -196,8 +199,7 @@ public class InboundWebsocketProcessorUtilTest {
                 apiKeyValidationInfoDTO.getApplicationId() + ":" + inboundMessageContext.getApiContext() + ":"
                         + inboundMessageContext.getVersion();
         String applicationLevelThrottleKey =
-                apiKeyValidationInfoDTO.getApplicationId() + ":" + apiKeyValidationInfoDTO.getEndUserName() + "@"
-                        + apiKeyValidationInfoDTO.getSubscriberTenantDomain();
+                apiKeyValidationInfoDTO.getApplicationId() + ":" + apiKeyValidationInfoDTO.getEndUserName();
         Mockito.when(dataPublisher.tryPublish(Mockito.anyObject())).thenReturn(true);
 
         PowerMockito.when(WebsocketUtil.getThrottleStatus(verbInfoDTO.getRequestKey(), subscriptionLevelThrottleKey,
@@ -249,7 +251,7 @@ public class InboundWebsocketProcessorUtilTest {
 
         String subscriptionLevelThrottleKey = apiKeyValidationInfoDTO.getApplicationId() + ":"
                 + inboundMessageContext.getApiContext() + ":" + inboundMessageContext.getVersion();
-        // Non-super-tenant format: no "@tenantDomain" suffix, unlike the super-tenant case.
+        // Application-level throttle key is tenant-agnostic
         String applicationLevelThrottleKey =
                 apiKeyValidationInfoDTO.getApplicationId() + ":" + apiKeyValidationInfoDTO.getEndUserName();
         PowerMockito.when(WebsocketUtil.getThrottleStatus(verbInfoDTO.getRequestKey(), subscriptionLevelThrottleKey,
@@ -258,6 +260,9 @@ public class InboundWebsocketProcessorUtilTest {
         InboundProcessorResponseDTO inboundProcessorResponseDTO =
                 InboundWebsocketProcessorUtil.doThrottleForGraphQL(msgSize, verbInfoDTO, inboundMessageContext,
                         operationId);
+        PowerMockito.verifyStatic(WebsocketUtil.class);
+        WebsocketUtil.getThrottleStatus(verbInfoDTO.getRequestKey(), subscriptionLevelThrottleKey,
+                applicationLevelThrottleKey);
         Assert.assertFalse(inboundProcessorResponseDTO.isError());
         Assert.assertNull(inboundProcessorResponseDTO.getErrorMessage());
         Assert.assertFalse(inboundProcessorResponseDTO.isCloseConnection());

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/test/java/org/wso2/carbon/apimgt/gateway/inbound/websocket/utils/InboundWebsocketProcessorUtilTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/test/java/org/wso2/carbon/apimgt/gateway/inbound/websocket/utils/InboundWebsocketProcessorUtilTest.java
@@ -143,6 +143,7 @@ public class InboundWebsocketProcessorUtilTest {
         apiKeyValidationInfoDTO.setTier(APIConstants.UNLIMITED_TIER);
         apiKeyValidationInfoDTO.setSubscriberTenantDomain(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
         apiKeyValidationInfoDTO.setSubscriber("admin");
+        apiKeyValidationInfoDTO.setEndUserName("otherUser");
         apiKeyValidationInfoDTO.setApiName("GraphQLAPI");
         apiKeyValidationInfoDTO.setApplicationId("12");
         inboundMessageContext.setTenantDomain(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
@@ -154,7 +155,7 @@ public class InboundWebsocketProcessorUtilTest {
         String subscriptionLevelThrottleKey = apiKeyValidationInfoDTO.getApplicationId() + ":"
                 + inboundMessageContext.getApiContext() + ":" + inboundMessageContext.getVersion();
         String applicationLevelThrottleKey = apiKeyValidationInfoDTO.getApplicationId() + ":"
-                + apiKeyValidationInfoDTO.getSubscriber() + "@" + apiKeyValidationInfoDTO.getSubscriberTenantDomain();
+                + apiKeyValidationInfoDTO.getEndUserName() + "@" + apiKeyValidationInfoDTO.getSubscriberTenantDomain();
         PowerMockito.when(WebsocketUtil.getThrottleStatus(verbInfoDTO.getRequestKey(), subscriptionLevelThrottleKey,
                 applicationLevelThrottleKey)).thenReturn(null);
         Mockito.when(dataPublisher.tryPublish(Mockito.anyObject())).thenReturn(true);
@@ -179,6 +180,7 @@ public class InboundWebsocketProcessorUtilTest {
         apiKeyValidationInfoDTO.setTier(APIConstants.UNLIMITED_TIER);
         apiKeyValidationInfoDTO.setSubscriberTenantDomain(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
         apiKeyValidationInfoDTO.setSubscriber("admin");
+        apiKeyValidationInfoDTO.setEndUserName("otherUser");
         apiKeyValidationInfoDTO.setApiName("GraphQLAPI");
         apiKeyValidationInfoDTO.setApplicationId("12");
         inboundMessageContext.setTenantDomain(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
@@ -194,7 +196,7 @@ public class InboundWebsocketProcessorUtilTest {
                 apiKeyValidationInfoDTO.getApplicationId() + ":" + inboundMessageContext.getApiContext() + ":"
                         + inboundMessageContext.getVersion();
         String applicationLevelThrottleKey =
-                apiKeyValidationInfoDTO.getApplicationId() + ":" + apiKeyValidationInfoDTO.getSubscriber() + "@"
+                apiKeyValidationInfoDTO.getApplicationId() + ":" + apiKeyValidationInfoDTO.getEndUserName() + "@"
                         + apiKeyValidationInfoDTO.getSubscriberTenantDomain();
         Mockito.when(dataPublisher.tryPublish(Mockito.anyObject())).thenReturn(true);
 
@@ -220,6 +222,45 @@ public class InboundWebsocketProcessorUtilTest {
                 WebSocketApiConstants.FrameErrorConstants.THROTTLED_OUT_ERROR_MESSAGE);
         org.junit.Assert.assertEquals(String.valueOf(payload.get(WebSocketApiConstants.FrameErrorConstants.ERROR_CODE)),
                 String.valueOf(WebSocketApiConstants.FrameErrorConstants.THROTTLED_OUT_ERROR));
+    }
+
+    @Test
+    public void testDoThrottleApplicationLevelKeyForNonSuperTenant() {
+        InboundMessageContext inboundMessageContext = new InboundMessageContext();
+        int msgSize = 100;
+        VerbInfoDTO verbInfoDTO = new VerbInfoDTO();
+        verbInfoDTO.setThrottling("Gold");
+        verbInfoDTO.setRequestKey("liftStatusChange");
+        String operationId = "1";
+        String tenantDomain = "abc.com";
+        APIKeyValidationInfoDTO apiKeyValidationInfoDTO = new APIKeyValidationInfoDTO();
+        apiKeyValidationInfoDTO.setApplicationTier(APIConstants.UNLIMITED_TIER);
+        apiKeyValidationInfoDTO.setTier(APIConstants.UNLIMITED_TIER);
+        apiKeyValidationInfoDTO.setSubscriberTenantDomain(tenantDomain);
+        apiKeyValidationInfoDTO.setSubscriber("admin");
+        apiKeyValidationInfoDTO.setEndUserName("otherUser");
+        apiKeyValidationInfoDTO.setApiName("GraphQLAPI");
+        apiKeyValidationInfoDTO.setApplicationId("12");
+        inboundMessageContext.setTenantDomain(tenantDomain);
+        inboundMessageContext.setApiContext("/graphql");
+        inboundMessageContext.setVersion("1.0.0");
+        inboundMessageContext.setUserIP("198.162.10.2");
+        inboundMessageContext.setInfoDTO(apiKeyValidationInfoDTO);
+
+        String subscriptionLevelThrottleKey = apiKeyValidationInfoDTO.getApplicationId() + ":"
+                + inboundMessageContext.getApiContext() + ":" + inboundMessageContext.getVersion();
+        // Non-super-tenant format: no "@tenantDomain" suffix, unlike the super-tenant case.
+        String applicationLevelThrottleKey =
+                apiKeyValidationInfoDTO.getApplicationId() + ":" + apiKeyValidationInfoDTO.getEndUserName();
+        PowerMockito.when(WebsocketUtil.getThrottleStatus(verbInfoDTO.getRequestKey(), subscriptionLevelThrottleKey,
+                applicationLevelThrottleKey)).thenReturn(null);
+        Mockito.when(dataPublisher.tryPublish(Mockito.anyObject())).thenReturn(true);
+        InboundProcessorResponseDTO inboundProcessorResponseDTO =
+                InboundWebsocketProcessorUtil.doThrottleForGraphQL(msgSize, verbInfoDTO, inboundMessageContext,
+                        operationId);
+        Assert.assertFalse(inboundProcessorResponseDTO.isError());
+        Assert.assertNull(inboundProcessorResponseDTO.getErrorMessage());
+        Assert.assertFalse(inboundProcessorResponseDTO.isCloseConnection());
     }
 
     @Test


### PR DESCRIPTION
Fix: [WebSocket API application level throttling is not working as expected #3851](https://github.com/wso2/api-manager/issues/3851)

Fixes application-level throttling for WebSocket APIs, which was incorrectly scoped to the application subscriber/owner instead of the actual end user. As a result, all users of a shared application collapsed onto a single throttle bucket,  e.g. with a 5-requests/min application tier, if the app owner sent 5 frames and exhausted the quota, a completely different user of the same application would also get throttled out, even without having sent any frames themselves. The fix changes the application-level throttle key to be built from `infoDTO.getEndUserName()` instead of `infoDTO.getSubscriber()`, so each end user gets their own independent quota within the shared application

Also fixes a double tenant-domain suffix bug in the WebSocket application-level throttle key, introduced while fixing the throttle key to be end-user bound instead of subscriber-bound.

`infoDTO.getEndUserName()`  already returns a fully tenant-qualified username. For super-tenant users, the code additionally appended "@" + subscriberTenantDomain", producing a malformed key like admin@carbon.super@carbon.super - which broke application-level throttling for super-tenant users entirely.

<img width="429" height="109" alt="Screenshot 2026-07-22 at 12 42 07" src="https://github.com/user-attachments/assets/def92230-1a34-439d-b16e-5b92ff68afe5" />

Modified the tests accordingly.
<img width="1396" height="224" alt="Screenshot 2026-07-22 at 12 49 24" src="https://github.com/user-attachments/assets/0a1497e7-4803-4b2b-9681-e26e1284ff35" />


