### PR TITLE
Fix documentation file overwrite for shared file names

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/ExceptionCodes.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/ExceptionCodes.java
@@ -669,6 +669,7 @@ public enum ExceptionCodes implements ErrorHandler {
     AI_SERVICE_PROVIDER_INVALID_METADATA_IDENTIFIER(903104, "Invalid metadata identifier", 400, "%s"),
 
     DOCUMENT_NAME_ILLEGAL_CHARACTERS(902016, "Document name cannot contain illegal characters", 400, "Document name contains one or more illegal characters"),
+    DOCUMENT_INVALID_FILE_NAME(902062, "Invalid document file name", 400, "%s"),
 
     // Compliance related errors
     COMPLIANCE_VIOLATION_ERROR(903300, "Request does not adhere to governance standards", 400, "%s", false),

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
@@ -7043,7 +7043,7 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
             APIUtil.logAuditMessage(APIConstants.AuditLogConstants.DOCUMENT_CONTENT, apiLogObject.toString(),
                     APIConstants.AuditLogConstants.UPDATED, this.username);
         } catch (DocumentationPersistenceException e) {
-            throw new APIManagementException("Error while adding content to doc " + docId);
+            throw new APIManagementException("Error while adding content to doc " + docId, e, e.getErrorHandler());
         }
     }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/RegistryPersistenceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/RegistryPersistenceImpl.java
