### PR TITLE
Add Elasticache as a semantic cache vector db

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/VectorDBProviderService.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/VectorDBProviderService.java
@@ -66,4 +66,10 @@ public interface VectorDBProviderService {
      * @throws APIManagementException if an error occurs while retrieving the response.
      */
     <T extends Serializable> T retrieve(double[] embeddings, Map<String, String> filter) throws APIManagementException;
+
+    /**
+     * Releases any resources (connections, clients, thread pools, etc.) acquired by this provider
+     * during {@link #init}. Called when the provider is being shut down.
+     */
+    void close() throws APIManagementException;
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/ElastiCacheVectorDBProviderServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/ElastiCacheVectorDBProviderServiceImpl.java
@@ -62,6 +62,39 @@ public class ElastiCacheVectorDBProviderServiceImpl implements VectorDBProviderS
     private static final int DEFAULT_CLUSTER_MAX_ATTEMPTS = 5;
     private static final String TAG_QUERY_SPECIAL_CHARS = ",.<>{}\"':;!@#$%^&*()-+=~[]";
 
+    public static final String VECTOR_DB_PROVIDER_ELASTICACHE_TYPE = "elasticache";
+    private static final String VECTOR_DB_PROVIDER_ELASTICACHE_HOST = "host";
+    private static final String VECTOR_DB_PROVIDER_ELASTICACHE_PORT = "port";
+    private static final String VECTOR_DB_PROVIDER_ELASTICACHE_USERNAME = "username";
+    private static final String VECTOR_DB_PROVIDER_ELASTICACHE_PASSWORD = "password";
+    private static final String VECTOR_DB_PROVIDER_ELASTICACHE_SSL_ENABLED = "ssl_enabled";
+    private static final String VECTOR_DB_PROVIDER_ELASTICACHE_CLUSTER_MODE_ENABLED = "cluster_mode_enabled";
+    private static final String VECTOR_DB_PROVIDER_ELASTICACHE_INDEX_SUFFIX = "_idx";
+    private static final String VECTOR_DB_PROVIDER_ELASTICACHE_KEY_PREFIX_SUFFIX = ":";
+    private static final int VECTOR_DB_PROVIDER_ELASTICACHE_HNSW_M = 64;
+    private static final int VECTOR_DB_PROVIDER_ELASTICACHE_HNSW_EF_CONSTRUCTION = 100;
+
+    // RediSearch schema/query keywords
+    private static final String VECTOR_DB_PROVIDER_ELASTICACHE_ON = "ON";
+    private static final String VECTOR_DB_PROVIDER_ELASTICACHE_HASH = "HASH";
+    private static final String VECTOR_DB_PROVIDER_ELASTICACHE_PREFIX = "PREFIX";
+    private static final String VECTOR_DB_PROVIDER_ELASTICACHE_SCHEMA = "SCHEMA";
+    private static final String VECTOR_DB_PROVIDER_ELASTICACHE_TAG = "TAG";
+    private static final String VECTOR_DB_PROVIDER_ELASTICACHE_NUMERIC = "NUMERIC";
+    private static final String VECTOR_DB_PROVIDER_ELASTICACHE_VECTOR = "VECTOR";
+    private static final String VECTOR_DB_PROVIDER_ELASTICACHE_HNSW = "HNSW";
+    private static final String VECTOR_DB_PROVIDER_ELASTICACHE_TYPE_KEYWORD = "TYPE";
+    private static final String VECTOR_DB_PROVIDER_ELASTICACHE_FLOAT32 = "FLOAT32";
+    private static final String VECTOR_DB_PROVIDER_ELASTICACHE_DIM = "DIM";
+    private static final String VECTOR_DB_PROVIDER_ELASTICACHE_DISTANCE_METRIC = "DISTANCE_METRIC";
+    private static final String VECTOR_DB_PROVIDER_ELASTICACHE_L2 = "L2";
+    private static final String VECTOR_DB_PROVIDER_ELASTICACHE_M = "M";
+    private static final String VECTOR_DB_PROVIDER_ELASTICACHE_EF_CONSTRUCTION = "EF_CONSTRUCTION";
+    private static final String VECTOR_DB_PROVIDER_ELASTICACHE_PARAMS = "PARAMS";
+    private static final String VECTOR_DB_PROVIDER_ELASTICACHE_DIALECT = "DIALECT";
+    private static final String VECTOR_DB_PROVIDER_ELASTICACHE_SCORE_ALIAS = "score";
+    private static final String VECTOR_DB_PROVIDER_ELASTICACHE_VECTOR_PARAM_NAME = "vec";
+
     // Jedis pool tuning properties under [apim.ai.vector_db_provider.properties]. Defaults match
     // JedisPoolConfig's own out-of-the-box values so behavior is unchanged unless explicitly set.
     private static final String JEDIS_POOL_MAX_TOTAL = "jedis.pool.max_total";
@@ -101,14 +134,14 @@ public class ElastiCacheVectorDBProviderServiceImpl implements VectorDBProviderS
     public void init(VectorDBProviderConfigurationDTO providerConfig) throws APIManagementException {
         log.debug("Initializing AWS ElastiCache Vector DB provider");
         Map<String, String> properties = providerConfig.getProperties();
-        String host = properties.get(APIConstants.AI.VECTOR_DB_PROVIDER_ELASTICACHE_HOST);
-        String portStr = properties.get(APIConstants.AI.VECTOR_DB_PROVIDER_ELASTICACHE_PORT);
-        String username = properties.get(APIConstants.AI.VECTOR_DB_PROVIDER_ELASTICACHE_USERNAME);
-        String password = properties.get(APIConstants.AI.VECTOR_DB_PROVIDER_ELASTICACHE_PASSWORD);
+        String host = properties.get(VECTOR_DB_PROVIDER_ELASTICACHE_HOST);
+        String portStr = properties.get(VECTOR_DB_PROVIDER_ELASTICACHE_PORT);
+        String username = properties.get(VECTOR_DB_PROVIDER_ELASTICACHE_USERNAME);
+        String password = properties.get(VECTOR_DB_PROVIDER_ELASTICACHE_PASSWORD);
         boolean sslEnabled = Boolean.parseBoolean(
-                properties.get(APIConstants.AI.VECTOR_DB_PROVIDER_ELASTICACHE_SSL_ENABLED));
+                properties.get(VECTOR_DB_PROVIDER_ELASTICACHE_SSL_ENABLED));
         boolean clusterModeEnabled = Boolean.parseBoolean(
-                properties.get(APIConstants.AI.VECTOR_DB_PROVIDER_ELASTICACHE_CLUSTER_MODE_ENABLED));
+                properties.get(VECTOR_DB_PROVIDER_ELASTICACHE_CLUSTER_MODE_ENABLED));
 
         List<String> missingParams = new ArrayList<>();
         if (host == null) {
@@ -151,7 +184,7 @@ public class ElastiCacheVectorDBProviderServiceImpl implements VectorDBProviderS
 
     @Override
     public String getType() {
-        return APIConstants.AI.VECTOR_DB_PROVIDER_ELASTICACHE_TYPE;
+        return VECTOR_DB_PROVIDER_ELASTICACHE_TYPE;
     }
 
     @Override
@@ -186,9 +219,9 @@ public class ElastiCacheVectorDBProviderServiceImpl implements VectorDBProviderS
         // into the index/key-prefix name - switching providers safely gets its own index instead of
         // colliding with one sized for a different model.
         indexName = APIConstants.AI.VECTOR_INDEX_PREFIX + dimension +
-                APIConstants.AI.VECTOR_DB_PROVIDER_ELASTICACHE_INDEX_SUFFIX;
+                VECTOR_DB_PROVIDER_ELASTICACHE_INDEX_SUFFIX;
         keyPrefix = APIConstants.AI.VECTOR_INDEX_PREFIX + dimension +
-                APIConstants.AI.VECTOR_DB_PROVIDER_ELASTICACHE_KEY_PREFIX_SUFFIX;
+                VECTOR_DB_PROVIDER_ELASTICACHE_KEY_PREFIX_SUFFIX;
 
         if (indexExists(indexName)) {
             log.info("Index already exists: " + indexName);
@@ -196,29 +229,29 @@ public class ElastiCacheVectorDBProviderServiceImpl implements VectorDBProviderS
         }
 
         List<String> vectorAttributes = Arrays.asList(
-                APIConstants.AI.VECTOR_DB_PROVIDER_ELASTICACHE_TYPE_KEYWORD,
-                APIConstants.AI.VECTOR_DB_PROVIDER_ELASTICACHE_FLOAT32,
-                APIConstants.AI.VECTOR_DB_PROVIDER_ELASTICACHE_DIM, String.valueOf(dimension),
-                APIConstants.AI.VECTOR_DB_PROVIDER_ELASTICACHE_DISTANCE_METRIC,
-                APIConstants.AI.VECTOR_DB_PROVIDER_ELASTICACHE_L2,
-                APIConstants.AI.VECTOR_DB_PROVIDER_ELASTICACHE_M,
-                String.valueOf(APIConstants.AI.VECTOR_DB_PROVIDER_ELASTICACHE_HNSW_M),
-                APIConstants.AI.VECTOR_DB_PROVIDER_ELASTICACHE_EF_CONSTRUCTION,
-                String.valueOf(APIConstants.AI.VECTOR_DB_PROVIDER_ELASTICACHE_HNSW_EF_CONSTRUCTION));
+                VECTOR_DB_PROVIDER_ELASTICACHE_TYPE_KEYWORD,
+                VECTOR_DB_PROVIDER_ELASTICACHE_FLOAT32,
+                VECTOR_DB_PROVIDER_ELASTICACHE_DIM, String.valueOf(dimension),
+                VECTOR_DB_PROVIDER_ELASTICACHE_DISTANCE_METRIC,
+                VECTOR_DB_PROVIDER_ELASTICACHE_L2,
+                VECTOR_DB_PROVIDER_ELASTICACHE_M,
+                String.valueOf(VECTOR_DB_PROVIDER_ELASTICACHE_HNSW_M),
+                VECTOR_DB_PROVIDER_ELASTICACHE_EF_CONSTRUCTION,
+                String.valueOf(VECTOR_DB_PROVIDER_ELASTICACHE_HNSW_EF_CONSTRUCTION));
 
         List<String> args = new ArrayList<>(Arrays.asList(
                 indexName,
-                APIConstants.AI.VECTOR_DB_PROVIDER_ELASTICACHE_ON,
-                APIConstants.AI.VECTOR_DB_PROVIDER_ELASTICACHE_HASH,
-                APIConstants.AI.VECTOR_DB_PROVIDER_ELASTICACHE_PREFIX, "1", keyPrefix,
-                APIConstants.AI.VECTOR_DB_PROVIDER_ELASTICACHE_SCHEMA,
+                VECTOR_DB_PROVIDER_ELASTICACHE_ON,
+                VECTOR_DB_PROVIDER_ELASTICACHE_HASH,
+                VECTOR_DB_PROVIDER_ELASTICACHE_PREFIX, "1", keyPrefix,
+                VECTOR_DB_PROVIDER_ELASTICACHE_SCHEMA,
                 APIConstants.AI.VECTOR_DB_PROVIDER_API_ID,
-                APIConstants.AI.VECTOR_DB_PROVIDER_ELASTICACHE_TAG,
+                VECTOR_DB_PROVIDER_ELASTICACHE_TAG,
                 APIConstants.AI.VECTOR_DB_PROVIDER_CREATED_AT,
-                APIConstants.AI.VECTOR_DB_PROVIDER_ELASTICACHE_NUMERIC,
+                VECTOR_DB_PROVIDER_ELASTICACHE_NUMERIC,
                 APIConstants.AI.VECTOR_DB_PROVIDER_EMBEDDING,
-                APIConstants.AI.VECTOR_DB_PROVIDER_ELASTICACHE_VECTOR,
-                APIConstants.AI.VECTOR_DB_PROVIDER_ELASTICACHE_HNSW, String.valueOf(vectorAttributes.size())));
+                VECTOR_DB_PROVIDER_ELASTICACHE_VECTOR,
+                VECTOR_DB_PROVIDER_ELASTICACHE_HNSW, String.valueOf(vectorAttributes.size())));
         args.addAll(vectorAttributes);
 
         executor.executeSearchCommand(RediSearchCommand.FT_CREATE, args.toArray(new String[0]));
