### PR TITLE
Add tenantflow wrappers for websocket auth

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/inbound/websocket/InboundWebSocketProcessor.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/inbound/websocket/InboundWebSocketProcessor.java
@@ -96,11 +96,12 @@ public class InboundWebSocketProcessor implements WebSocketProcessor {
      * @param ctx                   Channel pipeline context
      * @param inboundMessageContext InboundMessageContext
      * @return InboundProcessorResponseDTO with handshake processing response
+     * @implNote Tenancy: establishes and balances its own carbon tenant flow (the WS handshake runs on a raw netty
+     *           thread, not through Synapse dispatch); see the startTenantFlow/finally endTenantFlow pair below.
      */
     @Override
     public InboundProcessorResponseDTO handleHandshake(FullHttpRequest req, ChannelHandlerContext ctx,
                                                        InboundMessageContext inboundMessageContext) {
-
         InboundProcessorResponseDTO inboundProcessorResponseDTO;
         try {
             HandshakeProcessor handshakeProcessor = new HandshakeProcessor();
@@ -119,39 +120,46 @@ public class InboundWebSocketProcessor implements WebSocketProcessor {
             inboundMessageContext.getRequestHeaders().put(HttpHeaders.USER_AGENT, userAgent);
 
             PrivilegedCarbonContext.startTenantFlow();
-            PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantDomain(
-                    inboundMessageContext.getTenantDomain(), true);
-            if (isNoAuthentication(inboundMessageContext)) {
-                inboundMessageContext.setAuthenticator(new NoAuthAuthenticator());
-                setRequestHeaders(req, inboundMessageContext);
-                inboundProcessorResponseDTO = 
-                    handshakeProcessor.processHandshake(inboundMessageContext);
-            } else if (isOauthAuthentication(req, inboundMessageContext)) {
-                inboundMessageContext.setAuthenticator(new OAuthAuthenticator());
-                setRequestHeaders(req, inboundMessageContext);
-                setOrReplaceRequestHeaderIgnoreCase(WebsocketUtil.authorizationHeader, req, inboundMessageContext);
-                inboundProcessorResponseDTO =
+            try {
+                PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantDomain(
+                        inboundMessageContext.getTenantDomain(), true);
+                if (isNoAuthentication(inboundMessageContext)) {
+                    inboundMessageContext.setAuthenticator(new NoAuthAuthenticator());
+                    setRequestHeaders(req, inboundMessageContext);
+                    inboundProcessorResponseDTO =
                         handshakeProcessor.processHandshake(inboundMessageContext);
-                setRequestHeaders(req, inboundMessageContext);
-            } else if (isAPIKeyAuthentication(req, inboundMessageContext)) {
-                inboundMessageContext.setAuthenticator(new ApiKeyAuthenticator());
-                setRequestHeaders(req, inboundMessageContext);
-                setOrReplaceRequestHeaderIgnoreCase(APIConstants.API_KEY_HEADER_QUERY_PARAM, req, inboundMessageContext);
-                inboundProcessorResponseDTO =
-                        handshakeProcessor.processHandshake(inboundMessageContext);
-                setRequestHeaders(req, inboundMessageContext);
-            } else {
-                String errorMessage = "No Authorization header, access_token query parameter, apikey header or query " +
-                        "parameter present";
-                log.error(errorMessage + " in request for the websocket context "
-                        + inboundMessageContext.getApiContext());
-                inboundProcessorResponseDTO = InboundWebsocketProcessorUtil.getHandshakeErrorDTO(
-                        WebSocketApiConstants.HandshakeErrorConstants.API_AUTH_ERROR, errorMessage);
+                } else if (isOauthAuthentication(req, inboundMessageContext)) {
+                    inboundMessageContext.setAuthenticator(new OAuthAuthenticator());
+                    setRequestHeaders(req, inboundMessageContext);
+                    setOrReplaceRequestHeaderIgnoreCase(WebsocketUtil.authorizationHeader, req, inboundMessageContext);
+                    inboundProcessorResponseDTO =
+                            handshakeProcessor.processHandshake(inboundMessageContext);
+                    setRequestHeaders(req, inboundMessageContext);
+                } else if (isAPIKeyAuthentication(req, inboundMessageContext)) {
+                    inboundMessageContext.setAuthenticator(new ApiKeyAuthenticator());
+                    setRequestHeaders(req, inboundMessageContext);
+                    setOrReplaceRequestHeaderIgnoreCase(APIConstants.API_KEY_HEADER_QUERY_PARAM, req, inboundMessageContext);
+                    inboundProcessorResponseDTO =
+                            handshakeProcessor.processHandshake(inboundMessageContext);
+                    setRequestHeaders(req, inboundMessageContext);
+                } else {
+                    String errorMessage = "No Authorization header, access_token query parameter, apikey header or query " +
+                            "parameter present";
+                    log.error(errorMessage + " in request for the websocket context "
+                            + inboundMessageContext.getApiContext());
+                    inboundProcessorResponseDTO = InboundWebsocketProcessorUtil.getHandshakeErrorDTO(
+                            WebSocketApiConstants.HandshakeErrorConstants.API_AUTH_ERROR, errorMessage);
+                }
+                if (inboundProcessorResponseDTO.isError()) {
+                    publishHandshakeAuthErrorEvent(ctx, inboundProcessorResponseDTO.getErrorMessage());
+                }
+                return inboundProcessorResponseDTO;
+            } finally {
+                // Balance the startTenantFlow() above. Without this, the tenant domain set on the shared netty
+                // event-loop thread can leak to later requests handled on the same thread, causing cross-tenant
+                // lookups (e.g., resolving the wrong key manager) and rejecting valid tokens (900901).
+                PrivilegedCarbonContext.endTenantFlow();
             }
-            if (inboundProcessorResponseDTO.isError()) {
-                publishHandshakeAuthErrorEvent(ctx, inboundProcessorResponseDTO.getErrorMessage());
-            }
-            return inboundProcessorResponseDTO;
         } catch (APISecurityException e) {
             log.error("Authentication Failure for the websocket context: " + inboundMessageContext.getApiContext()
                     + e.getMessage());

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/inbound/websocket/utils/InboundWebsocketProcessorUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/inbound/websocket/utils/InboundWebsocketProcessorUtil.java
@@ -74,10 +74,11 @@ public class InboundWebsocketProcessorUtil {
      * @param authenticationContext Validated AuthenticationContext
      * @param inboundMessageContext InboundMessageContext
      * @return true if authenticated
+     * @implNote Tenancy: none of its own — runs inside the caller's tenant flow (the authenticators run under
+     *           isAuthenticated()/authenticateToken(), which establish it).
      */
     public static boolean validateAuthenticationContext(AuthenticationContext authenticationContext,
                                                         InboundMessageContext inboundMessageContext) {
-
         if (authenticationContext == null || !authenticationContext.isAuthenticated()) {
             return false;
         }
@@ -118,16 +119,29 @@ public class InboundWebsocketProcessorUtil {
      * @return true if authorized
      * @throws APIManagementException if an internal error occurs
      * @throws APISecurityException   if authorization fails
+     * @implNote Tenancy: establishes and balances its own carbon tenant flow from the request context; it is the
+     *           worker that validateScopes() delegates to.
      */
     public static boolean authorizeGraphQLSubscriptionEvents(String matchingResource,
                                                              InboundMessageContext inboundMessageContext)
             throws APIManagementException, APISecurityException {
-
-        JWTValidator jwtValidator = new JWTValidator(new APIKeyValidator(), inboundMessageContext.getTenantDomain());
-        jwtValidator.validateScopesForGraphQLSubscriptions(inboundMessageContext.getApiContext(),
-                inboundMessageContext.getVersion(), matchingResource, inboundMessageContext.getSignedJWTInfo(),
-                inboundMessageContext.getAuthContext());
-        return true;
+        // Subscription-event scope validation runs on the shared netty event-loop thread and must not rely on
+        // the tenant domain left there by a previous request. validateScopesForGraphQLSubscriptions reads the
+        // tenant from the thread-local carbon context, so establish (and always clear) the tenant flow from this
+        // request's own context — otherwise a null/stale tenant resolves the wrong key manager (or NPEs).
+        try {
+            PrivilegedCarbonContext.startTenantFlow();
+            PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantDomain(
+                    inboundMessageContext.getTenantDomain(), true);
+            JWTValidator jwtValidator = new JWTValidator(new APIKeyValidator(),
+                    inboundMessageContext.getTenantDomain());
+            jwtValidator.validateScopesForGraphQLSubscriptions(inboundMessageContext.getApiContext(),
+                    inboundMessageContext.getVersion(), matchingResource, inboundMessageContext.getSignedJWTInfo(),
+                    inboundMessageContext.getAuthContext());
+            return true;
+        } finally {
+            PrivilegedCarbonContext.endTenantFlow();
+        }
     }
 
     /**
@@ -180,11 +194,11 @@ public class InboundWebsocketProcessorUtil {
      * @param inboundMessageContext InboundMessageContext
      * @param operationId           Operation ID
      * @return InboundProcessorResponseDTO
+     * @implNote Tenancy: none of its own — delegates to doThrottle(), which establishes the tenant flow.
      */
     public static InboundProcessorResponseDTO doThrottleForGraphQL(int msgSize, VerbInfoDTO verbInfoDTO,
                                                                    InboundMessageContext inboundMessageContext,
                                                                    String operationId) {
-
         GraphQLProcessorResponseDTO responseDTO = new GraphQLProcessorResponseDTO();
         responseDTO.setId(operationId);
         return InboundWebsocketProcessorUtil.doThrottle(msgSize, verbInfoDTO, inboundMessageContext, responseDTO);
@@ -197,11 +211,11 @@ public class InboundWebsocketProcessorUtil {
      * @param verbInfoDTO           VerbInfoDTO for invoking operation. Pass null for websocket API throttling.
      * @param inboundMessageContext InboundMessageContext
      * @return false if throttled
+     * @implNote Tenancy: establishes and balances its own carbon tenant flow from the request context.
      */
     public static InboundProcessorResponseDTO doThrottle(int msgSize, VerbInfoDTO verbInfoDTO,
                                                          InboundMessageContext inboundMessageContext,
                                                          InboundProcessorResponseDTO responseDTO) {
-
         APIKeyValidationInfoDTO infoDTO = inboundMessageContext.getInfoDTO();
         String applicationLevelTier = infoDTO.getApplicationTier();
         String apiLevelTier = infoDTO.getApiTier() == null && verbInfoDTO == null ? APIConstants.UNLIMITED_TIER
@@ -356,9 +370,9 @@ public class InboundWebsocketProcessorUtil {
      * @param inboundMessageContext InboundMessageContext
      * @return whether authenticated or not
      * @throws APISecurityException   if authentication fails
+     * @implNote Tenancy: establishes and balances its own carbon tenant flow from the request context.
      */
     public static boolean isAuthenticated(InboundMessageContext inboundMessageContext) throws APISecurityException {
-
         try {
             PrivilegedCarbonContext.startTenantFlow();
             PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantDomain(
@@ -377,10 +391,21 @@ public class InboundWebsocketProcessorUtil {
      *
      * @param inboundMessageContext InboundMessageContext
      * @return InboundProcessorResponseDTO
+     * @implNote Tenancy: establishes and balances its own carbon tenant flow from the request context.
      */
     public static InboundProcessorResponseDTO authenticateToken(InboundMessageContext inboundMessageContext)
             throws APISecurityException {
-        return authenticate(inboundMessageContext);
+        // Frame authentication runs on the shared netty event-loop thread and must not rely on the
+        // tenant domain left there by a previous request's handshake. Establish (and always clear) the
+        // tenant flow from this request's own context so the correct key manager is resolved.
+        try {
+            PrivilegedCarbonContext.startTenantFlow();
+            PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantDomain(
+                    inboundMessageContext.getTenantDomain(), true);
+            return authenticate(inboundMessageContext);
+        } finally {
+            PrivilegedCarbonContext.endTenantFlow();
+        }
     }
 
     /**
@@ -388,6 +413,7 @@ public class InboundWebsocketProcessorUtil {
      *
      * @param inboundMessageContext InboundMessageContext
      * @return InboundProcessorResponseDTO
+     * @implNote Tenancy: none of its own — runs inside the caller's tenant flow (isAuthenticated()/authenticateToken()).
      */
     public static InboundProcessorResponseDTO authenticate(InboundMessageContext inboundMessageContext)
             throws APISecurityException {
@@ -518,10 +544,11 @@ public class InboundWebsocketProcessorUtil {
      * @param subscriptionOperation Subscription operation
      * @param operationId           GraphQL message Id
      * @return InboundProcessorResponseDTO
+     * @implNote Tenancy: none of its own — delegates to authorizeGraphQLSubscriptionEvents(), which establishes
+     *           the tenant flow.
      */
     public static InboundProcessorResponseDTO validateScopes(InboundMessageContext inboundMessageContext,
                                                              String subscriptionOperation, String operationId) {
-
         InboundProcessorResponseDTO responseDTO = new GraphQLProcessorResponseDTO();
         if (inboundMessageContext.isJWTToken()) { // scope validation not supported for Opaque tokens with gql subs
             // validate scopes based on subscription payload

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/test/java/org/wso2/carbon/apimgt/gateway/inbound/websocket/utils/InboundWebsocketProcessorUtilTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/test/java/org/wso2/carbon/apimgt/gateway/inbound/websocket/utils/InboundWebsocketProcessorUtilTest.java
@@ -36,7 +36,10 @@ import org.wso2.carbon.apimgt.gateway.dto.WebSocketThrottleResponseDTO;
 import org.wso2.carbon.apimgt.gateway.handlers.Utils;
 import org.wso2.carbon.apimgt.gateway.handlers.WebsocketUtil;
 import org.wso2.carbon.apimgt.gateway.handlers.WebsocketWSClient;
+import org.wso2.carbon.apimgt.gateway.handlers.security.APISecurityConstants;
 import org.wso2.carbon.apimgt.gateway.handlers.security.APISecurityException;
+import org.wso2.carbon.apimgt.gateway.handlers.security.APIKeyValidator;
+import org.wso2.carbon.apimgt.gateway.inbound.websocket.Authentication.Authenticator;
 import org.wso2.carbon.apimgt.gateway.handlers.security.jwt.JWTValidator;
 import org.wso2.carbon.apimgt.gateway.handlers.streaming.websocket.WebSocketApiConstants;
 import org.wso2.carbon.apimgt.gateway.inbound.InboundMessageContext;
@@ -168,6 +171,14 @@ public class InboundWebsocketProcessorUtilTest {
         Assert.assertFalse(inboundProcessorResponseDTO.isError());
         Assert.assertNull(inboundProcessorResponseDTO.getErrorMessage());
         Assert.assertFalse(inboundProcessorResponseDTO.isCloseConnection());
+        // Tenant-flow guard (fails if doThrottle's startTenantFlow/setTenantDomain/endTenantFlow line is removed):
+        // doThrottle() establishes and balances its own tenant flow from the request context.
+        PowerMockito.verifyStatic(PrivilegedCarbonContext.class, Mockito.times(1));
+        PrivilegedCarbonContext.startTenantFlow();
+        PowerMockito.verifyStatic(PrivilegedCarbonContext.class, Mockito.times(1));
+        PrivilegedCarbonContext.endTenantFlow();
+        Mockito.verify(PrivilegedCarbonContext.getThreadLocalCarbonContext(), Mockito.times(1))
+                .setTenantDomain(inboundMessageContext.getTenantDomain(), true);
     }
 
     @Test
@@ -366,6 +377,144 @@ public class InboundWebsocketProcessorUtilTest {
         InboundProcessorResponseDTO responseDTO = InboundWebsocketProcessorUtil.authenticateToken(
                 inboundMessageContext);
         Assert.assertTrue(responseDTO.isError());
+    }
+
+    /**
+     * Regression guard for the WS tenant-flow leak. authenticateToken must open a tenant flow from the
+     * request's own context and balance it with an endTenantFlow() on the success path, so a frame never
+     * resolves the tenant a previous handshake left on the shared netty event-loop thread. The inner
+     * authenticate(...) is stubbed so the assertion isolates authenticateToken's own start/end pair.
+     */
+    @Test
+    public void authenticateTokenBalancesTenantFlowOnSuccess() throws Exception {
+        InboundMessageContext inboundMessageContext = createWebSocketApiMessageContext();
+        PowerMockito.stub(PowerMockito.method(InboundWebsocketProcessorUtil.class, "authenticate",
+                        InboundMessageContext.class))
+                .toReturn(new InboundProcessorResponseDTO());
+
+        InboundProcessorResponseDTO responseDTO = InboundWebsocketProcessorUtil.authenticateToken(
+                inboundMessageContext);
+
+        Assert.assertFalse(responseDTO.isError());
+        PowerMockito.verifyStatic(PrivilegedCarbonContext.class, Mockito.times(1));
+        PrivilegedCarbonContext.startTenantFlow();
+        PowerMockito.verifyStatic(PrivilegedCarbonContext.class, Mockito.times(1));
+        PrivilegedCarbonContext.endTenantFlow();
+        // The tenant set on the flow must be THIS request's own tenant (overwrite=true), not one inherited
+        // from the thread — that is what makes the frame resolve the correct key manager.
+        Mockito.verify(PrivilegedCarbonContext.getThreadLocalCarbonContext(), Mockito.times(1))
+                .setTenantDomain(inboundMessageContext.getTenantDomain(), true);
+    }
+
+    /**
+     * The critical half of the tenant-flow leak fix: endTenantFlow() must run even when authentication
+     * throws, or an exception mid-frame would leave the request's tenant leaked on the shared event-loop
+     * thread. Stub the inner authenticate(...) to throw and assert the flow is still ended (finally ran)
+     * while the exception propagates.
+     */
+    @Test
+    public void authenticateTokenEndsTenantFlowWhenAuthenticationThrows() throws Exception {
+        InboundMessageContext inboundMessageContext = createWebSocketApiMessageContext();
+        PowerMockito.stub(PowerMockito.method(InboundWebsocketProcessorUtil.class, "authenticate",
+                        InboundMessageContext.class))
+                .toThrow(new APISecurityException(APISecurityConstants.API_AUTH_GENERAL_ERROR,
+                        "forced failure to verify the tenant flow is still ended"));
+
+        try {
+            InboundWebsocketProcessorUtil.authenticateToken(inboundMessageContext);
+            Assert.fail("Expected APISecurityException to propagate from authenticateToken");
+        } catch (APISecurityException expected) {
+            // expected — the finally block must still end the tenant flow
+        }
+
+        PowerMockito.verifyStatic(PrivilegedCarbonContext.class, Mockito.times(1));
+        PrivilegedCarbonContext.startTenantFlow();
+        PowerMockito.verifyStatic(PrivilegedCarbonContext.class, Mockito.times(1));
+        PrivilegedCarbonContext.endTenantFlow();
+    }
+
+    /**
+     * Regression guard for the second WS tenant-flow gap (the one the integration suite surfaced):
+     * authorizeGraphQLSubscriptionEvents is the worker that invokes JWTValidator.validateScopesForGraphQLSubscriptions,
+     * which reads the tenant from the shared event-loop thread. It must open a tenant flow from THIS request's own
+     * context and balance it, so a GraphQL-subscription frame's scope check resolves the correct tenant instead of a
+     * null/stale one left on the thread. The JWTValidator is mocked so the assertion isolates the tenant-flow pair.
+     */
+    @Test
+    public void authorizeGraphQLSubscriptionEventsBalancesTenantFlowOnSuccess() throws Exception {
+        InboundMessageContext inboundMessageContext = createWebSocketApiMessageContext();
+        inboundMessageContext.setJWTToken(true);
+        PowerMockito.whenNew(APIKeyValidator.class).withAnyArguments()
+                .thenReturn(Mockito.mock(APIKeyValidator.class));
+        JWTValidator jwtValidator = Mockito.mock(JWTValidator.class);
+        PowerMockito.whenNew(JWTValidator.class).withAnyArguments().thenReturn(jwtValidator);
+
+        boolean authorized = InboundWebsocketProcessorUtil.authorizeGraphQLSubscriptionEvents(
+                "liftStatusChange", inboundMessageContext);
+
+        Assert.assertTrue(authorized);
+        PowerMockito.verifyStatic(PrivilegedCarbonContext.class, Mockito.times(1));
+        PrivilegedCarbonContext.startTenantFlow();
+        PowerMockito.verifyStatic(PrivilegedCarbonContext.class, Mockito.times(1));
+        PrivilegedCarbonContext.endTenantFlow();
+        // The tenant set for the scope check must be THIS request's own tenant (overwrite=true), not one left
+        // on the shared thread — that is what makes validateScopesForGraphQLSubscriptions resolve the right KM.
+        Mockito.verify(PrivilegedCarbonContext.getThreadLocalCarbonContext(), Mockito.times(1))
+                .setTenantDomain(inboundMessageContext.getTenantDomain(), true);
+    }
+
+    /**
+     * The tenant flow around the subscription-event scope check must be ended even when the scope validation
+     * throws, or a rejected frame would leak the request's tenant onto the shared event-loop thread.
+     */
+    @Test
+    public void authorizeGraphQLSubscriptionEventsEndsTenantFlowWhenValidationThrows() throws Exception {
+        InboundMessageContext inboundMessageContext = createWebSocketApiMessageContext();
+        inboundMessageContext.setJWTToken(true);
+        PowerMockito.whenNew(APIKeyValidator.class).withAnyArguments()
+                .thenReturn(Mockito.mock(APIKeyValidator.class));
+        JWTValidator jwtValidator = Mockito.mock(JWTValidator.class);
+        PowerMockito.whenNew(JWTValidator.class).withAnyArguments().thenReturn(jwtValidator);
+        Mockito.doThrow(new APISecurityException(APISecurityConstants.API_AUTH_GENERAL_ERROR,
+                        "forced scope-validation failure to verify the tenant flow is still ended"))
+                .when(jwtValidator).validateScopesForGraphQLSubscriptions(Mockito.any(), Mockito.any(),
+                        Mockito.any(), Mockito.any(), Mockito.any());
+
+        try {
+            InboundWebsocketProcessorUtil.authorizeGraphQLSubscriptionEvents("liftStatusChange",
+                    inboundMessageContext);
+            Assert.fail("Expected APISecurityException to propagate from authorizeGraphQLSubscriptionEvents");
+        } catch (APISecurityException expected) {
+            // expected — the finally block must still end the tenant flow
+        }
+
+        PowerMockito.verifyStatic(PrivilegedCarbonContext.class, Mockito.times(1));
+        PrivilegedCarbonContext.startTenantFlow();
+        PowerMockito.verifyStatic(PrivilegedCarbonContext.class, Mockito.times(1));
+        PrivilegedCarbonContext.endTenantFlow();
+    }
+
+    /**
+     * Guard for the handshake-auth tenant flow: isAuthenticated() must open a tenant flow from the request's own
+     * context and balance it. The authenticator is stubbed so validateToken() short-circuits before authenticate(),
+     * isolating isAuthenticated()'s own start/set/end pair. Fails if that tenancy line is removed.
+     */
+    @Test
+    public void isAuthenticatedBalancesTenantFlow() throws Exception {
+        InboundMessageContext inboundMessageContext = createWebSocketApiMessageContext();
+        Authenticator authenticator = Mockito.mock(Authenticator.class);
+        Mockito.when(authenticator.validateToken(Mockito.any())).thenReturn(false);
+        inboundMessageContext.setAuthenticator(authenticator);
+
+        boolean authenticated = InboundWebsocketProcessorUtil.isAuthenticated(inboundMessageContext);
+
+        Assert.assertFalse(authenticated);
+        PowerMockito.verifyStatic(PrivilegedCarbonContext.class, Mockito.times(1));
+        PrivilegedCarbonContext.startTenantFlow();
+        PowerMockito.verifyStatic(PrivilegedCarbonContext.class, Mockito.times(1));
+        PrivilegedCarbonContext.endTenantFlow();
+        Mockito.verify(PrivilegedCarbonContext.getThreadLocalCarbonContext(), Mockito.times(1))
+                .setTenantDomain(inboundMessageContext.getTenantDomain(), true);
     }
 
     @Test


### PR DESCRIPTION
## Description

This pull request addresses a critical issue with tenant domain context leakage in the WebSocket gateway, which could cause authentication failures for valid tokens. The main change is to ensure that tenant flows are always properly started and ended around authentication logic, preventing the tenant domain from persisting on shared Netty event-loop threads.

**Tenant flow management improvements:**

* Added a `try-finally` block to ensure `PrivilegedCarbonContext.endTenantFlow()` is always called after `startTenantFlow()` in `handleHandshake`, preventing tenant context leakage across requests and avoiding invalid JWT token errors. [[1]](diffhunk://#diff-4e14ba61d4a15c033148b8ed5a0e1366d1bb17569706636ce045da9ae5552b1dR122) [[2]](diffhunk://#diff-4e14ba61d4a15c033148b8ed5a0e1366d1bb17569706636ce045da9ae5552b1dR156-R163)
* Updated `authenticateToken` to always establish and clear the tenant flow using a `try-finally` block, so the correct tenant domain is used for each authentication and not inherited from a previous request.

## Issue
https://github.com/wso2/api-manager/issues/5156