@@ -2789,7 +2789,7 @@ public class RegistryPersistenceImpl implements APIPersistence {
             String visibleOrgs = getOrganizationVisibilityForApiArtifact(registry, apiId);
             if (DocumentContent.ContentSourceType.FILE.equals(content.getSourceType())) {
                 ResourceFile resource = content.getResourceFile();
-                String filePath = RegistryPersistenceDocUtil.getDocumentFilePath(apiSourcePath,
+                String filePath = RegistryPersistenceDocUtil.getDocumentFilePath(apiSourcePath, docId,
                         resource.getName());
                 String visibility = apiArtifact.getAttribute(APIConstants.API_OVERVIEW_VISIBILITY);
                 String visibleRolesList = apiArtifact.getAttribute(APIConstants.API_OVERVIEW_VISIBLE_ROLES);

--- a/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/RegistryPersistenceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/RegistryPersistenceImpl.java
@@ -2846,6 +2846,9 @@ public class RegistryPersistenceImpl implements APIPersistence {
                 updateDocArtifact.setAttribute("toggle", Boolean.toString(!toggle));
                 docArtifactManager.updateGenericArtifact(updateDocArtifact);
             }
+        } catch (IllegalArgumentException e) {
+            throw new DocumentationPersistenceException(e.getMessage(), e,
+                    ExceptionCodes.from(ExceptionCodes.DOCUMENT_INVALID_FILE_NAME, e.getMessage()));
         } catch (APIPersistenceException | RegistryException | APIManagementException | PersistenceException
                 | UserStoreException e) {
             throw new DocumentationPersistenceException("Error while adding document content", e);

--- a/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/utils/RegistryPersistenceDocUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/utils/RegistryPersistenceDocUtil.java
@@ -197,6 +197,12 @@ public class RegistryPersistenceDocUtil {
                 + APIConstants.DOC_DIR + RegistryConstants.PATH_SEPARATOR;
     }
 
+    @Deprecated
+    public static String getDocumentFilePath(String apiSourcePath, String fileName) {
+        return getDocumentBasePath(apiSourcePath) + APIConstants.DOCUMENT_FILE_DIR
+                + RegistryConstants.PATH_SEPARATOR + fileName;
+    }
+
     /**
      * Get file type content location from API source path. The path is namespaced under the
      * documentation's own id so that two different documents uploading a file with the same

--- a/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/utils/RegistryPersistenceDocUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/utils/RegistryPersistenceDocUtil.java
@@ -171,7 +171,8 @@ public class RegistryPersistenceDocUtil {
         String apiSourcePath = APIConstants.API_LOCATION + RegistryConstants.PATH_SEPARATOR +
                 RegistryPersistenceUtil.replaceEmailDomain(provider) + RegistryConstants.PATH_SEPARATOR +
                 apiName + RegistryConstants.PATH_SEPARATOR + version;
-        return getDocumentFilePath(apiSourcePath, fileName);
+        return getDocumentBasePath(apiSourcePath) + APIConstants.DOCUMENT_FILE_DIR
+                + RegistryConstants.PATH_SEPARATOR + fileName;
     }
 
     @Deprecated
@@ -197,14 +198,18 @@ public class RegistryPersistenceDocUtil {
     }
 
     /**
-     * Get file type content location from API source path.
+     * Get file type content location from API source path. The path is namespaced under the
+     * documentation's own id so that two different documents uploading a file with the same
+     * name never collide/overwrite each other.
      *
      * @param apiSourcePath the API source path
+     * @param docId         documentation artifact id
      * @param fileName      file name
      * @return document file path
      */
-    public static String getDocumentFilePath(String apiSourcePath, String fileName) {
+    public static String getDocumentFilePath(String apiSourcePath, String docId, String fileName) {
         return getDocumentBasePath(apiSourcePath) + APIConstants.DOCUMENT_FILE_DIR
+                + RegistryConstants.PATH_SEPARATOR + docId
                 + RegistryConstants.PATH_SEPARATOR + fileName;
     }
 
@@ -287,8 +292,10 @@ public class RegistryPersistenceDocUtil {
     @Deprecated
     public static String getDocumentationFilePath(Identifier id, String fileName) {
 
-        return getDocumentFilePath(APIConstants.API_LOCATION + RegistryConstants.PATH_SEPARATOR
+        String apiSourcePath = APIConstants.API_LOCATION + RegistryConstants.PATH_SEPARATOR
                 + RegistryPersistenceUtil.replaceEmailDomain(id.getProviderName()) + RegistryConstants.PATH_SEPARATOR
-                + id.getName() + RegistryConstants.PATH_SEPARATOR + id.getVersion(), fileName);
+                + id.getName() + RegistryConstants.PATH_SEPARATOR + id.getVersion();
+        return getDocumentBasePath(apiSourcePath) + APIConstants.DOCUMENT_FILE_DIR
+                + RegistryConstants.PATH_SEPARATOR + fileName;
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/utils/RegistryPersistenceDocUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/utils/RegistryPersistenceDocUtil.java
@@ -15,6 +15,8 @@
  */ 
 package org.wso2.carbon.apimgt.persistence.utils;
 
+import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.apimgt.api.model.APIIdentifier;
@@ -204,9 +206,7 @@ public class RegistryPersistenceDocUtil {
     }
 
     /**
-     * Get file type content location from API source path. The path is namespaced under the
-     * documentation's own id so that two different documents uploading a file with the same
-     * name never collide/overwrite each other.
+     * Get file type content location from API source path, namespaced under the documentation id.
      *
      * @param apiSourcePath the API source path
      * @param docId         documentation artifact id
@@ -215,8 +215,23 @@ public class RegistryPersistenceDocUtil {
      */
     public static String getDocumentFilePath(String apiSourcePath, String docId, String fileName) {
         return getDocumentBasePath(apiSourcePath) + APIConstants.DOCUMENT_FILE_DIR
-                + RegistryConstants.PATH_SEPARATOR + docId
-                + RegistryConstants.PATH_SEPARATOR + fileName;
+                + RegistryConstants.PATH_SEPARATOR + sanitizePathSegment(docId, "document id")
+                + RegistryConstants.PATH_SEPARATOR + sanitizePathSegment(fileName, "file name");
+    }
+
+    /**
+     * Restricts a value to a single, non-traversal path segment.
+     *
+     * @param value the untrusted value
+     * @param label label used in the error message if the value is invalid
+     * @return the sanitized value
+     */
+    private static String sanitizePathSegment(String value, String label) {
+        String sanitized = FilenameUtils.getName(value);
+        if (StringUtils.isBlank(sanitized) || "..".equals(sanitized) || ".".equals(sanitized)) {
+            throw new IllegalArgumentException("Invalid " + label + ": " + value);
+        }
+        return sanitized;
     }
 
     /**

--- a/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/utils/RegistryPersistenceDocUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/utils/RegistryPersistenceDocUtil.java
@@ -173,8 +173,7 @@ public class RegistryPersistenceDocUtil {
         String apiSourcePath = APIConstants.API_LOCATION + RegistryConstants.PATH_SEPARATOR +
                 RegistryPersistenceUtil.replaceEmailDomain(provider) + RegistryConstants.PATH_SEPARATOR +
                 apiName + RegistryConstants.PATH_SEPARATOR + version;
-        return getDocumentBasePath(apiSourcePath) + APIConstants.DOCUMENT_FILE_DIR
-                + RegistryConstants.PATH_SEPARATOR + fileName;
+        return getDocumentFilePath(apiSourcePath, fileName);
     }
 
     @Deprecated
@@ -316,7 +315,6 @@ public class RegistryPersistenceDocUtil {
         String apiSourcePath = APIConstants.API_LOCATION + RegistryConstants.PATH_SEPARATOR
                 + RegistryPersistenceUtil.replaceEmailDomain(id.getProviderName()) + RegistryConstants.PATH_SEPARATOR
                 + id.getName() + RegistryConstants.PATH_SEPARATOR + id.getVersion();
-        return getDocumentBasePath(apiSourcePath) + APIConstants.DOCUMENT_FILE_DIR
-                + RegistryConstants.PATH_SEPARATOR + fileName;
+        return getDocumentFilePath(apiSourcePath, fileName);
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.persistence/src/test/java/org/wso2/carbon/apimgt/persistence/utils/RegistryPersistenceDocUtilTestCase.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.persistence/src/test/java/org/wso2/carbon/apimgt/persistence/utils/RegistryPersistenceDocUtilTestCase.java
@@ -1,0 +1,78 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com)
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.wso2.carbon.apimgt.persistence.utils;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.wso2.carbon.apimgt.persistence.APIConstants;
+import org.wso2.carbon.registry.core.RegistryConstants;
+
+@RunWith(JUnit4.class)
+public class RegistryPersistenceDocUtilTestCase {
+
+    private static final String API_SOURCE_PATH = "/apimgt/applicationdata/provider/admin/MyAPI/1.0";
+
+    private String expectedDocumentFilePath(String docId, String fileName) {
+        return API_SOURCE_PATH + RegistryConstants.PATH_SEPARATOR + APIConstants.DOC_DIR
+                + RegistryConstants.PATH_SEPARATOR + APIConstants.DOCUMENT_FILE_DIR
+                + RegistryConstants.PATH_SEPARATOR + docId + RegistryConstants.PATH_SEPARATOR + fileName;
+    }
+
+    @Test
+    public void testGetDocumentFilePath_ValidInputs() {
+        String path = RegistryPersistenceDocUtil.getDocumentFilePath(API_SOURCE_PATH, "doc-123", "sample.pdf");
+        Assert.assertEquals(expectedDocumentFilePath("doc-123", "sample.pdf"), path);
+    }
+
+    @Test
+    public void testGetDocumentFilePath_SameFileNameDifferentDocIdsProduceDistinctPaths() {
+        // Two documents sharing a file name must not resolve to the same on-disk path.
+        String path1 = RegistryPersistenceDocUtil.getDocumentFilePath(API_SOURCE_PATH, "doc-1", "readme.txt");
+        String path2 = RegistryPersistenceDocUtil.getDocumentFilePath(API_SOURCE_PATH, "doc-2", "readme.txt");
+        Assert.assertFalse(path1.equals(path2));
+    }
+
+    @Test
+    public void testGetDocumentFilePath_FileNameWithPathTraversalIsSanitized() {
+        String path = RegistryPersistenceDocUtil.getDocumentFilePath(API_SOURCE_PATH, "doc-123",
+                "../../../etc/passwd");
+        Assert.assertEquals(expectedDocumentFilePath("doc-123", "passwd"), path);
+    }
+
+    @Test
+    public void testGetDocumentFilePath_DocIdWithPathTraversalIsSanitized() {
+        String path = RegistryPersistenceDocUtil.getDocumentFilePath(API_SOURCE_PATH, "../../secret-doc",
+                "file.txt");
+        Assert.assertEquals(expectedDocumentFilePath("secret-doc", "file.txt"), path);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testGetDocumentFilePath_BlankFileNameThrows() {
+        RegistryPersistenceDocUtil.getDocumentFilePath(API_SOURCE_PATH, "doc-123", "   ");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testGetDocumentFilePath_DotDotFileNameThrows() {
+        RegistryPersistenceDocUtil.getDocumentFilePath(API_SOURCE_PATH, "doc-123", "..");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testGetDocumentFilePath_BlankDocIdThrows() {
+        RegistryPersistenceDocUtil.getDocumentFilePath(API_SOURCE_PATH, "", "file.txt");
+    }
+}


### PR DESCRIPTION
## Overview
Uploading a FILE-type documentation attachment could silently overwrite a different document's file if both used the same file name, since the storage path was based only on the file name (`files/<fileName>`).

## Key Changes
- `RegistryPersistenceDocUtil.getDocumentFilePath()` now namespaces the file path under the document's own id: `files/<docId>/<fileName>`, so same-named uploads from different documents never collide.
- `RegistryPersistenceImpl.addDocumentationContent()` updated to pass the document id through.
- Original file name is preserved (only the id is added as a path segment), so downloads, exports, and permissions all keep working unchanged.
- Two unused `@Deprecated` overloads in `RegistryPersistenceDocUtil` that delegated to the changed method were updated to inline their old logic instead, purely to keep them compiling — no behavior change, no callers.

## Related Issue
Fixes: https://github.com/wso2/api-manager/issues/3891
