### PR TITLE
Align direct application lookup with organization scope

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/SubscriptionValidationDAO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/SubscriptionValidationDAO.java
@@ -877,6 +877,31 @@ public class SubscriptionValidationDAO {
     }
 
     /*
+     * @param applicationId : unique identifier of an application
+     * @param organization : organization that owns the application
+     * @return {@link List<Application>} a list with one element when the application belongs to the organization
+     * */
+    public List<Application> getApplicationById(int applicationId, String organization) {
+
+        List<Application> applicationList = new ArrayList<>();
+
+        try (Connection conn = APIMgtDBUtil.getConnection();
+             PreparedStatement ps = conn.prepareStatement(
+                     SubscriptionValidationSQLConstants.GET_APPLICATION_BY_ID_AND_ORGANIZATION_SQL)) {
+            ps.setInt(1, applicationId);
+            ps.setString(2, organization);
+
+            try (ResultSet resultSet = ps.executeQuery()) {
+                addToApplicationList(applicationList, resultSet);
+            }
+
+        } catch (SQLException e) {
+            log.error("Error in loading Application by applicationId : " + applicationId, e);
+        }
+        return applicationList;
+    }
+
+    /*
      * @param policyName : name of an application level throttling policy
      * @return {@link ApplicationPolicy}
      * */

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/constants/SubscriptionValidationSQLConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/constants/SubscriptionValidationSQLConstants.java
@@ -107,6 +107,9 @@ public class SubscriptionValidationSQLConstants {
                     "   APP.SUBSCRIBER_ID = SUB.SUBSCRIBER_ID AND" +
                     "   APP.APPLICATION_ID = ? ";
 
+    public static final String GET_APPLICATION_BY_ID_AND_ORGANIZATION_SQL =
+            GET_APPLICATION_BY_ID_SQL + " AND APP.ORGANIZATION = ? ";
+
     public static final String GET_ORGANIZATION_SUBSCRIPTIONS_SQL =
             "SELECT " +
                     "   SUBS.UUID AS SUBSCRIPTION_UUID," +

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/dao/test/APIMgtDAOTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/dao/test/APIMgtDAOTest.java
@@ -58,6 +58,7 @@ import org.wso2.carbon.apimgt.impl.APIConstants;
 import org.wso2.carbon.apimgt.impl.APIManagerConfiguration;
 import org.wso2.carbon.apimgt.impl.APIManagerConfigurationServiceImpl;
 import org.wso2.carbon.apimgt.impl.dao.ApiMgtDAO;
+import org.wso2.carbon.apimgt.impl.dao.SubscriptionValidationDAO;
 import org.wso2.carbon.apimgt.impl.dto.APIInfoDTO;
 import org.wso2.carbon.apimgt.impl.dto.APIKeyInfoDTO;
 import org.wso2.carbon.apimgt.impl.dto.ApplicationRegistrationWorkflowDTO;
@@ -364,6 +365,42 @@ public class APIMgtDAOTest {
         assertNull(apiMgtDAO.getApplicationByName("testApplication2", null, null));
 
     }
+
+    @Test
+    public void testGetApplicationByIdAndOrganization() throws Exception {
+        String organization = "application-owner.example";
+        Subscriber subscriber = new Subscriber("APPLICATION_SCOPE_USER");
+        subscriber.setEmail("application-scope-user@example.com");
+        subscriber.setSubscribedDate(new Date());
+        subscriber.setTenantId(MultitenantConstants.SUPER_TENANT_ID);
+        apiMgtDAO.addSubscriber(subscriber, null);
+
+        Application application = new Application("scopedApplication", subscriber);
+        application.setUUID(UUID.randomUUID().toString());
+        int applicationId = -1;
+        try {
+            applicationId = apiMgtDAO.addApplication(application, subscriber.getName(), organization);
+            application.setId(applicationId);
+
+            SubscriptionValidationDAO subscriptionValidationDAO = new SubscriptionValidationDAO();
+            List<org.wso2.carbon.apimgt.api.model.subscription.Application> matchingApplications =
+                    subscriptionValidationDAO.getApplicationById(applicationId, organization);
+            List<org.wso2.carbon.apimgt.api.model.subscription.Application> foreignApplications =
+                    subscriptionValidationDAO.getApplicationById(applicationId, "other.example");
+
+            assertEquals(1, matchingApplications.size());
+            assertEquals(applicationId, matchingApplications.get(0).getId());
+            assertEquals(organization, matchingApplications.get(0).getOrganization());
+            assertTrue(foreignApplications.isEmpty());
+            assertEquals(1, subscriptionValidationDAO.getApplicationById(applicationId).size());
+        } finally {
+            if (applicationId > 0) {
+                apiMgtDAO.deleteApplication(application);
+            }
+            deleteSubscriber(subscriber.getId());
+        }
+    }
+
     @Test
     public void testKeyForwardCompatibilityWhenNewAPIVersion() throws Exception {
         List<API> oldApiVersionList = new ArrayList<>();

--- a/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/main/java/org/wso2/carbon/apimgt/internal/service/impl/ApplicationsApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/main/java/org/wso2/carbon/apimgt/internal/service/impl/ApplicationsApiServiceImpl.java
@@ -25,9 +25,11 @@ import org.wso2.carbon.apimgt.impl.APIConstants;
 import org.wso2.carbon.apimgt.impl.dao.SubscriptionValidationDAO;
 import org.wso2.carbon.apimgt.internal.service.ApplicationsApiService;
 import org.wso2.carbon.apimgt.internal.service.utils.SubscriptionValidationDataUtil;
+import org.wso2.carbon.apimgt.rest.api.common.RestApiCommonUtil;
 import org.wso2.carbon.apimgt.rest.api.util.utils.RestApiUtil;
 import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 
+import java.util.Collections;
 import java.util.List;
 import javax.ws.rs.core.Response;
 
@@ -38,7 +40,9 @@ public class ApplicationsApiServiceImpl implements ApplicationsApiService {
 
         SubscriptionValidationDAO subscriptionValidationDAO = new SubscriptionValidationDAO();
         if (appId != null && appId > 0) {
-            List<Application> application = subscriptionValidationDAO.getApplicationById(appId);
+            String authenticatedOrganization = RestApiCommonUtil.getLoggedInUserTenantDomain();
+            List<Application> application =
+                    getApplicationById(subscriptionValidationDAO, appId, authenticatedOrganization);
             return Response.ok().entity(SubscriptionValidationDataUtil.fromApplicationToApplicationListDTO(application)
             ).build();
         }
@@ -59,5 +63,17 @@ public class ApplicationsApiServiceImpl implements ApplicationsApiService {
         }
         return Response.ok().entity(SubscriptionValidationDataUtil.fromApplicationToApplicationListDTO(
                 subscriptionValidationDAO.getAllApplications())).build();
+    }
+
+    static List<Application> getApplicationById(SubscriptionValidationDAO subscriptionValidationDAO, int appId,
+                                                String authenticatedOrganization) {
+
+        if (StringUtils.isEmpty(authenticatedOrganization)) {
+            return Collections.emptyList();
+        }
+        if (MultitenantConstants.SUPER_TENANT_DOMAIN_NAME.equalsIgnoreCase(authenticatedOrganization)) {
+            return subscriptionValidationDAO.getApplicationById(appId);
+        }
+        return subscriptionValidationDAO.getApplicationById(appId, authenticatedOrganization);
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/test/java/org/wso2/carbon/apimgt/internal/service/impl/ApplicationsApiServiceImplTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/test/java/org/wso2/carbon/apimgt/internal/service/impl/ApplicationsApiServiceImplTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.apimgt.internal.service.impl;
+
+import org.junit.Test;
+import org.wso2.carbon.apimgt.api.model.subscription.Application;
+import org.wso2.carbon.apimgt.impl.dao.SubscriptionValidationDAO;
+import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class ApplicationsApiServiceImplTest {
+
+    private static final int APPLICATION_ID = 42;
+    private static final String TENANT_DOMAIN = "application-owner.example";
+
+    @Test
+    public void testTenantLookupUsesOrganizationScopedQuery() {
+        RecordingSubscriptionValidationDAO dao = new RecordingSubscriptionValidationDAO();
+
+        List<Application> applications =
+                ApplicationsApiServiceImpl.getApplicationById(dao, APPLICATION_ID, TENANT_DOMAIN);
+
+        assertEquals(1, applications.size());
+        assertEquals(0, dao.unscopedCalls);
+        assertEquals(1, dao.scopedCalls);
+        assertEquals(TENANT_DOMAIN, dao.requestedOrganization);
+    }
+
+    @Test
+    public void testSuperTenantLookupUsesExistingQuery() {
+        RecordingSubscriptionValidationDAO dao = new RecordingSubscriptionValidationDAO();
+
+        List<Application> applications = ApplicationsApiServiceImpl.getApplicationById(
+                dao, APPLICATION_ID, MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
+
+        assertEquals(1, applications.size());
+        assertEquals(1, dao.unscopedCalls);
+        assertEquals(0, dao.scopedCalls);
+    }
+
+    @Test
+    public void testMissingOrganizationDoesNotUseUnscopedQuery() {
+        RecordingSubscriptionValidationDAO dao = new RecordingSubscriptionValidationDAO();
+
+        assertTrue(ApplicationsApiServiceImpl.getApplicationById(dao, APPLICATION_ID, null).isEmpty());
+        assertTrue(ApplicationsApiServiceImpl.getApplicationById(dao, APPLICATION_ID, "").isEmpty());
+        assertEquals(0, dao.unscopedCalls);
+        assertEquals(0, dao.scopedCalls);
+    }
+
+    @Test
+    public void testScopedLookupPreservesEmptyResult() {
+        RecordingSubscriptionValidationDAO dao = new RecordingSubscriptionValidationDAO();
+        dao.scopedResult = Collections.emptyList();
+
+        assertTrue(ApplicationsApiServiceImpl.getApplicationById(dao, APPLICATION_ID, TENANT_DOMAIN).isEmpty());
+        assertEquals(0, dao.unscopedCalls);
+        assertEquals(1, dao.scopedCalls);
+    }
+
+    private static class RecordingSubscriptionValidationDAO extends SubscriptionValidationDAO {
+
+        private int unscopedCalls;
+        private int scopedCalls;
+        private String requestedOrganization;
+        private List<Application> scopedResult = Collections.singletonList(new Application());
+
+        @Override
+        public List<Application> getApplicationById(int applicationId) {
+            unscopedCalls++;
+            return Collections.singletonList(new Application());
+        }
+
+        @Override
+        public List<Application> getApplicationById(int applicationId, String organization) {
+            scopedCalls++;
+            requestedOrganization = organization;
+            return scopedResult;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- add an organization-aware application lookup overload
- use the authenticated organization for direct application lookup
- preserve the existing super-tenant lookup behavior
- add DAO and service coverage for scoped, unscoped, missing-context, and empty-result paths

## Tests

- `mvn -f components/apimgt/org.wso2.carbon.apimgt.impl/pom.xml clean test -Dskip.aspectj=true` (791 tests)
- `mvn -f components/apimgt/org.wso2.carbon.apimgt.internal.service/pom.xml clean test` (5 tests)