@@ -306,19 +339,19 @@ public class ElastiCacheVectorDBProviderServiceImpl implements VectorDBProviderS
         // threshold (mirroring Zilliz's "radius" semantics) is applied client-side on the score.
         String queryExpr = "(@" + APIConstants.AI.VECTOR_DB_PROVIDER_API_ID + ":{" + escapeTagValue(apiId) +
                 "})=>[KNN 1 @" + APIConstants.AI.VECTOR_DB_PROVIDER_EMBEDDING + " $" +
-                APIConstants.AI.VECTOR_DB_PROVIDER_ELASTICACHE_VECTOR_PARAM_NAME + " AS " +
-                APIConstants.AI.VECTOR_DB_PROVIDER_ELASTICACHE_SCORE_ALIAS + "]";
+                VECTOR_DB_PROVIDER_ELASTICACHE_VECTOR_PARAM_NAME + " AS " +
+                VECTOR_DB_PROVIDER_ELASTICACHE_SCORE_ALIAS + "]";
 
         // No SORTBY: it only accepts indexed schema fields, not the ad-hoc KNN "AS score" alias,
         // and KNN results are already returned in ascending vector-distance order by default.
         byte[][] args = {
                 SafeEncoder.encode(indexName),
                 SafeEncoder.encode(queryExpr),
-                SafeEncoder.encode(APIConstants.AI.VECTOR_DB_PROVIDER_ELASTICACHE_PARAMS),
+                SafeEncoder.encode(VECTOR_DB_PROVIDER_ELASTICACHE_PARAMS),
                 SafeEncoder.encode("2"),
-                SafeEncoder.encode(APIConstants.AI.VECTOR_DB_PROVIDER_ELASTICACHE_VECTOR_PARAM_NAME),
+                SafeEncoder.encode(VECTOR_DB_PROVIDER_ELASTICACHE_VECTOR_PARAM_NAME),
                 toVectorBytes(embeddings),
-                SafeEncoder.encode(APIConstants.AI.VECTOR_DB_PROVIDER_ELASTICACHE_DIALECT),
+                SafeEncoder.encode(VECTOR_DB_PROVIDER_ELASTICACHE_DIALECT),
                 SafeEncoder.encode("2")
         };
 
@@ -354,7 +387,7 @@ public class ElastiCacheVectorDBProviderServiceImpl implements VectorDBProviderS
             String fieldName = SafeEncoder.encode((byte[]) fields.get(i));
             if (APIConstants.AI.VECTOR_DB_PROVIDER_RESPONSE.equals(fieldName)) {
                 response = SafeEncoder.encode((byte[]) fields.get(i + 1));
-            } else if (APIConstants.AI.VECTOR_DB_PROVIDER_ELASTICACHE_SCORE_ALIAS.equals(fieldName)) {
+            } else if (VECTOR_DB_PROVIDER_ELASTICACHE_SCORE_ALIAS.equals(fieldName)) {
                 score = Double.parseDouble(SafeEncoder.encode((byte[]) fields.get(i + 1)));
             }
         }

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/ElastiCacheVectorDBProviderServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/ElastiCacheVectorDBProviderServiceImpl.java
@@ -154,6 +154,14 @@ public class ElastiCacheVectorDBProviderServiceImpl implements VectorDBProviderS
         return APIConstants.AI.VECTOR_DB_PROVIDER_ELASTICACHE_TYPE;
     }
 
+    @Override
+    public void close() throws APIManagementException {
+        if (executor != null) {
+            log.debug("Closing AWS ElastiCache Vector DB provider");
+            executor.close();
+        }
+    }
+
     /**
      * Create a RediSearch vector index in ElastiCache if it does not already exist.
      */
@@ -404,6 +412,18 @@ public class ElastiCacheVectorDBProviderServiceImpl implements VectorDBProviderS
                 JEDIS_POOL_TIME_BETWEEN_EVICTION_RUNS_MILLIS, JEDIS_POOL_TIME_BETWEEN_EVICTION_RUNS_MILLIS_DEFAULT));
         poolConfig.setNumTestsPerEvictionRun(parseIntProperty(properties, JEDIS_POOL_NUM_TESTS_PER_EVICTION_RUN,
                 JEDIS_POOL_NUM_TESTS_PER_EVICTION_RUN_DEFAULT));
+        if (log.isDebugEnabled()) {
+            log.debug("Resolved Jedis pool config: maxTotal=" + poolConfig.getMaxTotal() +
+                    ", maxIdle=" + poolConfig.getMaxIdle() +
+                    ", minIdle=" + poolConfig.getMinIdle() +
+                    ", testOnBorrow=" + poolConfig.getTestOnBorrow() +
+                    ", testOnReturn=" + poolConfig.getTestOnReturn() +
+                    ", testWhileIdle=" + poolConfig.getTestWhileIdle() +
+                    ", blockWhenExhausted=" + poolConfig.getBlockWhenExhausted() +
+                    ", minEvictableIdleTimeMillis=" + poolConfig.getMinEvictableIdleTimeMillis() +
+                    ", timeBetweenEvictionRunsMillis=" + poolConfig.getTimeBetweenEvictionRunsMillis() +
+                    ", numTestsPerEvictionRun=" + poolConfig.getNumTestsPerEvictionRun());
+        }
         return poolConfig;
     }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/ElastiCacheVectorDBProviderServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/ElastiCacheVectorDBProviderServiceImpl.java
