### PR TITLE
Fix userstoreDomainInSubject schema in DCR API spec

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.common/src/main/resources/dcr.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.common/src/main/resources/dcr.yaml
@@ -94,8 +94,7 @@ components:
           readOnly: true
           example: JWT
         userstoreDomainInSubject:
-          type: string
-          readOnly: true
+          type: boolean
           example: true
     DCRResult:
       title: DCRResult

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.dcr/src/main/resources/dcr.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.dcr/src/main/resources/dcr.yaml
@@ -94,8 +94,7 @@ components:
           readOnly: true
           example: JWT
         userstoreDomainInSubject:
-          type: string
-          readOnly: true
+          type: boolean
           example: true
     DCRResult:
       title: DCRResult


### PR DESCRIPTION
## Summary

Fixes wso2/api-manager#5077.

The DCR OpenAPI specification defines `userstoreDomainInSubject` as a `string` and marks it as `readOnly`, while the runtime implementation treats it as a boolean request field.

## Changes

- Change `type` from `string` to `boolean`
- Remove the incorrect `readOnly` attribute
- Synchronize the common DCR specification copy

## Testing

- Verified that both DCR specification files contain the corrected schema.
- Confirmed that only the two expected YAML files were modified.