### PR TITLE
Fix API Product default version routing for migrated products

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/SubscriptionValidationDAO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/SubscriptionValidationDAO.java
@@ -1277,7 +1277,9 @@ public class SubscriptionValidationDAO {
                         String revision = resultSet.getString("REVISION_UUID");
                         api.setStatus(resultSet.getString("STATUS"));
                         api.setOrganization(resultSet.getString("ORGANIZATION"));
-                        api.setIsDefaultVersion(isAPIDefaultVersion(connection, provider, name, version));
+                        String publishedDefaultApiVersion = getAPIDefaultVersion(connection, provider, name);
+                        setDefaultVersionContext(apiType, api, version, publishedDefaultApiVersion,
+                                api.getContext(), api.getContextTemplate());
                         if (resultSet.getString("IS_EGRESS") != null) {
                             api.setEgress(parseInt(resultSet.getString("IS_EGRESS")));
                         }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/SubscriptionValidationDAO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/SubscriptionValidationDAO.java
@@ -1613,8 +1613,6 @@ public class SubscriptionValidationDAO {
                     return resultSet.getString("PUBLISHED_DEFAULT_API_VERSION");
                 }
             }
-        } catch (SQLException e) {
-            log.error("Error while loading default version", e);
         }
         return null;
     }


### PR DESCRIPTION
## Problem

Fixes https://github.com/wso2/api-manager/issues/5150

After migrating an older API-M deployment to 4.6.0, migrated API Products are assigned version `1.0.0` and are reported as the default version by both the Publisher and the Developer Portal, but they cannot be invoked without the version in the context path:

- `GET /<product-context>/1.0.0/<resource>` → `200`
- `GET /<product-context>/<resource>` → `404` (worked before the upgrade)

This breaks backward compatibility for existing clients of a migrated API Product.

## Root cause

`SubscriptionValidationDAO.getAPIByContextAndVersion` only set the `isDefaultVersion` flag via `isAPIDefaultVersion(...)`; it never derived the default version **context**.

Migrated API Products have `CONTEXT_TEMPLATE = NULL` and no `AM_API_DEFAULT_VERSION` row, so the gateway never obtained a version-less route for them and the request did not match any deployed API.

`getAPIByContextAndVersion` — the lookup the gateway uses to resolve an incoming context and version — was the only remaining call site using the old pattern. The sibling paths in the same DAO (`getAllApis` (both overloads), `getApiByUUID`, `getAllApisByLabel`) already call `setDefaultVersionContext`.

## Fix

Derive the default version context via `getAPIDefaultVersion` + `setDefaultVersionContext`, consistent with those sibling paths.

`setDefaultVersionContext` already handles the migrated-product shape explicitly: for an API Product at version `1.0.0` with a blank `contextTemplate`, and a blank `publishedDefaultApiVersion` (i.e. no `AM_API_DEFAULT_VERSION` row), it marks the product as the default version and sets `contextTemplate` to the version-less context. No migration or data change is required.

This is a runtime-only change — it writes nothing to the database.

## Verification

Reproduced end-to-end on a real 4.0.0 → 4.6.0 migration (MySQL, all-in-one) using the bundled PizzaShack API exposed through an API Product, then re-tested against the same migrated database with only the patched `org.wso2.carbon.apimgt.impl` jar swapped in.

| Call | Pre-fix | Post-fix |
|---|---|---|
| `/pizzaproduct/menu` (no version) | 404 | **200** |
| `/pizzaproduct/1.0.0/menu` | 200 | 200 |
| `/pizzashack/1.0.0/menu` (control API) | 200 | 200 |

Negative controls, confirming the change does not broaden routing or weaken auth:

| Negative control | Pre-fix | Post-fix |
|---|---|---|
| `/pizzaproduct/9.9.9/menu` (unknown version) | 404 | 404 |
| `/nosuchproduct/menu` (unknown context) | 404 | 404 |
| `/pizzaproduct/menu` without a token | 401 | 401 |
| `/pizzashack/menu` (API that is *not* a default version) | 404 | 404 |

The last row is the important one: version-less routing is restored only for the migrated API Product case, not enabled across the board. `AM_API_DEFAULT_VERSION` remains empty after the fix.