@@ -1,0 +1,451 @@
+/*
+ * Copyright (c) 2026 WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.apimgt.gateway;
+
+import com.google.gson.Gson;
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.apimgt.api.APIManagementException;
+import org.wso2.carbon.apimgt.api.VectorDBProviderService;
+import org.wso2.carbon.apimgt.api.dto.VectorDBProviderConfigurationDTO;
+import org.wso2.carbon.apimgt.gateway.utils.redis.ClusterRedisCommandExecutor;
+import org.wso2.carbon.apimgt.gateway.utils.redis.RediSearchCommand;
+import org.wso2.carbon.apimgt.gateway.utils.redis.RedisCommandExecutor;
+import org.wso2.carbon.apimgt.gateway.utils.redis.StandaloneRedisCommandExecutor;
+import org.wso2.carbon.apimgt.impl.APIConstants;
+import redis.clients.jedis.HostAndPort;
+import redis.clients.jedis.JedisCluster;
+import redis.clients.jedis.JedisPool;
+import redis.clients.jedis.JedisPoolConfig;
+import redis.clients.jedis.Protocol;
+import redis.clients.jedis.util.SafeEncoder;
+
+import java.io.Serializable;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+/**
+ * This class is responsible for interacting with AWS ElastiCache (Redis/Valkey vector search,
+ * i.e. the RediSearch-compatible FT.CREATE/FT.SEARCH command set) to create indexes, store
+ * embeddings, and retrieve similar responses. Supports both standalone and cluster-mode
+ * ElastiCache deployments.
+ */
+public class ElastiCacheVectorDBProviderServiceImpl implements VectorDBProviderService {
+    private static final Log log = LogFactory.getLog(ElastiCacheVectorDBProviderServiceImpl.class);
+
+    // Matches the retry count Jedis itself defaults to for cluster-mode MOVED/ASK redirection.
+    private static final int DEFAULT_CLUSTER_MAX_ATTEMPTS = 5;
+    private static final String TAG_QUERY_SPECIAL_CHARS = ",.<>{}\"':;!@#$%^&*()-+=~[]";
+
+    // Jedis pool tuning properties under [apim.ai.vector_db_provider.properties]. Defaults match
+    // JedisPoolConfig's own out-of-the-box values so behavior is unchanged unless explicitly set.
+    private static final String JEDIS_POOL_MAX_TOTAL = "jedis.pool.max_total";
+    private static final String JEDIS_POOL_MAX_TOTAL_DEFAULT = "8";
+    private static final String JEDIS_POOL_MAX_IDLE = "jedis.pool.max_idle";
+    private static final String JEDIS_POOL_MAX_IDLE_DEFAULT = "8";
+    private static final String JEDIS_POOL_MIN_IDLE = "jedis.pool.min_idle";
+    private static final String JEDIS_POOL_MIN_IDLE_DEFAULT = "0";
+    private static final String JEDIS_POOL_TEST_ON_BORROW = "jedis.pool.test_on_borrow";
+    private static final String JEDIS_POOL_TEST_ON_BORROW_DEFAULT = "false";
+    private static final String JEDIS_POOL_TEST_ON_RETURN = "jedis.pool.test_on_return";
+    private static final String JEDIS_POOL_TEST_ON_RETURN_DEFAULT = "false";
+    private static final String JEDIS_POOL_TEST_WHILE_IDLE = "jedis.pool.test_while_idle";
+    private static final String JEDIS_POOL_TEST_WHILE_IDLE_DEFAULT = "true";
+    private static final String JEDIS_POOL_BLOCK_WHEN_EXHAUSTED = "jedis.pool.block_when_exhausted";
+    private static final String JEDIS_POOL_BLOCK_WHEN_EXHAUSTED_DEFAULT = "true";
+    private static final String JEDIS_POOL_MIN_EVICTABLE_IDLE_TIME_MILLIS =
+            "jedis.pool.min_evictable_idle_time_millis";
+    private static final String JEDIS_POOL_MIN_EVICTABLE_IDLE_TIME_MILLIS_DEFAULT = "60000";
+    private static final String JEDIS_POOL_TIME_BETWEEN_EVICTION_RUNS_MILLIS =
+            "jedis.pool.time_between_eviction_runs_millis";
+    private static final String JEDIS_POOL_TIME_BETWEEN_EVICTION_RUNS_MILLIS_DEFAULT = "30000";
+    private static final String JEDIS_POOL_NUM_TESTS_PER_EVICTION_RUN = "jedis.pool.num_tests_per_eviction_run";
+    private static final String JEDIS_POOL_NUM_TESTS_PER_EVICTION_RUN_DEFAULT = "-1";
+
+    private RedisCommandExecutor executor;
+    private String indexName;
+    private String keyPrefix;
+    private int dimension;
+    private int ttl;
+    private final Gson gson = new Gson();
+
+    /**
+     * Initialize the AWS ElastiCache Vector DB provider with configuration.
+     */
+    @Override
+    public void init(VectorDBProviderConfigurationDTO providerConfig) throws APIManagementException {
+        log.debug("Initializing AWS ElastiCache Vector DB provider");
+        Map<String, String> properties = providerConfig.getProperties();
+        String host = properties.get(APIConstants.AI.VECTOR_DB_PROVIDER_ELASTICACHE_HOST);
+        String portStr = properties.get(APIConstants.AI.VECTOR_DB_PROVIDER_ELASTICACHE_PORT);
+        String username = properties.get(APIConstants.AI.VECTOR_DB_PROVIDER_ELASTICACHE_USERNAME);
+        String password = properties.get(APIConstants.AI.VECTOR_DB_PROVIDER_ELASTICACHE_PASSWORD);
+        boolean sslEnabled = Boolean.parseBoolean(
+                properties.get(APIConstants.AI.VECTOR_DB_PROVIDER_ELASTICACHE_SSL_ENABLED));
+        boolean clusterModeEnabled = Boolean.parseBoolean(
+                properties.get(APIConstants.AI.VECTOR_DB_PROVIDER_ELASTICACHE_CLUSTER_MODE_ENABLED));
+
+        List<String> missingParams = new ArrayList<>();
+        if (host == null) {
+            missingParams.add("'host'");
+        }
+        if (portStr == null) {
+            missingParams.add("'port'");
+        }
+        if (!missingParams.isEmpty()) {
+            throw new IllegalArgumentException("Missing required ElastiCache configuration parameter(s): " +
+                    String.join(", ", missingParams));
+        }
+        int port;
+        try {
+            port = Integer.parseInt(portStr);
+        } catch (NumberFormatException nfe) {
+            throw new IllegalArgumentException("Invalid ElastiCache port: '" + portStr + "'", nfe);
+        }
+
+        String ttlStr = properties.getOrDefault(APIConstants.AI.VECTOR_DB_PROVIDER_TTL,
+                APIConstants.AI.VECTOR_DB_PROVIDER_TTL_DEFAULT);
+        try {
+            ttl = Integer.parseInt(ttlStr);
+        } catch (NumberFormatException nfe) {
+            log.warn("Invalid TTL value '" + ttlStr + "', falling back to default: " +
+                    APIConstants.AI.VECTOR_DB_PROVIDER_TTL_DEFAULT);
+            ttl = Integer.parseInt(APIConstants.AI.VECTOR_DB_PROVIDER_TTL_DEFAULT);
+        }
+
+        if (clusterModeEnabled) {
+            executor = new ClusterRedisCommandExecutor(createJedisCluster(host, port, username, password,
+                    sslEnabled, properties));
+        } else {
+            executor = new StandaloneRedisCommandExecutor(createJedisPool(host, port, username, password,
+                    sslEnabled, properties));
+        } // TODO Test Redis OSS Variant, just tested the ValKey variant
+        log.info("Initialized AWS ElastiCache Vector DB provider with endpoint: " + host + ":" + port +
+                " (clusterMode=" + clusterModeEnabled + ")");
+    }
+
+    @Override
+    public String getType() {
+        return APIConstants.AI.VECTOR_DB_PROVIDER_ELASTICACHE_TYPE;
+    }
+
+    /**
+     * Create a RediSearch vector index in ElastiCache if it does not already exist.
+     */
+    @Override
+    public void createIndex(Map<String, String> config) throws APIManagementException {
+        log.info("Creating ElastiCache vector index");
+        String dimStr = config.get(APIConstants.AI.VECTOR_DB_PROVIDER_EMBEDDING_DIMENSION);
+        if (dimStr == null) {
+            throw new APIManagementException("Missing required config: '" +
+                    APIConstants.AI.VECTOR_DB_PROVIDER_EMBEDDING_DIMENSION + "'");
+        }
+        try {
+            dimension = Integer.parseInt(dimStr);
+        } catch (NumberFormatException nfe) {
+            throw new APIManagementException("Invalid embedding dimension: '" + dimStr + "'", nfe);
+        }
+        if (dimension <= 0) {
+            throw new APIManagementException("Embedding dimension must be > 0. Received: " + dimension);
+        }
+        // dimension varies by embedding provider/model (e.g. 1024 for Mistral's mistral-embed, 1536 for
+        // OpenAI's text-embedding-3-small) and RediSearch requires a fixed DIM per index, so it's baked
+        // into the index/key-prefix name - switching providers safely gets its own index instead of
+        // colliding with one sized for a different model.
+        indexName = APIConstants.AI.VECTOR_INDEX_PREFIX + dimension +
+                APIConstants.AI.VECTOR_DB_PROVIDER_ELASTICACHE_INDEX_SUFFIX;
+        keyPrefix = APIConstants.AI.VECTOR_INDEX_PREFIX + dimension +
+                APIConstants.AI.VECTOR_DB_PROVIDER_ELASTICACHE_KEY_PREFIX_SUFFIX;
+
+        if (indexExists(indexName)) {
+            log.info("Index already exists: " + indexName);
+            return;
+        }
+
+        List<String> vectorAttributes = Arrays.asList(
+                APIConstants.AI.VECTOR_DB_PROVIDER_ELASTICACHE_TYPE_KEYWORD,
+                APIConstants.AI.VECTOR_DB_PROVIDER_ELASTICACHE_FLOAT32,
+                APIConstants.AI.VECTOR_DB_PROVIDER_ELASTICACHE_DIM, String.valueOf(dimension),
+                APIConstants.AI.VECTOR_DB_PROVIDER_ELASTICACHE_DISTANCE_METRIC,
+                APIConstants.AI.VECTOR_DB_PROVIDER_ELASTICACHE_L2,
+                APIConstants.AI.VECTOR_DB_PROVIDER_ELASTICACHE_M,
+                String.valueOf(APIConstants.AI.VECTOR_DB_PROVIDER_ELASTICACHE_HNSW_M),
+                APIConstants.AI.VECTOR_DB_PROVIDER_ELASTICACHE_EF_CONSTRUCTION,
+                String.valueOf(APIConstants.AI.VECTOR_DB_PROVIDER_ELASTICACHE_HNSW_EF_CONSTRUCTION));
+
+        List<String> args = new ArrayList<>(Arrays.asList(
+                indexName,
+                APIConstants.AI.VECTOR_DB_PROVIDER_ELASTICACHE_ON,
+                APIConstants.AI.VECTOR_DB_PROVIDER_ELASTICACHE_HASH,
+                APIConstants.AI.VECTOR_DB_PROVIDER_ELASTICACHE_PREFIX, "1", keyPrefix,
+                APIConstants.AI.VECTOR_DB_PROVIDER_ELASTICACHE_SCHEMA,
+                APIConstants.AI.VECTOR_DB_PROVIDER_API_ID,
+                APIConstants.AI.VECTOR_DB_PROVIDER_ELASTICACHE_TAG,
+                APIConstants.AI.VECTOR_DB_PROVIDER_CREATED_AT,
+                APIConstants.AI.VECTOR_DB_PROVIDER_ELASTICACHE_NUMERIC,
+                APIConstants.AI.VECTOR_DB_PROVIDER_EMBEDDING,
+                APIConstants.AI.VECTOR_DB_PROVIDER_ELASTICACHE_VECTOR,
+                APIConstants.AI.VECTOR_DB_PROVIDER_ELASTICACHE_HNSW, String.valueOf(vectorAttributes.size())));
+        args.addAll(vectorAttributes);
+
+        executor.executeSearchCommand(RediSearchCommand.FT_CREATE, args.toArray(new String[0]));
+        log.info("Successfully created index: " + indexName);
+    }
+
+    private boolean indexExists(String indexName) {
+        try {
+            executor.executeSearchCommand(RediSearchCommand.FT_INFO, indexName);
+            return true;
+        } catch (APIManagementException e) {
+            return false;
+        }
+    }
+
+    @Override
+    public <T extends Serializable> void store(double[] embeddings, T response, Map<String, String> filter)
+            throws APIManagementException {
+        if (embeddings == null || embeddings.length != dimension) {
+            throw new APIManagementException("Invalid embedding dimension. Expected: " + dimension +
+                    ", Received: " + (embeddings != null ? embeddings.length : "null"));
+        }
+        if (filter == null || !filter.containsKey(APIConstants.AI.VECTOR_DB_PROVIDER_API_ID)) {
+            throw new APIManagementException("Missing required filter: 'api_id'");
+        }
+        String apiId = filter.get(APIConstants.AI.VECTOR_DB_PROVIDER_API_ID);
+        if (log.isDebugEnabled()) {
+            log.debug("Storing embeddings in ElastiCache for API ID: " + apiId);
+        }
+
+        String id = UUID.randomUUID().toString();
+        byte[] key = SafeEncoder.encode(keyPrefix + id);
+
+        Map<byte[], byte[]> fields = new LinkedHashMap<>();
+        fields.put(SafeEncoder.encode(APIConstants.AI.VECTOR_DB_PROVIDER_ID), SafeEncoder.encode(id));
+        fields.put(SafeEncoder.encode(APIConstants.AI.VECTOR_DB_PROVIDER_API_ID), SafeEncoder.encode(apiId));
+        fields.put(SafeEncoder.encode(APIConstants.AI.VECTOR_DB_PROVIDER_CREATED_AT),
+                SafeEncoder.encode(String.valueOf(System.currentTimeMillis())));
+        fields.put(SafeEncoder.encode(APIConstants.AI.VECTOR_DB_PROVIDER_EMBEDDING), toVectorBytes(embeddings));
+        fields.put(SafeEncoder.encode(APIConstants.AI.VECTOR_DB_PROVIDER_RESPONSE),
+                SafeEncoder.encode(gson.toJson(response)));
+
+        try {
+            executor.hsetBinary(key, fields);
+            executor.expire(key, ttl);
+            log.info("Successfully stored response in ElastiCache for API ID: " + apiId);
+        } catch (APIManagementException e) {
+            String errorMsg = "Error storing embeddings in ElastiCache for API ID " + apiId + ": " + e.getMessage();
+            log.error(errorMsg, e);
+            throw new APIManagementException(errorMsg, e);
+        }
+    }
+
+    /**
+     * Retrieve the most similar response from the vector database.
+     */
+    @Override
+    public <T extends Serializable> T retrieve(double[] embeddings, Map<String, String> filter)
+            throws APIManagementException {
+        if (embeddings == null || embeddings.length != dimension) {
+            throw new APIManagementException("Invalid embedding dimension. Expected: " + dimension +
+                    ", Received: " + (embeddings != null ? embeddings.length : "null"));
+        }
+        if (filter == null || !filter.containsKey(APIConstants.AI.VECTOR_DB_PROVIDER_API_ID)
+                || !filter.containsKey(APIConstants.AI.VECTOR_DB_PROVIDER_THRESHOLD)) {
+            throw new APIManagementException("Missing required filter: 'api_id' or 'threshold'");
+        }
+        String apiId = filter.get(APIConstants.AI.VECTOR_DB_PROVIDER_API_ID);
+        double threshold = Double.parseDouble(filter.get(APIConstants.AI.VECTOR_DB_PROVIDER_THRESHOLD));
+        if (log.isDebugEnabled()) {
+            log.debug("Retrieving similar response from ElastiCache for API ID: " + apiId);
+        }
+
+        // RediSearch's KNN syntax has no built-in radius/range filter here, so the L2 distance
+        // threshold (mirroring Zilliz's "radius" semantics) is applied client-side on the score.
+        String queryExpr = "(@" + APIConstants.AI.VECTOR_DB_PROVIDER_API_ID + ":{" + escapeTagValue(apiId) +
+                "})=>[KNN 1 @" + APIConstants.AI.VECTOR_DB_PROVIDER_EMBEDDING + " $" +
+                APIConstants.AI.VECTOR_DB_PROVIDER_ELASTICACHE_VECTOR_PARAM_NAME + " AS " +
+                APIConstants.AI.VECTOR_DB_PROVIDER_ELASTICACHE_SCORE_ALIAS + "]";
+
+        // No SORTBY: it only accepts indexed schema fields, not the ad-hoc KNN "AS score" alias,
+        // and KNN results are already returned in ascending vector-distance order by default.
+        byte[][] args = {
+                SafeEncoder.encode(indexName),
+                SafeEncoder.encode(queryExpr),
+                SafeEncoder.encode(APIConstants.AI.VECTOR_DB_PROVIDER_ELASTICACHE_PARAMS),
+                SafeEncoder.encode("2"),
+                SafeEncoder.encode(APIConstants.AI.VECTOR_DB_PROVIDER_ELASTICACHE_VECTOR_PARAM_NAME),
+                toVectorBytes(embeddings),
+                SafeEncoder.encode(APIConstants.AI.VECTOR_DB_PROVIDER_ELASTICACHE_DIALECT),
+                SafeEncoder.encode("2")
+        };
+
+        try {
+            Object reply = executor.executeSearchCommand(RediSearchCommand.FT_SEARCH, args);
+            ScoredResponse best = parseTopResult((List<Object>) reply);
+            if (best == null || best.score > threshold) {
+                log.debug("No similar responses found in ElastiCache");
+                return null;
+            }
+            log.debug("Successfully retrieved similar response from ElastiCache");
+            return (T) best.response;
+        } catch (Exception e) {
+            String errorMsg = "Error retrieving response from ElastiCache (index: " + indexName +
+                    ", filter: " + filter + "): " + e.getMessage();
+            log.error(errorMsg, e);
+            throw new APIManagementException(errorMsg, e);
+        }
+    }
+
+    private static ScoredResponse parseTopResult(List<Object> reply) {
+        if (reply == null || reply.isEmpty() || reply.size() < 3) {
+            return null;
+        }
+        long total = (Long) reply.get(0);
+        if (total == 0) {
+            return null;
+        }
+        List<Object> fields = (List<Object>) reply.get(2);
+        String response = null;
+        Double score = null;
+        for (int i = 0; i < fields.size() - 1; i += 2) {
+            String fieldName = SafeEncoder.encode((byte[]) fields.get(i));
+            if (APIConstants.AI.VECTOR_DB_PROVIDER_RESPONSE.equals(fieldName)) {
+                response = SafeEncoder.encode((byte[]) fields.get(i + 1));
+            } else if (APIConstants.AI.VECTOR_DB_PROVIDER_ELASTICACHE_SCORE_ALIAS.equals(fieldName)) {
+                score = Double.parseDouble(SafeEncoder.encode((byte[]) fields.get(i + 1)));
+            }
+        }
+        return (response != null && score != null) ? new ScoredResponse(response, score) : null;
+    }
+
+    private static String escapeTagValue(String value) {
+        StringBuilder escaped = new StringBuilder();
+        for (char c : value.toCharArray()) {
+            if (TAG_QUERY_SPECIAL_CHARS.indexOf(c) >= 0) {
+                escaped.append('\\');
+            }
+            escaped.append(c);
+        }
+        return escaped.toString();
+    }
+
+    private static byte[] toVectorBytes(double[] embeddings) {
+        ByteBuffer buffer = ByteBuffer.allocate(embeddings.length * Float.BYTES).order(ByteOrder.LITTLE_ENDIAN);
+        for (double value : embeddings) {
+            buffer.putFloat((float) value);
+        }
+        return buffer.array();
+    }
+
+    private static JedisPool createJedisPool(String host, int port, String username, String password,
+            boolean sslEnabled, Map<String, String> properties) {
+        JedisPoolConfig poolConfig = buildJedisPoolConfig(properties);
+        if (StringUtils.isNotEmpty(username)) {
+            return new JedisPool(poolConfig, host, port, Protocol.DEFAULT_TIMEOUT, username, password,
+                    Protocol.DEFAULT_DATABASE, sslEnabled);
+        }
+        return new JedisPool(poolConfig, host, port, Protocol.DEFAULT_TIMEOUT, password,
+                Protocol.DEFAULT_DATABASE, sslEnabled);
+    }
+
+    private static JedisCluster createJedisCluster(String host, int port, String username, String password,
+            boolean sslEnabled, Map<String, String> properties) {
+        Set<HostAndPort> nodes = Collections.singleton(new HostAndPort(host, port));
+        JedisPoolConfig poolConfig = buildJedisPoolConfig(properties);
+        return new JedisCluster(nodes, Protocol.DEFAULT_TIMEOUT, Protocol.DEFAULT_TIMEOUT,
+                DEFAULT_CLUSTER_MAX_ATTEMPTS, username, password, null, poolConfig, sslEnabled);
+    }
+
+    /**
+     * Builds a {@link JedisPoolConfig} from the "jedis.pool.*" properties, falling back to
+     * JedisPoolConfig's own defaults for anything not explicitly set.
+     */
+    private static JedisPoolConfig buildJedisPoolConfig(Map<String, String> properties) {
+        JedisPoolConfig poolConfig = new JedisPoolConfig();
+        poolConfig.setMaxTotal(parseIntProperty(properties, JEDIS_POOL_MAX_TOTAL, JEDIS_POOL_MAX_TOTAL_DEFAULT));
+        poolConfig.setMaxIdle(parseIntProperty(properties, JEDIS_POOL_MAX_IDLE, JEDIS_POOL_MAX_IDLE_DEFAULT));
+        poolConfig.setMinIdle(parseIntProperty(properties, JEDIS_POOL_MIN_IDLE, JEDIS_POOL_MIN_IDLE_DEFAULT));
+        poolConfig.setTestOnBorrow(parseBooleanProperty(properties, JEDIS_POOL_TEST_ON_BORROW,
+                JEDIS_POOL_TEST_ON_BORROW_DEFAULT));
+        poolConfig.setTestOnReturn(parseBooleanProperty(properties, JEDIS_POOL_TEST_ON_RETURN,
+                JEDIS_POOL_TEST_ON_RETURN_DEFAULT));
+        poolConfig.setTestWhileIdle(parseBooleanProperty(properties, JEDIS_POOL_TEST_WHILE_IDLE,
+                JEDIS_POOL_TEST_WHILE_IDLE_DEFAULT));
+        poolConfig.setBlockWhenExhausted(parseBooleanProperty(properties, JEDIS_POOL_BLOCK_WHEN_EXHAUSTED,
+                JEDIS_POOL_BLOCK_WHEN_EXHAUSTED_DEFAULT));
+        poolConfig.setMinEvictableIdleTimeMillis(parseLongProperty(properties,
+                JEDIS_POOL_MIN_EVICTABLE_IDLE_TIME_MILLIS, JEDIS_POOL_MIN_EVICTABLE_IDLE_TIME_MILLIS_DEFAULT));
+        poolConfig.setTimeBetweenEvictionRunsMillis(parseLongProperty(properties,
+                JEDIS_POOL_TIME_BETWEEN_EVICTION_RUNS_MILLIS, JEDIS_POOL_TIME_BETWEEN_EVICTION_RUNS_MILLIS_DEFAULT));
+        poolConfig.setNumTestsPerEvictionRun(parseIntProperty(properties, JEDIS_POOL_NUM_TESTS_PER_EVICTION_RUN,
+                JEDIS_POOL_NUM_TESTS_PER_EVICTION_RUN_DEFAULT));
+        return poolConfig;
+    }
+
+    private static int parseIntProperty(Map<String, String> properties, String key, String defaultValue) {
+        String rawValue = properties.getOrDefault(key, defaultValue);
+        try {
+            return Integer.parseInt(rawValue);
+        } catch (NumberFormatException nfe) {
+            log.warn("Invalid value for '" + key + "': '" + rawValue + "', falling back to default: " +
+                    defaultValue);
+            return Integer.parseInt(defaultValue);
+        }
+    }
+
+    private static long parseLongProperty(Map<String, String> properties, String key, String defaultValue) {
+        String rawValue = properties.getOrDefault(key, defaultValue);
+        try {
+            return Long.parseLong(rawValue);
+        } catch (NumberFormatException nfe) {
+            log.warn("Invalid value for '" + key + "': '" + rawValue + "', falling back to default: " +
+                    defaultValue);
+            return Long.parseLong(defaultValue);
+        }
+    }
+
+    private static boolean parseBooleanProperty(Map<String, String> properties, String key, String defaultValue) {
+        String rawValue = properties.getOrDefault(key, defaultValue);
+        if (!"true".equalsIgnoreCase(rawValue) && !"false".equalsIgnoreCase(rawValue)) {
+            log.warn("Invalid value for '" + key + "': '" + rawValue + "', falling back to default: " +
+                    defaultValue);
+            return Boolean.parseBoolean(defaultValue);
+        }
+        return Boolean.parseBoolean(rawValue);
+    }
+
+    private static final class ScoredResponse {
+        private final String response;
+        private final double score;
+
+        private ScoredResponse(String response, double score) {
+            this.response = response;
+            this.score = score;
+        }
+    }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/ElastiCacheVectorDBProviderServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/ElastiCacheVectorDBProviderServiceImpl.java
@@ -266,6 +266,11 @@ public class ElastiCacheVectorDBProviderServiceImpl implements VectorDBProviderS
             executor.expire(key, ttl);
             log.info("Successfully stored response in ElastiCache for API ID: " + apiId);
         } catch (APIManagementException e) {
+            try {
+                executor.delete(key);
+            } catch (APIManagementException deleteEx) {
+                log.warn("Failed to clean up orphaned key after store failure for API ID " + apiId, deleteEx);
+            }
             String errorMsg = "Error storing embeddings in ElastiCache for API ID " + apiId + ": " + e.getMessage();
             log.error(errorMsg, e);
             throw new APIManagementException(errorMsg, e);
@@ -287,7 +292,12 @@ public class ElastiCacheVectorDBProviderServiceImpl implements VectorDBProviderS
             throw new APIManagementException("Missing required filter: 'api_id' or 'threshold'");
         }
         String apiId = filter.get(APIConstants.AI.VECTOR_DB_PROVIDER_API_ID);
-        double threshold = Double.parseDouble(filter.get(APIConstants.AI.VECTOR_DB_PROVIDER_THRESHOLD));
+        double threshold;
+        try {
+            threshold = Double.parseDouble(filter.get(APIConstants.AI.VECTOR_DB_PROVIDER_THRESHOLD));
+        } catch (NumberFormatException nfe) {
+            throw new APIManagementException("Invalid threshold value in filter", nfe);
+        }
         if (log.isDebugEnabled()) {
             log.debug("Retrieving similar response from ElastiCache for API ID: " + apiId);
         }

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/ZillizVectorDBProviderServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/ZillizVectorDBProviderServiceImpl.java
@@ -93,6 +93,12 @@ public class ZillizVectorDBProviderServiceImpl implements VectorDBProviderServic
 
     @Override public String getType() { return APIConstants.AI.VECTOR_DB_PROVIDER_ZILLIZ_TYPE; }
 
+    @Override
+    public void close() {
+        // No persistent resource to release: each request builds and discards its own HttpClient
+        // in invokeZillizAPI() rather than reusing one held by this instance.
+    }
+
     /**
      * Create a vector index in the database if it does not exist.
      */

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/internal/APIHandlerServiceComponent.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/internal/APIHandlerServiceComponent.java
@@ -290,7 +290,7 @@ public class APIHandlerServiceComponent {
                     case APIConstants.AI.VECTOR_DB_PROVIDER_ZILLIZ_TYPE:
                         vectorDBProviderService = new ZillizVectorDBProviderServiceImpl();
                         break;
-                    case APIConstants.AI.VECTOR_DB_PROVIDER_ELASTICACHE_TYPE:
+                    case ElastiCacheVectorDBProviderServiceImpl.VECTOR_DB_PROVIDER_ELASTICACHE_TYPE:
                         vectorDBProviderService = new ElastiCacheVectorDBProviderServiceImpl();
                         break;
                     default:

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/internal/APIHandlerServiceComponent.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/internal/APIHandlerServiceComponent.java
@@ -109,6 +109,7 @@ public class APIHandlerServiceComponent {
 
     private APIKeyValidatorClientPool clientPool;
     private ServiceRegistration registration;
+    private VectorDBProviderService vectorDBProviderService;
 
     @Activate
     protected void activate(ComponentContext context) {
@@ -285,7 +286,6 @@ public class APIHandlerServiceComponent {
         if (vectorDBProviderConfigurationDTO.getType() != null) {
             try {
                 String vectorDBProviderType = vectorDBProviderConfigurationDTO.getType();
-                VectorDBProviderService vectorDBProviderService;
                 switch (vectorDBProviderType) {
                     case APIConstants.AI.VECTOR_DB_PROVIDER_ZILLIZ_TYPE:
                         vectorDBProviderService = new ZillizVectorDBProviderServiceImpl();
@@ -343,6 +343,13 @@ public class APIHandlerServiceComponent {
         if (ServiceReferenceHolder.getInstance().getRedisPool() != null &&
                 !ServiceReferenceHolder.getInstance().getRedisPool().isClosed()) {
             ServiceReferenceHolder.getInstance().getRedisPool().destroy();
+        }
+        if (vectorDBProviderService != null) {
+            try {
+                vectorDBProviderService.close();
+            } catch (APIManagementException e) {
+                log.error("Error closing Vector DB provider service", e);
+            }
         }
     }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/internal/APIHandlerServiceComponent.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/internal/APIHandlerServiceComponent.java
@@ -54,6 +54,7 @@ import org.wso2.carbon.apimgt.gateway.AWSBedrockGuardrailProviderServiceImpl;
 import org.wso2.carbon.apimgt.gateway.AzureContentSafetyGuardrailProviderServiceImpl;
 import org.wso2.carbon.apimgt.gateway.AzureOpenAIEmbeddingProviderServiceImpl;
 import org.wso2.carbon.apimgt.gateway.AzureOpenAILLMProviderServiceImpl;
+import org.wso2.carbon.apimgt.gateway.ElastiCacheVectorDBProviderServiceImpl;
 import org.wso2.carbon.apimgt.gateway.HybridThrottleProcessor;
 import org.wso2.carbon.apimgt.gateway.MistralEmbeddingProviderServiceImpl;
 import org.wso2.carbon.apimgt.gateway.MistralLLMProviderServiceImpl;
@@ -288,6 +289,9 @@ public class APIHandlerServiceComponent {
                 switch (vectorDBProviderType) {
                     case APIConstants.AI.VECTOR_DB_PROVIDER_ZILLIZ_TYPE:
                         vectorDBProviderService = new ZillizVectorDBProviderServiceImpl();
+                        break;
+                    case APIConstants.AI.VECTOR_DB_PROVIDER_ELASTICACHE_TYPE:
+                        vectorDBProviderService = new ElastiCacheVectorDBProviderServiceImpl();
                         break;
                     default:
                         throw new APIManagementException("Unsupported vector DB provider type: "

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/utils/redis/ClusterRedisCommandExecutor.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/utils/redis/ClusterRedisCommandExecutor.java
@@ -25,20 +25,35 @@ import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisCluster;
 import redis.clients.jedis.JedisPool;
 import redis.clients.jedis.commands.ProtocolCommand;
+import redis.clients.jedis.util.SafeEncoder;
 
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
 
 /**
  * Executes Redis commands against a cluster-mode-enabled ElastiCache deployment. FT.CREATE/FT.SEARCH
  * are sent once to a single reachable node: an index name with no hash tag (ours has none) is treated
  * by the valkey-search module as a cluster-wide index, so it replicates FT.CREATE to every shard and
  * merges FT.SEARCH results across shards on its own — no client-side fan-out needed.
+ *
+ * FT.CREATE is a write, so it (and FT.INFO/FT.SEARCH, which we route the same way since valkey-search's
+ * cross-shard behavior on a replica isn't documented/verified) must land on a primary — jedisCluster's own
+ * getClusterNodes() doesn't distinguish primaries from replicas, so we ask the cluster directly via
+ * CLUSTER SLOTS and cache the result until a command actually fails. CLUSTER SLOTS is used over CLUSTER
+ * NODES because the master is always the first node entry per slot range - a protocol guarantee - so
+ * there's no flag text (e.g. "master,fail" for a node that's down but not yet evicted) to misparse.
  */
-public class ClusterRedisCommandExecutor implements RedisCommandExecutor { // TODO Test the Cluster mode
+public class ClusterRedisCommandExecutor implements RedisCommandExecutor {
 
     private static final Log log = LogFactory.getLog(ClusterRedisCommandExecutor.class);
 
     private final JedisCluster jedisCluster;
+    private volatile List<Map.Entry<String, JedisPool>> cachedPrimaryNodes;
 
     public ClusterRedisCommandExecutor(JedisCluster jedisCluster) {
         this.jedisCluster = jedisCluster;
@@ -46,22 +61,12 @@ public class ClusterRedisCommandExecutor implements RedisCommandExecutor { // TO
 
     @Override
     public Object executeSearchCommand(ProtocolCommand command, String... args) throws APIManagementException {
-        Map.Entry<String, JedisPool> node = getFirstNode();
-        try (Jedis jedis = node.getValue().getResource()) {
-            return jedis.sendCommand(command, args);
-        } catch (Exception e) {
-            throw new APIManagementException("Error executing Redis command: " + command, e);
-        }
+        return executeOnPrimary(command, jedis -> jedis.sendCommand(command, args));
     }
 
     @Override
     public Object executeSearchCommand(ProtocolCommand command, byte[]... args) throws APIManagementException {
-        Map.Entry<String, JedisPool> node = getFirstNode();
-        try (Jedis jedis = node.getValue().getResource()) {
-            return jedis.sendCommand(command, args);
-        } catch (Exception e) {
-            throw new APIManagementException("Error executing Redis command: " + command, e);
-        }
+        return executeOnPrimary(command, jedis -> jedis.sendCommand(command, args));
     }
 
     @Override
@@ -83,6 +88,15 @@ public class ClusterRedisCommandExecutor implements RedisCommandExecutor { // TO
     }
 
     @Override
+    public void delete(byte[] key) throws APIManagementException {
+        try {
+            jedisCluster.del(key);
+        } catch (Exception e) {
+            throw new APIManagementException("Error executing DEL", e);
+        }
+    }
+
+    @Override
     public void close() {
         try {
             jedisCluster.close();
@@ -91,8 +105,84 @@ public class ClusterRedisCommandExecutor implements RedisCommandExecutor { // TO
         }
     }
 
-    private Map.Entry<String, JedisPool> getFirstNode() throws APIManagementException {
-        return jedisCluster.getClusterNodes().entrySet().stream().findFirst()
-                .orElseThrow(() -> new APIManagementException("No reachable ElastiCache cluster nodes"));
+    /**
+     * Runs {@code action} against a known primary, falling back to the next known primary if the
+     * chosen one rejects the command (e.g. READONLY, a MOVED/ASK redirect, or a connection failure).
+     * If every cached primary fails, the primary list is refreshed once (in case a failover changed
+     * it) and retried before giving up.
+     */
+    private Object executeOnPrimary(ProtocolCommand command, Function<Jedis, Object> action)
+            throws APIManagementException {
+        Exception lastError = null;
+        for (boolean refreshed : new boolean[] {false, true}) {
+            for (Map.Entry<String, JedisPool> primary : getPrimaryNodes(refreshed)) {
+                try (Jedis jedis = primary.getValue().getResource()) {
+                    return action.apply(jedis);
+                } catch (Exception e) {
+                    lastError = e;
+                    log.warn("Redis command " + command + " failed on primary " + primary.getKey(), e);
+                }
+            }
+        }
+        throw new APIManagementException("Error executing Redis command: " + command +
+                " - no writable ElastiCache primary node reachable", lastError);
+    }
+
+    /**
+     * Returns the cluster's current primary nodes, asking any one reachable node for CLUSTER SLOTS
+     * (cluster topology is gossiped, so any node can answer) and caching the result. Pass
+     * forceRefresh=true to bypass the cache, e.g. after a primary has just failed a command.
+     */
+    private List<Map.Entry<String, JedisPool>> getPrimaryNodes(boolean forceRefresh) throws APIManagementException {
+        List<Map.Entry<String, JedisPool>> primaries = cachedPrimaryNodes;
+        if (!forceRefresh && primaries != null && !primaries.isEmpty()) {
+            return primaries;
+        }
+        Map<String, JedisPool> allNodes = jedisCluster.getClusterNodes();
+        if (allNodes.isEmpty()) {
+            throw new APIManagementException("No reachable ElastiCache cluster nodes");
+        }
+        Exception lastError = null;
+        for (Map.Entry<String, JedisPool> node : allNodes.entrySet()) {
+            try (Jedis jedis = node.getValue().getResource()) {
+                primaries = parsePrimaries(jedis.clusterSlots(), allNodes);
+                if (!primaries.isEmpty()) {
+                    cachedPrimaryNodes = primaries;
+                    return primaries;
+                }
+            } catch (Exception e) {
+                lastError = e;
+            }
+        }
+        throw new APIManagementException("No primary ElastiCache cluster nodes found", lastError);
+    }
+
+    /**
+     * Parses a CLUSTER SLOTS reply: one entry per slot range, shaped [startSlot, endSlot, master,
+     * replica...], where master/replica are themselves [ip, port, nodeId, ...]. The master is always
+     * index 2 - a protocol guarantee, not something we infer from node state text - so a node that's
+     * failed and been replaced simply doesn't appear here (it owns no slots), with no flag to check.
+     */
+    private static List<Map.Entry<String, JedisPool>> parsePrimaries(List<Object> clusterSlotsReply,
+            Map<String, JedisPool> allNodes) {
+        Set<String> masterAddresses = new LinkedHashSet<>();
+        for (Object slotRangeObj : clusterSlotsReply) {
+            List<Object> slotRange = (List<Object>) slotRangeObj;
+            if (slotRange.size() < 3) {
+                continue;
+            }
+            List<Object> master = (List<Object>) slotRange.get(2);
+            String ip = SafeEncoder.encode((byte[]) master.get(0));
+            long port = (Long) master.get(1);
+            masterAddresses.add(ip + ":" + port);
+        }
+        List<Map.Entry<String, JedisPool>> primaries = new ArrayList<>();
+        for (String address : masterAddresses) {
+            JedisPool pool = allNodes.get(address);
+            if (pool != null) {
+                primaries.add(new AbstractMap.SimpleEntry<>(address, pool));
+            }
+        }
+        return primaries;
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/utils/redis/ClusterRedisCommandExecutor.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/utils/redis/ClusterRedisCommandExecutor.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2026 WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.apimgt.gateway.utils.redis;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.apimgt.api.APIManagementException;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.JedisCluster;
+import redis.clients.jedis.JedisPool;
+import redis.clients.jedis.commands.ProtocolCommand;
+
+import java.util.Map;
+
+/**
+ * Executes Redis commands against a cluster-mode-enabled ElastiCache deployment. FT.CREATE/FT.SEARCH
+ * are sent once to a single reachable node: an index name with no hash tag (ours has none) is treated
+ * by the valkey-search module as a cluster-wide index, so it replicates FT.CREATE to every shard and
+ * merges FT.SEARCH results across shards on its own — no client-side fan-out needed.
+ */
+public class ClusterRedisCommandExecutor implements RedisCommandExecutor { // TODO Test the Cluster mode
+
+    private static final Log log = LogFactory.getLog(ClusterRedisCommandExecutor.class);
+
+    private final JedisCluster jedisCluster;
+
+    public ClusterRedisCommandExecutor(JedisCluster jedisCluster) {
+        this.jedisCluster = jedisCluster;
+    }
+
+    @Override
+    public Object executeSearchCommand(ProtocolCommand command, String... args) throws APIManagementException {
+        Map.Entry<String, JedisPool> node = getFirstNode();
+        try (Jedis jedis = node.getValue().getResource()) {
+            return jedis.sendCommand(command, args);
+        } catch (Exception e) {
+            throw new APIManagementException("Error executing Redis command: " + command, e);
+        }
+    }
+
+    @Override
+    public Object executeSearchCommand(ProtocolCommand command, byte[]... args) throws APIManagementException {
+        Map.Entry<String, JedisPool> node = getFirstNode();
+        try (Jedis jedis = node.getValue().getResource()) {
+            return jedis.sendCommand(command, args);
+        } catch (Exception e) {
+            throw new APIManagementException("Error executing Redis command: " + command, e);
+        }
+    }
+
+    @Override
+    public void hsetBinary(byte[] key, Map<byte[], byte[]> fields) throws APIManagementException {
+        try {
+            jedisCluster.hset(key, fields);
+        } catch (Exception e) {
+            throw new APIManagementException("Error executing HSET", e);
+        }
+    }
+
+    @Override
+    public void expire(byte[] key, int seconds) throws APIManagementException {
+        try {
+            jedisCluster.expire(key, seconds);
+        } catch (Exception e) {
+            throw new APIManagementException("Error executing EXPIRE", e);
+        }
+    }
+
+    @Override
+    public void close() {
+        try {
+            jedisCluster.close();
+        } catch (Exception e) {
+            log.warn("Error closing JedisCluster", e);
+        }
+    }
+
+    private Map.Entry<String, JedisPool> getFirstNode() throws APIManagementException {
+        return jedisCluster.getClusterNodes().entrySet().stream().findFirst()
+                .orElseThrow(() -> new APIManagementException("No reachable ElastiCache cluster nodes"));
+    }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/utils/redis/RediSearchCommand.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/utils/redis/RediSearchCommand.java
@@ -18,7 +18,6 @@
 
 package org.wso2.carbon.apimgt.gateway.utils.redis;
 
-import org.wso2.carbon.apimgt.impl.APIConstants;
 import redis.clients.jedis.commands.ProtocolCommand;
 import redis.clients.jedis.util.SafeEncoder;
 
@@ -28,9 +27,9 @@ import redis.clients.jedis.util.SafeEncoder;
  */
 public enum RediSearchCommand implements ProtocolCommand {
 
-    FT_CREATE(APIConstants.AI.VECTOR_DB_PROVIDER_ELASTICACHE_FT_CREATE),
-    FT_SEARCH(APIConstants.AI.VECTOR_DB_PROVIDER_ELASTICACHE_FT_SEARCH),
-    FT_INFO(APIConstants.AI.VECTOR_DB_PROVIDER_ELASTICACHE_FT_INFO);
+    FT_CREATE("FT.CREATE"),
+    FT_SEARCH("FT.SEARCH"),
+    FT_INFO("FT.INFO");
 
     private final byte[] raw;
 

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/utils/redis/RediSearchCommand.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/utils/redis/RediSearchCommand.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2026 WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.apimgt.gateway.utils.redis;
+
+import org.wso2.carbon.apimgt.impl.APIConstants;
+import redis.clients.jedis.commands.ProtocolCommand;
+import redis.clients.jedis.util.SafeEncoder;
+
+/**
+ * RediSearch (vector search) commands not present in Jedis 3.3's typed API.
+ * Sent via {@code Jedis#sendCommand}/{@code JedisCluster#sendCommand}.
+ */
+public enum RediSearchCommand implements ProtocolCommand {
+
+    FT_CREATE(APIConstants.AI.VECTOR_DB_PROVIDER_ELASTICACHE_FT_CREATE),
+    FT_SEARCH(APIConstants.AI.VECTOR_DB_PROVIDER_ELASTICACHE_FT_SEARCH),
+    FT_INFO(APIConstants.AI.VECTOR_DB_PROVIDER_ELASTICACHE_FT_INFO);
+
+    private final byte[] raw;
+
+    RediSearchCommand(String command) {
+        this.raw = SafeEncoder.encode(command);
+    }
+
+    @Override
+    public byte[] getRaw() {
+        return raw;
+    }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/utils/redis/RedisCommandExecutor.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/utils/redis/RedisCommandExecutor.java
@@ -75,6 +75,15 @@ public interface RedisCommandExecutor {
     void expire(byte[] key, int seconds) throws APIManagementException;
 
     /**
+     * Deletes a key, used as best-effort cleanup when a preceding operation on the same key
+     * (e.g. EXPIRE) fails after the key was already written.
+     *
+     * @param key the key to delete
+     * @throws APIManagementException if the DEL could not be executed
+     */
+    void delete(byte[] key) throws APIManagementException;
+
+    /**
      * Releases the underlying Redis connection(s)/pool held by this executor.
      */
     void close();

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/utils/redis/RedisCommandExecutor.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/utils/redis/RedisCommandExecutor.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2026 WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.apimgt.gateway.utils.redis;
+
+import org.wso2.carbon.apimgt.api.APIManagementException;
+import redis.clients.jedis.commands.ProtocolCommand;
+
+import java.util.Map;
+
+/**
+ * Abstracts standalone vs cluster-mode Redis connectivity for the ElastiCache vector DB provider,
+ * so the provider implementation doesn't branch on deployment mode. RediSearch (FT.*) commands are
+ * sent via the raw {@code sendCommand} methods since Jedis 3.3 has no typed API for them; HSET/EXPIRE
+ * use the native typed Jedis/JedisCluster APIs.
+ *
+ * <p>FT.CREATE and FT.SEARCH are index-wide operations rather than slot-bound keys, but a single
+ * call to either is sufficient even in cluster mode: the underlying valkey-search module treats an
+ * index name with no hash tag (ours has none) as a cluster-wide index, replicating FT.CREATE to every
+ * shard and transparently merging FT.SEARCH results across shards server-side.</p>
+ */
+public interface RedisCommandExecutor {
+
+    /**
+     * Sends a RediSearch (FT.*) command with string arguments, e.g. FT.CREATE, FT.INFO.
+     *
+     * @param command the RediSearch command to execute
+     * @param args    string-encoded command arguments
+     * @return the raw reply from Redis/valkey-search
+     * @throws APIManagementException if the command could not be executed
+     */
+    Object executeSearchCommand(ProtocolCommand command, String... args) throws APIManagementException;
+
+    /**
+     * Sends a RediSearch (FT.*) command with binary arguments, e.g. FT.SEARCH with a raw vector payload.
+     *
+     * @param command the RediSearch command to execute
+     * @param args    binary-encoded command arguments
+     * @return the raw reply from Redis/valkey-search
+     * @throws APIManagementException if the command could not be executed
+     */
+    Object executeSearchCommand(ProtocolCommand command, byte[]... args) throws APIManagementException;
+
+    /**
+     * Writes a hash's fields using binary keys/values, used to store an embedding and its response.
+     *
+     * @param key    the hash key
+     * @param fields field name/value pairs to set on the hash
+     * @throws APIManagementException if the HSET could not be executed
+     */
+    void hsetBinary(byte[] key, Map<byte[], byte[]> fields) throws APIManagementException;
+
+    /**
+     * Sets a TTL on a key so cached entries are automatically evicted.
+     *
+     * @param key     the key to expire
+     * @param seconds time-to-live in seconds
+     * @throws APIManagementException if the EXPIRE could not be executed
+     */
+    void expire(byte[] key, int seconds) throws APIManagementException;
+
+    /**
+     * Releases the underlying Redis connection(s)/pool held by this executor.
+     */
+    void close();
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/utils/redis/StandaloneRedisCommandExecutor.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/utils/redis/StandaloneRedisCommandExecutor.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2026 WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.apimgt.gateway.utils.redis;
+
+import org.wso2.carbon.apimgt.api.APIManagementException;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.JedisPool;
+import redis.clients.jedis.commands.ProtocolCommand;
+
+import java.util.Map;
+
+/**
+ * Executes Redis commands against a single-endpoint (non cluster-mode) ElastiCache deployment.
+ */
+public class StandaloneRedisCommandExecutor implements RedisCommandExecutor {
+
+    private final JedisPool jedisPool;
+
+    public StandaloneRedisCommandExecutor(JedisPool jedisPool) {
+        this.jedisPool = jedisPool;
+    }
+
+    @Override
+    public Object executeSearchCommand(ProtocolCommand command, String... args) throws APIManagementException {
+        try (Jedis jedis = jedisPool.getResource()) {
+            return jedis.sendCommand(command, args);
+        } catch (Exception e) {
+            throw new APIManagementException("Error executing Redis command: " + command, e);
+        }
+    }
+
+    @Override
+    public Object executeSearchCommand(ProtocolCommand command, byte[]... args) throws APIManagementException {
+        try (Jedis jedis = jedisPool.getResource()) {
+            return jedis.sendCommand(command, args);
+        } catch (Exception e) {
+            throw new APIManagementException("Error executing Redis command: " + command, e);
+        }
+    }
+
+    @Override
+    public void hsetBinary(byte[] key, Map<byte[], byte[]> fields) throws APIManagementException {
+        try (Jedis jedis = jedisPool.getResource()) {
+            jedis.hset(key, fields);
+        } catch (Exception e) {
+            throw new APIManagementException("Error executing HSET", e);
+        }
+    }
+
+    @Override
+    public void expire(byte[] key, int seconds) throws APIManagementException {
+        try (Jedis jedis = jedisPool.getResource()) {
+            jedis.expire(key, seconds);
+        } catch (Exception e) {
+            throw new APIManagementException("Error executing EXPIRE", e);
+        }
+    }
+
+    @Override
+    public void close() {
+        jedisPool.close();
+    }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/utils/redis/StandaloneRedisCommandExecutor.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/utils/redis/StandaloneRedisCommandExecutor.java
@@ -73,6 +73,15 @@ public class StandaloneRedisCommandExecutor implements RedisCommandExecutor {
     }
 
     @Override
+    public void delete(byte[] key) throws APIManagementException {
+        try (Jedis jedis = jedisPool.getResource()) {
+            jedis.del(key);
+        } catch (Exception e) {
+            throw new APIManagementException("Error executing DEL", e);
+        }
+    }
+
+    @Override
     public void close() {
         jedisPool.close();
     }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -726,44 +726,6 @@ public final class APIConstants {
         public static final String VECTOR_DB_PROVIDER_ZILLIZ_INSERT_ENDPOINT = "/v2/vectordb/entities/insert";
         public static final String VECTOR_DB_PROVIDER_ZILLIZ_SEARCH_ENDPOINT = "/v2/vectordb/entities/search";
 
-        public static final String VECTOR_DB_PROVIDER_ELASTICACHE_TYPE = "elasticache";
-        public static final String VECTOR_DB_PROVIDER_ELASTICACHE_HOST = "host";
-        public static final String VECTOR_DB_PROVIDER_ELASTICACHE_PORT = "port";
-        public static final String VECTOR_DB_PROVIDER_ELASTICACHE_USERNAME = "username";
-        public static final String VECTOR_DB_PROVIDER_ELASTICACHE_PASSWORD = "password";
-        public static final String VECTOR_DB_PROVIDER_ELASTICACHE_SSL_ENABLED = "ssl_enabled";
-        public static final String VECTOR_DB_PROVIDER_ELASTICACHE_CLUSTER_MODE_ENABLED = "cluster_mode_enabled";
-        public static final String VECTOR_DB_PROVIDER_ELASTICACHE_INDEX_SUFFIX = "_idx";
-        public static final String VECTOR_DB_PROVIDER_ELASTICACHE_KEY_PREFIX_SUFFIX = ":";
-        public static final int VECTOR_DB_PROVIDER_ELASTICACHE_HNSW_M = 64;
-        public static final int VECTOR_DB_PROVIDER_ELASTICACHE_HNSW_EF_CONSTRUCTION = 100;
-
-        // RediSearch (FT.*) command names
-        public static final String VECTOR_DB_PROVIDER_ELASTICACHE_FT_CREATE = "FT.CREATE";
-        public static final String VECTOR_DB_PROVIDER_ELASTICACHE_FT_SEARCH = "FT.SEARCH";
-        public static final String VECTOR_DB_PROVIDER_ELASTICACHE_FT_INFO = "FT.INFO";
-
-        // RediSearch schema/query keywords
-        public static final String VECTOR_DB_PROVIDER_ELASTICACHE_ON = "ON";
-        public static final String VECTOR_DB_PROVIDER_ELASTICACHE_HASH = "HASH";
-        public static final String VECTOR_DB_PROVIDER_ELASTICACHE_PREFIX = "PREFIX";
-        public static final String VECTOR_DB_PROVIDER_ELASTICACHE_SCHEMA = "SCHEMA";
-        public static final String VECTOR_DB_PROVIDER_ELASTICACHE_TAG = "TAG";
-        public static final String VECTOR_DB_PROVIDER_ELASTICACHE_NUMERIC = "NUMERIC";
-        public static final String VECTOR_DB_PROVIDER_ELASTICACHE_VECTOR = "VECTOR";
-        public static final String VECTOR_DB_PROVIDER_ELASTICACHE_HNSW = "HNSW";
-        public static final String VECTOR_DB_PROVIDER_ELASTICACHE_TYPE_KEYWORD = "TYPE";
-        public static final String VECTOR_DB_PROVIDER_ELASTICACHE_FLOAT32 = "FLOAT32";
-        public static final String VECTOR_DB_PROVIDER_ELASTICACHE_DIM = "DIM";
-        public static final String VECTOR_DB_PROVIDER_ELASTICACHE_DISTANCE_METRIC = "DISTANCE_METRIC";
-        public static final String VECTOR_DB_PROVIDER_ELASTICACHE_L2 = "L2";
-        public static final String VECTOR_DB_PROVIDER_ELASTICACHE_M = "M";
-        public static final String VECTOR_DB_PROVIDER_ELASTICACHE_EF_CONSTRUCTION = "EF_CONSTRUCTION";
-        public static final String VECTOR_DB_PROVIDER_ELASTICACHE_PARAMS = "PARAMS";
-        public static final String VECTOR_DB_PROVIDER_ELASTICACHE_DIALECT = "DIALECT";
-        public static final String VECTOR_DB_PROVIDER_ELASTICACHE_SCORE_ALIAS = "score";
-        public static final String VECTOR_DB_PROVIDER_ELASTICACHE_VECTOR_PARAM_NAME = "vec";
-
         public static final String GUARDRAIL_PROVIDERS = "GuardrailProviders";
         public static final String GUARDRAIL_PROVIDER = "GuardrailProvider";
         public static final String GUARDRAIL_PROVIDER_TYPE = "type";

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -714,6 +714,44 @@ public final class APIConstants {
         public static final String VECTOR_DB_PROVIDER_ZILLIZ_INSERT_ENDPOINT = "/v2/vectordb/entities/insert";
         public static final String VECTOR_DB_PROVIDER_ZILLIZ_SEARCH_ENDPOINT = "/v2/vectordb/entities/search";
 
+        public static final String VECTOR_DB_PROVIDER_ELASTICACHE_TYPE = "elasticache";
+        public static final String VECTOR_DB_PROVIDER_ELASTICACHE_HOST = "host";
+        public static final String VECTOR_DB_PROVIDER_ELASTICACHE_PORT = "port";
+        public static final String VECTOR_DB_PROVIDER_ELASTICACHE_USERNAME = "username";
+        public static final String VECTOR_DB_PROVIDER_ELASTICACHE_PASSWORD = "password";
+        public static final String VECTOR_DB_PROVIDER_ELASTICACHE_SSL_ENABLED = "ssl_enabled";
+        public static final String VECTOR_DB_PROVIDER_ELASTICACHE_CLUSTER_MODE_ENABLED = "cluster_mode_enabled";
+        public static final String VECTOR_DB_PROVIDER_ELASTICACHE_INDEX_SUFFIX = "_idx";
+        public static final String VECTOR_DB_PROVIDER_ELASTICACHE_KEY_PREFIX_SUFFIX = ":";
+        public static final int VECTOR_DB_PROVIDER_ELASTICACHE_HNSW_M = 64;
+        public static final int VECTOR_DB_PROVIDER_ELASTICACHE_HNSW_EF_CONSTRUCTION = 100;
+
+        // RediSearch (FT.*) command names
+        public static final String VECTOR_DB_PROVIDER_ELASTICACHE_FT_CREATE = "FT.CREATE";
+        public static final String VECTOR_DB_PROVIDER_ELASTICACHE_FT_SEARCH = "FT.SEARCH";
+        public static final String VECTOR_DB_PROVIDER_ELASTICACHE_FT_INFO = "FT.INFO";
+
+        // RediSearch schema/query keywords
+        public static final String VECTOR_DB_PROVIDER_ELASTICACHE_ON = "ON";
+        public static final String VECTOR_DB_PROVIDER_ELASTICACHE_HASH = "HASH";
+        public static final String VECTOR_DB_PROVIDER_ELASTICACHE_PREFIX = "PREFIX";
+        public static final String VECTOR_DB_PROVIDER_ELASTICACHE_SCHEMA = "SCHEMA";
+        public static final String VECTOR_DB_PROVIDER_ELASTICACHE_TAG = "TAG";
+        public static final String VECTOR_DB_PROVIDER_ELASTICACHE_NUMERIC = "NUMERIC";
+        public static final String VECTOR_DB_PROVIDER_ELASTICACHE_VECTOR = "VECTOR";
+        public static final String VECTOR_DB_PROVIDER_ELASTICACHE_HNSW = "HNSW";
+        public static final String VECTOR_DB_PROVIDER_ELASTICACHE_TYPE_KEYWORD = "TYPE";
+        public static final String VECTOR_DB_PROVIDER_ELASTICACHE_FLOAT32 = "FLOAT32";
+        public static final String VECTOR_DB_PROVIDER_ELASTICACHE_DIM = "DIM";
+        public static final String VECTOR_DB_PROVIDER_ELASTICACHE_DISTANCE_METRIC = "DISTANCE_METRIC";
+        public static final String VECTOR_DB_PROVIDER_ELASTICACHE_L2 = "L2";
+        public static final String VECTOR_DB_PROVIDER_ELASTICACHE_M = "M";
+        public static final String VECTOR_DB_PROVIDER_ELASTICACHE_EF_CONSTRUCTION = "EF_CONSTRUCTION";
+        public static final String VECTOR_DB_PROVIDER_ELASTICACHE_PARAMS = "PARAMS";
+        public static final String VECTOR_DB_PROVIDER_ELASTICACHE_DIALECT = "DIALECT";
+        public static final String VECTOR_DB_PROVIDER_ELASTICACHE_SCORE_ALIAS = "score";
+        public static final String VECTOR_DB_PROVIDER_ELASTICACHE_VECTOR_PARAM_NAME = "vec";
+
         public static final String GUARDRAIL_PROVIDERS = "GuardrailProviders";
         public static final String GUARDRAIL_PROVIDER = "GuardrailProvider";
         public static final String GUARDRAIL_PROVIDER_TYPE = "type";

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -726,6 +726,44 @@ public final class APIConstants {
         public static final String VECTOR_DB_PROVIDER_ZILLIZ_INSERT_ENDPOINT = "/v2/vectordb/entities/insert";
         public static final String VECTOR_DB_PROVIDER_ZILLIZ_SEARCH_ENDPOINT = "/v2/vectordb/entities/search";
 
+        public static final String VECTOR_DB_PROVIDER_ELASTICACHE_TYPE = "elasticache";
+        public static final String VECTOR_DB_PROVIDER_ELASTICACHE_HOST = "host";
+        public static final String VECTOR_DB_PROVIDER_ELASTICACHE_PORT = "port";
+        public static final String VECTOR_DB_PROVIDER_ELASTICACHE_USERNAME = "username";
+        public static final String VECTOR_DB_PROVIDER_ELASTICACHE_PASSWORD = "password";
+        public static final String VECTOR_DB_PROVIDER_ELASTICACHE_SSL_ENABLED = "ssl_enabled";
+        public static final String VECTOR_DB_PROVIDER_ELASTICACHE_CLUSTER_MODE_ENABLED = "cluster_mode_enabled";
+        public static final String VECTOR_DB_PROVIDER_ELASTICACHE_INDEX_SUFFIX = "_idx";
+        public static final String VECTOR_DB_PROVIDER_ELASTICACHE_KEY_PREFIX_SUFFIX = ":";
+        public static final int VECTOR_DB_PROVIDER_ELASTICACHE_HNSW_M = 64;
+        public static final int VECTOR_DB_PROVIDER_ELASTICACHE_HNSW_EF_CONSTRUCTION = 100;
+
+        // RediSearch (FT.*) command names
+        public static final String VECTOR_DB_PROVIDER_ELASTICACHE_FT_CREATE = "FT.CREATE";
+        public static final String VECTOR_DB_PROVIDER_ELASTICACHE_FT_SEARCH = "FT.SEARCH";
+        public static final String VECTOR_DB_PROVIDER_ELASTICACHE_FT_INFO = "FT.INFO";
+
+        // RediSearch schema/query keywords
+        public static final String VECTOR_DB_PROVIDER_ELASTICACHE_ON = "ON";
+        public static final String VECTOR_DB_PROVIDER_ELASTICACHE_HASH = "HASH";
+        public static final String VECTOR_DB_PROVIDER_ELASTICACHE_PREFIX = "PREFIX";
+        public static final String VECTOR_DB_PROVIDER_ELASTICACHE_SCHEMA = "SCHEMA";
+        public static final String VECTOR_DB_PROVIDER_ELASTICACHE_TAG = "TAG";
+        public static final String VECTOR_DB_PROVIDER_ELASTICACHE_NUMERIC = "NUMERIC";
+        public static final String VECTOR_DB_PROVIDER_ELASTICACHE_VECTOR = "VECTOR";
+        public static final String VECTOR_DB_PROVIDER_ELASTICACHE_HNSW = "HNSW";
+        public static final String VECTOR_DB_PROVIDER_ELASTICACHE_TYPE_KEYWORD = "TYPE";
+        public static final String VECTOR_DB_PROVIDER_ELASTICACHE_FLOAT32 = "FLOAT32";
+        public static final String VECTOR_DB_PROVIDER_ELASTICACHE_DIM = "DIM";
+        public static final String VECTOR_DB_PROVIDER_ELASTICACHE_DISTANCE_METRIC = "DISTANCE_METRIC";
+        public static final String VECTOR_DB_PROVIDER_ELASTICACHE_L2 = "L2";
+        public static final String VECTOR_DB_PROVIDER_ELASTICACHE_M = "M";
+        public static final String VECTOR_DB_PROVIDER_ELASTICACHE_EF_CONSTRUCTION = "EF_CONSTRUCTION";
+        public static final String VECTOR_DB_PROVIDER_ELASTICACHE_PARAMS = "PARAMS";
+        public static final String VECTOR_DB_PROVIDER_ELASTICACHE_DIALECT = "DIALECT";
+        public static final String VECTOR_DB_PROVIDER_ELASTICACHE_SCORE_ALIAS = "score";
+        public static final String VECTOR_DB_PROVIDER_ELASTICACHE_VECTOR_PARAM_NAME = "vec";
+
         public static final String GUARDRAIL_PROVIDERS = "GuardrailProviders";
         public static final String GUARDRAIL_PROVIDER = "GuardrailProvider";
         public static final String GUARDRAIL_PROVIDER_TYPE = "type";


### PR DESCRIPTION
### Purpose
$subject. Adds `ElastiCacheVectorDBProviderServiceImpl`, a second implementation of `VectorDBProviderService` (alongside the existing `ZillizVectorDBProviderServiceImpl`), backed by AWS ElastiCache for Valkey's vector search capability (the RediSearch-compatible `FT.CREATE`/`FT.SEARCH` command set). This lets semantic caching use ElastiCache as the vector store. Fixes https://github.com/wso2/api-manager/issues/5158

#### Config
```
[apim.ai.vector_db_provider]
type = "elasticache"
[apim.ai.vector_db_provider.properties]
host = "127.0.0.1"
port = "16379"
ssl_enabled = "false"
cluster_mode_enabled = "false"
ttl = "120"
"jedis.pool.max_total" = 15
"jedis.pool.max_idle" = 5
"jedis.pool.min_idle" = 2
"jedis.pool.test_on_borrow" = true
"jedis.pool.test_on_return" = true
"jedis.pool.test_while_idle" = false
"jedis.pool.block_when_exhausted" = false
"jedis.pool.min_evictable_idle_time_millis" = 45000
"jedis.pool.time_between_eviction_runs_millis" = 20000
"jedis.pool.num_tests_per_eviction_run" = 5
```

### What's included

**`ElastiCacheVectorDBProviderServiceImpl`** (new)
- `init()` — reads `host`/`port`/`username`/`password`/`ssl_enabled`/`cluster_mode_enabled`/`ttl` plus a full set of configurable Jedis connection-pool tuning properties (`jedis.pool.max_total`, `max_idle`, `min_idle`, `test_on_borrow`, etc., each falling back to `JedisPoolConfig`'s own defaults) from the provider config, and builds either a `JedisPool` (standalone) or `JedisCluster` (cluster mode).
- `createIndex()` — names the index/key-prefix by embedding dimension (dimension varies by embedding provider/model, and RediSearch requires a fixed `DIM` per index, so switching models gets its own index rather than colliding with one sized for another), and issues `FT.CREATE` with an HNSW/L2 vector field (`M=64`, `EF_CONSTRUCTION=100`, matching the existing Zilliz index parameters), a `TAG` field for `api_id`, and a `NUMERIC` field for `created_at`. Checks for an existing index via `FT.INFO` first.
- `store()` — writes each entry as a Redis HASH via `HSET` (`id`, `api_id`, `created_at`, packed little-endian FLOAT32 `embedding` bytes, JSON `response` via Gson), then sets a native per-key `EXPIRE` for TTL. If `EXPIRE` fails after the `HSET` already succeeded, best-effort deletes the orphaned key rather than leaving an un-expiring entry behind.
- `retrieve()` — runs `FT.SEARCH` with a `TAG`-scoped KNN query (top-1 by `api_id`), then applies the `threshold` filter client-side against the returned distance score, since RediSearch's KNN syntax has no server-side radius/range filter the way Zilliz's `radius` search param does.
- `close()` — releases the underlying `JedisPool`/`JedisCluster`.

**`RedisCommandExecutor` abstraction** (new: interface + `StandaloneRedisCommandExecutor` + `ClusterRedisCommandExecutor`)
- Lets the main class avoid branching on standalone vs. cluster mode.
- `ClusterRedisCommandExecutor` routes `FT.CREATE`/`FT.SEARCH` to a **known primary node** — discovered via `CLUSTER SLOTS` (parsed for the master entry per slot range) and cached, with fallback to the next primary and a forced topology refresh if a primary rejects a command — rather than any arbitrary node, since these are writes and must land on a primary. This relies on the underlying `valkey-search` module treating a non-hash-tagged index name (ours has none) as a cluster-wide index: one call reaches every shard and gets results merged server-side, so no manual per-shard fan-out is needed.

**`RediSearchCommand`** (new enum)
- Implements Jedis's `ProtocolCommand` so `FT.CREATE`/`FT.SEARCH`/`FT.INFO` can be sent via Jedis 3.3's raw `sendCommand` API, since this codebase's existing Jedis dependency (shared with other Redis consumers in the gateway) predates typed RediSearch support and wasn't bumped for this change.

**`VectorDBProviderService`** (interface change)
- Added a `close()` lifecycle method, implemented as a real resource release in the new ElastiCache provider and as a documented no-op in `ZillizVectorDBProviderServiceImpl` (it holds no persistent connection — each request builds and discards its own `HttpClient`).

