### PR TITLE
Fix concurrent export temp-directory collision corrupting archives

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.api/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt</artifactId>
-        <version>9.33.163-SNAPSHOT</version>
+        <version>9.33.163</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/apimgt/org.wso2.carbon.apimgt.api/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt</artifactId>
-        <version>9.33.163</version>
+        <version>9.33.164-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/apimgt/org.wso2.carbon.apimgt.broker.lifecycle/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.broker.lifecycle/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>apimgt</artifactId>
         <groupId>org.wso2.carbon.apimgt</groupId>
-        <version>9.33.163-SNAPSHOT</version>
+        <version>9.33.163</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/apimgt/org.wso2.carbon.apimgt.broker.lifecycle/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.broker.lifecycle/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>apimgt</artifactId>
         <groupId>org.wso2.carbon.apimgt</groupId>
-        <version>9.33.163</version>
+        <version>9.33.164-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/apimgt/org.wso2.carbon.apimgt.cache.invalidation/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.cache.invalidation/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>apimgt</artifactId>
         <groupId>org.wso2.carbon.apimgt</groupId>
-        <version>9.33.163-SNAPSHOT</version>
+        <version>9.33.163</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/components/apimgt/org.wso2.carbon.apimgt.cache.invalidation/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.cache.invalidation/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>apimgt</artifactId>
         <groupId>org.wso2.carbon.apimgt</groupId>
-        <version>9.33.163</version>
+        <version>9.33.164-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/components/apimgt/org.wso2.carbon.apimgt.cleanup.service/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.cleanup.service/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt</artifactId>
-        <version>9.33.163</version>
+        <version>9.33.164-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/apimgt/org.wso2.carbon.apimgt.cleanup.service/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.cleanup.service/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt</artifactId>
-        <version>9.33.163-SNAPSHOT</version>
+        <version>9.33.163</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/apimgt/org.wso2.carbon.apimgt.common.analytics/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.common.analytics/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt</artifactId>
-        <version>9.33.163-SNAPSHOT</version>
+        <version>9.33.163</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/components/apimgt/org.wso2.carbon.apimgt.common.analytics/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.common.analytics/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt</artifactId>
-        <version>9.33.163</version>
+        <version>9.33.164-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/components/apimgt/org.wso2.carbon.apimgt.common.gateway/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.common.gateway/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt</artifactId>
-        <version>9.33.163-SNAPSHOT</version>
+        <version>9.33.163</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/components/apimgt/org.wso2.carbon.apimgt.common.gateway/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.common.gateway/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt</artifactId>
-        <version>9.33.163</version>
+        <version>9.33.164-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/components/apimgt/org.wso2.carbon.apimgt.common.jms/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.common.jms/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt</artifactId>
-        <version>9.33.163</version>
+        <version>9.33.164-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/components/apimgt/org.wso2.carbon.apimgt.common.jms/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.common.jms/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt</artifactId>
-        <version>9.33.163-SNAPSHOT</version>
+        <version>9.33.163</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/components/apimgt/org.wso2.carbon.apimgt.core/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt</artifactId>
-        <version>9.33.163-SNAPSHOT</version>
+        <version>9.33.163</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/apimgt/org.wso2.carbon.apimgt.core/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt</artifactId>
-        <version>9.33.163</version>
+        <version>9.33.164-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/apimgt/org.wso2.carbon.apimgt.devops.impl/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.devops.impl/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt</artifactId>
-        <version>9.33.163</version>
+        <version>9.33.164-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/apimgt/org.wso2.carbon.apimgt.devops.impl/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.devops.impl/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt</artifactId>
-        <version>9.33.163-SNAPSHOT</version>
+        <version>9.33.163</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/apimgt/org.wso2.carbon.apimgt.eventing.hub/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.eventing.hub/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apimgt</artifactId>
         <groupId>org.wso2.carbon.apimgt</groupId>
-        <version>9.33.163-SNAPSHOT</version>
+        <version>9.33.163</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/apimgt/org.wso2.carbon.apimgt.eventing.hub/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.eventing.hub/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apimgt</artifactId>
         <groupId>org.wso2.carbon.apimgt</groupId>
-        <version>9.33.163</version>
+        <version>9.33.164-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/apimgt/org.wso2.carbon.apimgt.eventing/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.eventing/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apimgt</artifactId>
         <groupId>org.wso2.carbon.apimgt</groupId>
-        <version>9.33.163-SNAPSHOT</version>
+        <version>9.33.163</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/apimgt/org.wso2.carbon.apimgt.eventing/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.eventing/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apimgt</artifactId>
         <groupId>org.wso2.carbon.apimgt</groupId>
-        <version>9.33.163</version>
+        <version>9.33.164-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/apimgt/org.wso2.carbon.apimgt.federated.gateway/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.federated.gateway/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>carbon-apimgt</artifactId>
-        <version>9.33.163-SNAPSHOT</version>
+        <version>9.33.163</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
 

--- a/components/apimgt/org.wso2.carbon.apimgt.federated.gateway/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.federated.gateway/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>carbon-apimgt</artifactId>
-        <version>9.33.163</version>
+        <version>9.33.164-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
 

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt</artifactId>
-        <version>9.33.163</version>
+        <version>9.33.164-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt</artifactId>
-        <version>9.33.163-SNAPSHOT</version>
+        <version>9.33.163</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/apimgt/org.wso2.carbon.apimgt.governance.api/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.governance.api/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt</artifactId>
-        <version>9.33.163-SNAPSHOT</version>
+        <version>9.33.163</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/apimgt/org.wso2.carbon.apimgt.governance.api/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.governance.api/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt</artifactId>
-        <version>9.33.163</version>
+        <version>9.33.164-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/apimgt/org.wso2.carbon.apimgt.governance.impl/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.governance.impl/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt</artifactId>
-        <version>9.33.163-SNAPSHOT</version>
+        <version>9.33.163</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/apimgt/org.wso2.carbon.apimgt.governance.impl/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.governance.impl/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt</artifactId>
-        <version>9.33.163</version>
+        <version>9.33.164-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/apimgt/org.wso2.carbon.apimgt.governance.impl/src/main/java/org/wso2/carbon/apimgt/governance/impl/APIGovernanceHandler.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.governance.impl/src/main/java/org/wso2/carbon/apimgt/governance/impl/APIGovernanceHandler.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -454,21 +455,28 @@ public class APIGovernanceHandler implements ArtifactGovernanceHandler {
                     apiDtoTypeWrapper = new APIDTOTypeWrapper(apiDtoToReturn);
                     isMCPServer = false;
                 }
+                // Request-scoped export: the archive lives under a UNIQUE temp parent (no shared-name collision
+                // with a concurrent user/revision export), so the bytes read here are always this call's own.
                 File apiProject = ExportUtils.exportAPI(
                         apiProvider, apiIdentifier, apiDtoTypeWrapper, api,
-                        apiIdentifier.getProviderName(), ExportFormat.YAML, true, true, 
-                        StringUtils.EMPTY, organization, false
-                ); // returns zip file
-                if (log.isDebugEnabled()) {
-                    if (!isMCPServer) {
-                        log.debug("Successfully exported API with id " + apiId + " in organization "
-                                + organization + " with revision " + revisionId);
-                    } else {
-                        log.debug("Successfully exported MCP Server with id " + apiId + " in organization "
-                                + organization + " with revision " + revisionId);
+                        apiIdentifier.getProviderName(), ExportFormat.YAML, true, true,
+                        StringUtils.EMPTY, organization, false, true
+                ); // returns a zip inside a caller-owned unique temp directory
+                try {
+                    if (log.isDebugEnabled()) {
+                        if (!isMCPServer) {
+                            log.debug("Successfully exported API with id " + apiId + " in organization "
+                                    + organization + " with revision " + revisionId);
+                        } else {
+                            log.debug("Successfully exported MCP Server with id " + apiId + " in organization "
+                                    + organization + " with revision " + revisionId);
+                        }
                     }
+                    return Files.readAllBytes(apiProject.toPath());
+                } finally {
+                    // Delete the request-scoped temp directory produced by the per-request export.
+                    FileUtils.deleteQuietly(apiProject.getParentFile());
                 }
-                return Files.readAllBytes(apiProject.toPath());
             } catch (APIManagementException | APIImportExportException | IOException e) {
                 throw new APIMGovernanceException(APIMGovExceptionCodes.ERROR_WHILE_GETTING_APIM_PROJECT, e,
                         apiId, organization);

--- a/components/apimgt/org.wso2.carbon.apimgt.governance.rest.api/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.governance.rest.api/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt</artifactId>
-        <version>9.33.163</version>
+        <version>9.33.164-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/apimgt/org.wso2.carbon.apimgt.governance.rest.api/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.governance.rest.api/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt</artifactId>
-        <version>9.33.163-SNAPSHOT</version>
+        <version>9.33.163</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt</artifactId>
-        <version>9.33.163-SNAPSHOT</version>
+        <version>9.33.163</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt</artifactId>
-        <version>9.33.163</version>
+        <version>9.33.164-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
@@ -25,6 +25,7 @@ import org.apache.axiom.om.OMElement;
 import org.apache.axiom.om.util.AXIOMUtil;
 import org.apache.axis2.Constants;
 import org.apache.axis2.util.JavaUtils;
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang.StringEscapeUtils;
@@ -7462,10 +7463,14 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
                     + apiRevision.getApiUUID(), e);
         }
         if (importExportAPI != null) {
+            File artifact = null;
             try {
-                File artifact = importExportAPI
-                        .exportAPI(apiRevision.getApiUUID(), revisionUUID, true, ExportFormat.JSON, false, true,
-                                organization);
+                // Request-scoped export: the artifact lives under a UNIQUE temp parent, so a concurrent export of
+                // the same API (another revision, Governance, a user download) can never overwrite the bytes we
+                // persist here as the gateway artifact.
+                artifact = importExportAPI
+                        .exportAPI(apiRevision.getApiUUID(), revisionUUID, true, ExportFormat.JSON, false,
+                                true, organization, true);
 
                 String apiType = apiMgtDAO.getAPITypeFromUUID(apiId.getUUID());
                 if (StringUtils.equals(apiType, APIConstants.API_TYPE_MCP)) {
@@ -7488,6 +7493,10 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
             } catch (APIImportExportException | ArtifactSynchronizerException e) {
                 throw new APIManagementException("Error while Store the Revision Artifact",
                         ExceptionCodes.from(ExceptionCodes.API_REVISION_UUID_NOT_FOUND));
+            } finally {
+                if (artifact != null) {
+                    FileUtils.deleteQuietly(artifact.getParentFile());
+                }
             }
         }
         return revisionUUID;
@@ -8433,10 +8442,13 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
         }
         apiRevision.setRevisionUUID(revisionUUID);
         apiMgtDAO.addAPIProductRevision(apiRevision);
+        File artifact = null;
         try {
-            File artifact = importExportAPI
+            // Request-scoped export: unique temp parent, so a concurrent same-product export can't overwrite the
+            // bytes we persist here as the gateway artifact.
+            artifact = importExportAPI
                     .exportAPIProduct(apiRevision.getApiUUID(), revisionUUID, true, ExportFormat.JSON,
-                            false, true, organization);
+                            false, true, organization, true);
             gatewayArtifactsMgtDAO
                     .addGatewayAPIArtifactAndMetaData(apiRevision.getApiUUID(), apiProductIdentifier.getName(),
                             apiProductIdentifier.getVersion(), apiRevision.getRevisionUUID(), tenantDomain,
@@ -8448,6 +8460,10 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
         } catch (APIImportExportException | ArtifactSynchronizerException e) {
             throw new APIManagementException("Error while Store the Revision Artifact",
                     ExceptionCodes.from(ExceptionCodes.API_REVISION_UUID_NOT_FOUND));
+        } finally {
+            if (artifact != null) {
+                FileUtils.deleteQuietly(artifact.getParentFile());
+            }
         }
         return revisionUUID;
     }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/ImportExportAPI.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/ImportExportAPI.java
@@ -94,7 +94,12 @@ public interface ImportExportAPI {
      * @return API artifact.
      * @throws APIManagementException
      * @throws APIImportExportException
+     * @deprecated This overload uses a shared identity-keyed temp directory and is concurrency-unsafe: concurrent
+     * exports of the same API can corrupt each other's archives. Use
+     * {@link #exportAPI(String, String, boolean, ExportFormat, boolean, boolean, String, boolean)} with
+     * {@code requestScoped = true} for concurrency-safe exports.
      */
+    @Deprecated
     public File exportAPI(String apiId, String revisionUUID, boolean preserveStatus, ExportFormat format,
                           boolean preserveDocs, boolean preserveCredentials, String organization)
             throws APIManagementException, APIImportExportException;
@@ -111,9 +116,66 @@ public interface ImportExportAPI {
      * @return API artifact.
      * @throws APIManagementException
      * @throws APIImportExportException
+     * @deprecated This overload uses a shared identity-keyed temp directory and is concurrency-unsafe: concurrent
+     * exports of the same API Product can corrupt each other's archives. Use
+     * {@link #exportAPIProduct(String, String, boolean, ExportFormat, boolean, boolean, String, boolean)} with
+     * {@code requestScoped = true} for concurrency-safe exports.
      */
+    @Deprecated
     public File exportAPIProduct(String apiId, String revisionUUID, boolean preserveStatus, ExportFormat format,
                           boolean preserveDocs, boolean preserveCredentials, String organization)
+            throws APIManagementException, APIImportExportException;
+
+    /**
+     * Used to export API artifact.
+     * <p>
+     * When {@code requestScoped} is {@code true}, the archive lives under a UNIQUE per-call parent, so
+     * concurrent exports of the same API never collide or read each other's content, and the CALLER owns the temp
+     * directory and must delete {@code returnedFile.getParentFile()} once the archive is consumed. When it is
+     * {@code false}, the legacy shared identity-keyed temp directory is used (concurrency-unsafe, no caller cleanup).
+     *
+     * @param apiId               UUID of API.
+     * @param revisionUUID        UUID of revision.
+     * @param preserveStatus      Preserve API status on export
+     * @param format              Format of output documents. Can be YAML or JSON
+     * @param preserveDocs        Preserve documentation on Export.
+     * @param preserveCredentials Preserve credentials on export
+     * @param organization        Organization
+     * @param requestScoped If {@code true}, assemble under a unique per-call parent (caller owns cleanup);
+     *                             if {@code false}, use the shared identity-keyed temp directory (legacy behaviour).
+     * @return API artifact.
+     * @throws APIManagementException
+     * @throws APIImportExportException
+     */
+    public File exportAPI(String apiId, String revisionUUID, boolean preserveStatus, ExportFormat format,
+                          boolean preserveDocs, boolean preserveCredentials, String organization,
+                          boolean requestScoped)
+            throws APIManagementException, APIImportExportException;
+
+    /**
+     * Used to export API Product artifact.
+     * <p>
+     * When {@code requestScoped} is {@code true}, the archive lives under a UNIQUE per-call parent, so
+     * concurrent exports of the same API Product never collide, and the CALLER owns the temp directory and must
+     * delete {@code returnedFile.getParentFile()} once consumed. When it is {@code false}, the legacy shared
+     * identity-keyed temp directory is used (concurrency-unsafe, no caller cleanup).
+     *
+     * @param apiId               UUID of API Product.
+     * @param revisionUUID        UUID of revision.
+     * @param preserveStatus      Preserve API status on export
+     * @param format              Format of output documents. Can be YAML or JSON
+     * @param preserveDocs        Preserve documentation on Export.
+     * @param preserveCredentials Preserve credentials on export
+     * @param organization        Organization
+     * @param requestScoped If {@code true}, assemble under a unique per-call parent (caller owns cleanup);
+     *                             if {@code false}, use the shared identity-keyed temp directory (legacy behaviour).
+     * @return API Product artifact.
+     * @throws APIManagementException
+     * @throws APIImportExportException
+     */
+    public File exportAPIProduct(String apiId, String revisionUUID, boolean preserveStatus,
+                          ExportFormat format, boolean preserveDocs, boolean preserveCredentials, String organization,
+                          boolean requestScoped)
             throws APIManagementException, APIImportExportException;
 
     /**

--- a/components/apimgt/org.wso2.carbon.apimgt.internal.service/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.internal.service/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt</artifactId>
-        <version>9.33.163-SNAPSHOT</version>
+        <version>9.33.163</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/apimgt/org.wso2.carbon.apimgt.internal.service/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.internal.service/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt</artifactId>
-        <version>9.33.163</version>
+        <version>9.33.164-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/apimgt/org.wso2.carbon.apimgt.jms.listener/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.jms.listener/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt</artifactId>
-        <version>9.33.163</version>
+        <version>9.33.164-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/components/apimgt/org.wso2.carbon.apimgt.jms.listener/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.jms.listener/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt</artifactId>
-        <version>9.33.163-SNAPSHOT</version>
+        <version>9.33.163</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/components/apimgt/org.wso2.carbon.apimgt.keymgt.client/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.keymgt.client/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt</artifactId>
-        <version>9.33.163-SNAPSHOT</version>
+        <version>9.33.163</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/apimgt/org.wso2.carbon.apimgt.keymgt.client/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.keymgt.client/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt</artifactId>
-        <version>9.33.163</version>
+        <version>9.33.164-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/apimgt/org.wso2.carbon.apimgt.keymgt/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.keymgt/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt</artifactId>
-        <version>9.33.163-SNAPSHOT</version>
+        <version>9.33.163</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/apimgt/org.wso2.carbon.apimgt.keymgt/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.keymgt/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt</artifactId>
-        <version>9.33.163</version>
+        <version>9.33.164-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/apimgt/org.wso2.carbon.apimgt.multitenant.auth/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.multitenant.auth/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt</artifactId>
-        <version>9.33.163</version>
+        <version>9.33.164-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/apimgt/org.wso2.carbon.apimgt.multitenant.auth/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.multitenant.auth/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt</artifactId>
-        <version>9.33.163-SNAPSHOT</version>
+        <version>9.33.163</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/apimgt/org.wso2.carbon.apimgt.notification/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.notification/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>apimgt</artifactId>
         <groupId>org.wso2.carbon.apimgt</groupId>
-        <version>9.33.163</version>
+        <version>9.33.164-SNAPSHOT</version>
     </parent>
     <artifactId>org.wso2.carbon.apimgt.notification</artifactId>
     <modelVersion>4.0.0</modelVersion>

--- a/components/apimgt/org.wso2.carbon.apimgt.notification/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.notification/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>apimgt</artifactId>
         <groupId>org.wso2.carbon.apimgt</groupId>
-        <version>9.33.163-SNAPSHOT</version>
+        <version>9.33.163</version>
     </parent>
     <artifactId>org.wso2.carbon.apimgt.notification</artifactId>
     <modelVersion>4.0.0</modelVersion>

--- a/components/apimgt/org.wso2.carbon.apimgt.output.adapter.http/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.output.adapter.http/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt</artifactId>
-        <version>9.33.163</version>
+        <version>9.33.164-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/apimgt/org.wso2.carbon.apimgt.output.adapter.http/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.output.adapter.http/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt</artifactId>
-        <version>9.33.163-SNAPSHOT</version>
+        <version>9.33.163</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/apimgt/org.wso2.carbon.apimgt.persistence/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.persistence/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>apimgt</artifactId>
         <groupId>org.wso2.carbon.apimgt</groupId>
-        <version>9.33.163-SNAPSHOT</version>
+        <version>9.33.163</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/components/apimgt/org.wso2.carbon.apimgt.persistence/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.persistence/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>apimgt</artifactId>
         <groupId>org.wso2.carbon.apimgt</groupId>
-        <version>9.33.163</version>
+        <version>9.33.164-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt</artifactId>
-        <version>9.33.163-SNAPSHOT</version>
+        <version>9.33.163</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt</artifactId>
-        <version>9.33.163</version>
+        <version>9.33.164-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.common/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.common/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt</artifactId>
-        <version>9.33.163-SNAPSHOT</version>
+        <version>9.33.163</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.common/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.common/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt</artifactId>
-        <version>9.33.163</version>
+        <version>9.33.164-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.dcr/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.dcr/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt</artifactId>
-        <version>9.33.163</version>
+        <version>9.33.164-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.dcr/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.dcr/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt</artifactId>
-        <version>9.33.163-SNAPSHOT</version>
+        <version>9.33.163</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.devops/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.devops/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt</artifactId>
-        <version>9.33.163</version>
+        <version>9.33.164-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.devops/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.devops/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt</artifactId>
-        <version>9.33.163-SNAPSHOT</version>
+        <version>9.33.163</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.gateway/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.gateway/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt</artifactId>
-        <version>9.33.163-SNAPSHOT</version>
+        <version>9.33.163</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.gateway/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.gateway/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt</artifactId>
-        <version>9.33.163</version>
+        <version>9.33.164-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt</artifactId>
-        <version>9.33.163-SNAPSHOT</version>
+        <version>9.33.163</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt</artifactId>
-        <version>9.33.163</version>
+        <version>9.33.164-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/ImportExportAPIServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/ImportExportAPIServiceImpl.java
@@ -151,9 +151,19 @@ public class ImportExportAPIServiceImpl implements ImportExportAPI {
                 format, preserveStatus, preserveDocs, originalDevPortalUrl, organization, preserveCredentials);
     }
 
+    @Deprecated
     @Override
     public File exportAPI(String apiId, String revisionUUID, boolean preserveStatus, ExportFormat format,
                           boolean preserveDocs, boolean preserveCredentials, String organization)
+            throws APIManagementException, APIImportExportException {
+        return exportAPI(apiId, revisionUUID, preserveStatus, format, preserveDocs, preserveCredentials,
+                organization, false);
+    }
+
+    @Override
+    public File exportAPI(String apiId, String revisionUUID, boolean preserveStatus, ExportFormat format,
+                          boolean preserveDocs, boolean preserveCredentials, String organization,
+                          boolean requestScoped)
             throws APIManagementException, APIImportExportException {
 
         APIProvider apiProvider = RestApiCommonUtil.getLoggedInUserProvider();
@@ -168,25 +178,31 @@ public class ImportExportAPIServiceImpl implements ImportExportAPI {
         API api = apiProvider.getAPIbyUUID(revisionUUID, organization);
         api.setUuid(apiId);
         apiIdentifier.setUuid(apiId);
+        APIDTOTypeWrapper dtoWrapper;
         if (APIConstants.API_TYPE_MCP.equals(api.getType())) {
-            MCPServerDTO mcpServerDtoToReturn = APIMappingUtil.fromAPItoMCPServerDTO(api, preserveCredentials,
-                    apiProvider);
-            return ExportUtils.exportAPI(
-                    apiProvider, apiIdentifier, new APIDTOTypeWrapper(mcpServerDtoToReturn), api, userName, format,
-                    preserveStatus, preserveDocs, StringUtils.EMPTY, organization, preserveCredentials
-            );
+            dtoWrapper = new APIDTOTypeWrapper(APIMappingUtil.fromAPItoMCPServerDTO(api, preserveCredentials,
+                    apiProvider));
         } else {
-            APIDTO apiDtoToReturn = APIMappingUtil.fromAPItoDTO(api, preserveCredentials, apiProvider);
-            return ExportUtils.exportAPI(
-                    apiProvider, apiIdentifier, new APIDTOTypeWrapper(apiDtoToReturn), api, userName, format,
-                    preserveStatus, preserveDocs, StringUtils.EMPTY, organization, preserveCredentials
-            );
+            dtoWrapper = new APIDTOTypeWrapper(APIMappingUtil.fromAPItoDTO(api, preserveCredentials, apiProvider));
         }
+        return ExportUtils.exportAPI(apiProvider, apiIdentifier, dtoWrapper, api, userName, format,
+                preserveStatus, preserveDocs, StringUtils.EMPTY, organization, preserveCredentials,
+                requestScoped);
     }
 
+    @Deprecated
     @Override
     public File exportAPIProduct(String apiId, String revisionUUID, boolean preserveStatus, ExportFormat format,
                                  boolean preserveDocs, boolean preserveCredentials, String organization)
+            throws APIManagementException, APIImportExportException {
+        return exportAPIProduct(apiId, revisionUUID, preserveStatus, format, preserveDocs,
+                preserveCredentials, organization, false);
+    }
+
+    @Override
+    public File exportAPIProduct(String apiId, String revisionUUID, boolean preserveStatus,
+                                 ExportFormat format, boolean preserveDocs, boolean preserveCredentials,
+                                 String organization, boolean requestScoped)
             throws APIManagementException, APIImportExportException {
 
         APIProvider apiProvider = RestApiCommonUtil.getLoggedInUserProvider();
@@ -195,7 +211,7 @@ public class ImportExportAPIServiceImpl implements ImportExportAPI {
         APIProduct product = apiProvider.getAPIProductbyUUID(revisionUUID, organization);
         APIProductDTO apiProductDtoToReturn = APIMappingUtil.fromAPIProducttoDTO(product, preserveCredentials);
         return ExportUtils.exportApiProduct(apiProvider, apiProductIdentifier, apiProductDtoToReturn, userName,
-                format, preserveStatus, preserveDocs, preserveCredentials, organization);
+                format, preserveStatus, preserveDocs, preserveCredentials, organization, requestScoped);
     }
 
     @Override

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ExportUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ExportUtils.java
@@ -199,11 +199,57 @@ public class ExportUtils {
      * @param preserveCredentials  Preserve credentials on export
      * @return File containing the exported API artifact.
      * @throws APIManagementException If an error occurs while getting governance registry
+     * @deprecated This overload uses a shared {@code ${java.io.tmpdir}/<identifier>/} working directory and is
+     * concurrency-unsafe: concurrent exports of the same API collide on that directory and can corrupt each other's
+     * archives. Use {@link #exportAPI(APIProvider, APIIdentifier, APIDTOTypeWrapper, API, String, ExportFormat,
+     * boolean, boolean, String, String, boolean, boolean)} with {@code requestScoped = true} for
+     * concurrency-safe exports.
      */
+    @Deprecated
     public static File exportAPI(APIProvider apiProvider, APIIdentifier apiIdentifier, APIDTOTypeWrapper apiDtoToReturn,
                                  API api, String userName, ExportFormat exportFormat, boolean preserveStatus,
                                  boolean preserveDocs, String originalDevPortalUrl, String organization,
                                  boolean preserveCredentials) throws APIManagementException, APIImportExportException {
+        return exportAPI(apiProvider, apiIdentifier, apiDtoToReturn, api, userName, exportFormat, preserveStatus,
+                preserveDocs, originalDevPortalUrl, organization, preserveCredentials, false);
+    }
+
+    /**
+     * Exports an API from API Manager for a given API. Meta information, API icon, documentation,
+     * WSDL and sequences are exported.
+     * <p>
+     * When {@code requestScoped} is {@code false}, the export is assembled in the shared
+     * {@code ${java.io.tmpdir}/<identifier>/} directory and the returned archive is the stable
+     * {@code ${java.io.tmpdir}/<identifier>.zip} path (no caller cleanup required). This is concurrency-unsafe:
+     * concurrent exports of the same API share that directory.
+     * <p>
+     * When {@code requestScoped} is {@code true}, the export is assembled under a UNIQUE per-call parent so
+     * concurrent exports of the same API never collide, and the returned archive lives inside that unique parent.
+     * The CALLER owns the temp directory and must delete {@code returnedFile.getParentFile()} once the archive is
+     * consumed.
+     *
+     * @param apiProvider          API Provider
+     * @param apiIdentifier        API Identifier
+     * @param apiDtoToReturn       API DTO
+     * @param api                  API
+     * @param userName             Username
+     * @param exportFormat         Format of output documents. Can be YAML or JSON
+     * @param preserveStatus       Preserve API status on export
+     * @param preserveDocs         Preserve documentation on Export.
+     * @param originalDevPortalUrl Original DevPortal URL (redirect URL) for the original Store
+     *                             (This is used for advertise only APIs).
+     * @param organization         Organization
+     * @param preserveCredentials  Preserve credentials on export
+     * @param requestScoped If {@code true}, assemble under a unique per-call parent (caller owns cleanup);
+     *                             if {@code false}, use the shared identity-keyed temp directory (legacy behaviour).
+     * @return File containing the exported API artifact.
+     * @throws APIManagementException If an error occurs while getting governance registry
+     */
+    public static File exportAPI(APIProvider apiProvider, APIIdentifier apiIdentifier, APIDTOTypeWrapper apiDtoToReturn,
+                                 API api, String userName, ExportFormat exportFormat, boolean preserveStatus,
+                                 boolean preserveDocs, String originalDevPortalUrl, String organization,
+                                 boolean preserveCredentials, boolean requestScoped)
+            throws APIManagementException, APIImportExportException {
 
         int tenantId;
         String currentApiUuid;
@@ -219,7 +265,18 @@ public class ExportUtils {
             currentApiUuid = apiDtoToReturn.getId();
         }
 
-        File exportFolder = CommonUtil.createTempDirectory(apiIdentifier);
+        File workRoot = null;
+        File exportFolder;
+        if (requestScoped) {
+            // Assemble under a per-export UNIQUE private working root so concurrent exports of the SAME API never
+            // share a temp directory; the caller owns cleanup of the returned archive's parent.
+            workRoot = CommonUtil.createTempDirectory(null);
+            exportFolder = new File(workRoot, apiIdentifier.toString());
+            CommonUtil.createDirectory(exportFolder.getPath());
+        } else {
+            exportFolder = CommonUtil.createTempDirectory(apiIdentifier);
+        }
+        try {
         String exportAPIBasePath = exportFolder.toString();
         String archivePath = exportAPIBasePath
                 .concat(File.separator + apiIdentifier.getApiName() + "-" + apiIdentifier.getVersion());
@@ -306,8 +363,18 @@ public class ExportUtils {
                 organization, currentApiUuid);
 
         CommonUtil.archiveDirectory(exportAPIBasePath);
-        FileUtils.deleteQuietly(new File(exportAPIBasePath));
+        if (!requestScoped) {
+            FileUtils.deleteQuietly(new File(exportAPIBasePath));
+        }
         return new File(exportAPIBasePath + APIConstants.ZIP_FILE_EXTENSION);
+        } catch (APIManagementException | APIImportExportException | RuntimeException e) {
+            // Request-scoped export owns its unique temp dir; reclaim it on failure since the caller gets no
+            // File back and cannot. The shared-path (requestScoped == false) branch keeps its original behaviour.
+            if (requestScoped && workRoot != null) {
+                FileUtils.deleteQuietly(workRoot);
+            }
+            throw e;
+        }
     }
 
     /**
@@ -338,17 +405,67 @@ public class ExportUtils {
      * @param exportFormat          Format of output documents. Can be YAML or JSON
      * @param preserveStatus        Preserve API Product status on export
      * @param organization          Organization Identifier
-     * @return
+     * @return File containing the exported API Product artifact.
      * @throws APIManagementException If an error occurs while getting governance registry
+     * @deprecated This overload uses a shared {@code ${java.io.tmpdir}/<identifier>/} working directory and is
+     * concurrency-unsafe: concurrent exports of the same API Product collide on that directory and can corrupt each
+     * other's archives. Use {@link #exportApiProduct(APIProvider, APIProductIdentifier, APIProductDTO, String,
+     * ExportFormat, Boolean, boolean, boolean, String, boolean)} with {@code requestScoped = true} for
+     * concurrency-safe exports.
      */
+    @Deprecated
     public static File exportApiProduct(APIProvider apiProvider, APIProductIdentifier apiProductIdentifier,
             APIProductDTO apiProductDtoToReturn, String userName, ExportFormat exportFormat, Boolean preserveStatus,
             boolean preserveDocs, boolean preserveCredentials, String organization)
             throws APIManagementException, APIImportExportException {
+        return exportApiProduct(apiProvider, apiProductIdentifier, apiProductDtoToReturn, userName, exportFormat,
+                preserveStatus, preserveDocs, preserveCredentials, organization, false);
+    }
+
+    /**
+     * Exports an API Product from API Manager for a given API Product. MMeta information, API Product icon,
+     * documentation, client certificates and dependent APIs are exported.
+     * <p>
+     * When {@code requestScoped} is {@code false}, the export is assembled in the shared
+     * {@code ${java.io.tmpdir}/<identifier>/} directory and the returned archive is the stable
+     * {@code ${java.io.tmpdir}/<identifier>.zip} path (no caller cleanup required). This is concurrency-unsafe:
+     * concurrent exports of the same API Product share that directory.
+     * <p>
+     * When {@code requestScoped} is {@code true}, the export is assembled under a UNIQUE per-call parent so
+     * concurrent exports of the same API Product never collide, and the returned archive lives inside that unique
+     * parent. The CALLER owns the temp directory and must delete {@code returnedFile.getParentFile()} once consumed.
+     *
+     * @param apiProvider           API Provider
+     * @param apiProductIdentifier  API Product Identifier
+     * @param apiProductDtoToReturn API Product DTO
+     * @param userName              Username
+     * @param exportFormat          Format of output documents. Can be YAML or JSON
+     * @param preserveStatus        Preserve API Product status on export
+     * @param organization          Organization Identifier
+     * @param requestScoped  If {@code true}, assemble under a unique per-call parent (caller owns cleanup);
+     *                              if {@code false}, use the shared identity-keyed temp directory (legacy behaviour).
+     * @return File containing the exported API Product artifact.
+     * @throws APIManagementException If an error occurs while getting governance registry
+     */
+    public static File exportApiProduct(APIProvider apiProvider, APIProductIdentifier apiProductIdentifier,
+            APIProductDTO apiProductDtoToReturn, String userName, ExportFormat exportFormat, Boolean preserveStatus,
+            boolean preserveDocs, boolean preserveCredentials, String organization, boolean requestScoped)
+            throws APIManagementException, APIImportExportException {
 
         int tenantId = 0;
         // Create temp location for storing API Product data
-        File exportFolder = CommonUtil.createTempDirectory(apiProductIdentifier);
+        File workRoot = null;
+        File exportFolder;
+        if (requestScoped) {
+            // Assemble under a per-export UNIQUE private working root so concurrent exports of the SAME product never
+            // share a temp directory; the caller owns cleanup of the returned archive's parent.
+            workRoot = CommonUtil.createTempDirectory(null);
+            exportFolder = new File(workRoot, apiProductIdentifier.toString());
+            CommonUtil.createDirectory(exportFolder.getPath());
+        } else {
+            exportFolder = CommonUtil.createTempDirectory(apiProductIdentifier);
+        }
+        try {
         String exportAPIBasePath = exportFolder.toString();
         String archivePath = exportAPIBasePath
                 .concat(File.separator + apiProductIdentifier.getName() + "-" + apiProductIdentifier.getVersion());
@@ -380,8 +497,18 @@ public class ExportUtils {
                 organization);
 
         CommonUtil.archiveDirectory(exportAPIBasePath);
-        FileUtils.deleteQuietly(new File(exportAPIBasePath));
+        if (!requestScoped) {
+            FileUtils.deleteQuietly(new File(exportAPIBasePath));
+        }
         return new File(exportAPIBasePath + APIConstants.ZIP_FILE_EXTENSION);
+        } catch (APIManagementException | APIImportExportException | RuntimeException e) {
+            // Request-scoped export owns its unique temp dir; reclaim it on failure since the caller gets no
+            // File back and cannot. The shared-path (requestScoped == false) branch keeps its original behaviour.
+            if (requestScoped && workRoot != null) {
+                FileUtils.deleteQuietly(workRoot);
+            }
+            throw e;
+        }
     }
 
     /**

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt</artifactId>
-        <version>9.33.163-SNAPSHOT</version>
+        <version>9.33.163</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt</artifactId>
-        <version>9.33.163</version>
+        <version>9.33.164-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/utils/RestApiPublisherUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/utils/RestApiPublisherUtils.java
@@ -318,15 +318,56 @@ public class RestApiPublisherUtils {
         }
     }
 
+    /**
+     * Exports operation-policy data.
+     *
+     * @deprecated This overload uses a shared identity-keyed temp directory and is concurrency-unsafe: concurrent
+     * exports of the same operation policy can corrupt each other's archives. Use
+     * {@link #exportOperationPolicyData(OperationPolicyData, String, boolean)} with
+     * {@code requestScoped = true} for concurrency-safe exports.
+     */
+    @Deprecated
     public static File exportOperationPolicyData(OperationPolicyData policyData, String format)
             throws APIManagementException {
+        return exportOperationPolicyData(policyData, format, false);
+    }
+
+    /**
+     * Exports operation-policy data.
+     * <p>
+     * When {@code requestScoped} is {@code false}, the export is assembled in the shared identity-keyed temp
+     * directory and the returned archive is the stable {@code ${java.io.tmpdir}/<name>_<version>.zip} path (no caller
+     * cleanup required). This is concurrency-unsafe: concurrent exports of the same policy share that directory.
+     * <p>
+     * When {@code requestScoped} is {@code true}, the export is assembled under a UNIQUE per-call parent so
+     * concurrent exports of the same policy never collide, and the returned archive lives inside that unique parent.
+     * The CALLER owns the temp directory and must delete {@code returnedFile.getParentFile()} once consumed.
+     *
+     * @param policyData           the operation-policy data to export
+     * @param format               format of the exported policy specification (YAML or JSON)
+     * @param requestScoped If {@code true}, assemble under a unique per-call parent (caller owns cleanup);
+     *                             if {@code false}, use the shared identity-keyed temp directory (legacy behaviour).
+     * @return archive containing the operation-policy
+     * @throws APIManagementException if the export fails
+     */
+    public static File exportOperationPolicyData(OperationPolicyData policyData, String format,
+            boolean requestScoped) throws APIManagementException {
 
         File exportFolder = null;
         try {
             String sanitizedPolicyName = policyData.getSpecification().getName()
                     .replaceAll(APIConstants.POLICY_FILENAME_INVALID_CHARS_REGEX, "");
-            exportFolder = CommonUtil.createTempDirectoryFromName(sanitizedPolicyName + "_" +
-                    policyData.getSpecification().getVersion());
+            if (requestScoped) {
+                // Assemble under a per-export UNIQUE private working root so concurrent exports of the SAME policy
+                // never share a temp directory; the caller owns cleanup of the returned archive's parent.
+                String policyDirName = sanitizedPolicyName + "_" + policyData.getSpecification().getVersion();
+                File workRoot = CommonUtil.createTempDirectory(null);
+                exportFolder = new File(workRoot, policyDirName);
+                CommonUtil.createDirectory(exportFolder.getPath());
+            } else {
+                exportFolder = CommonUtil.createTempDirectoryFromName(sanitizedPolicyName + "_" +
+                        policyData.getSpecification().getVersion());
+            }
             String exportAPIBasePath = exportFolder.toString();
             String archivePath = exportAPIBasePath.concat(File.separator + sanitizedPolicyName);
             CommonUtil.createDirectory(archivePath);
@@ -352,9 +393,16 @@ public class RestApiPublisherUtils {
             }
 
             CommonUtil.archiveDirectory(exportAPIBasePath);
-            FileUtils.deleteQuietly(new File(exportAPIBasePath));
+            if (!requestScoped) {
+                FileUtils.deleteQuietly(new File(exportAPIBasePath));
+            }
             return new File(exportAPIBasePath + APIConstants.ZIP_FILE_EXTENSION);
         } catch (APIImportExportException | IOException e) {
+            // Request-scoped export owns its unique temp dir (exportFolder's parent); reclaim it on failure since
+            // the caller gets no File back. The shared-path (requestScoped == false) branch is left untouched.
+            if (requestScoped && exportFolder != null) {
+                FileUtils.deleteQuietly(exportFolder.getParentFile());
+            }
             throw new APIManagementException("Error while exporting operation policy", e);
         }
     }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/test/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/utils/RestApiPublisherUtilsExportRaceTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/test/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/utils/RestApiPublisherUtilsExportRaceTest.java
@@ -1,0 +1,208 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.wso2.carbon.apimgt.rest.api.publisher.v1.utils;
+
+import org.junit.Test;
+import org.wso2.carbon.apimgt.api.model.OperationPolicyData;
+import org.wso2.carbon.apimgt.api.model.OperationPolicyDefinition;
+import org.wso2.carbon.apimgt.api.model.OperationPolicySpecification;
+
+import java.io.File;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * Regression test for the concurrent operation-policy export race, validating PER-INVOCATION CONTENT.
+ * <p>
+ * Many threads export the SAME policy identity ({@code name_version}) concurrently but each with DISTINCT
+ * content (a unique marker embedded in the definition) via the request-scoped
+ * {@link RestApiPublisherUtils#exportOperationPolicyData(OperationPolicyData, String, boolean)} with
+ * {@code requestScoped = true}. Each invocation must get back its OWN,
+ * complete archive carrying ITS marker.
+ * <p>
+ * With the per-request fix (each export in its own private working root) this passes. Against the shared,
+ * identity-keyed publish (the old {@code exportOperationPolicyData} / pre-fix behaviour), concurrent exports
+ * overwrite the one {@code ${tmpdir}/<name>_<version>.zip} file, so a thread reads a sibling's content — the
+ * marker assertion then fails, which is exactly the cross-contamination this test guards against.
+ */
+public class RestApiPublisherUtilsExportRaceTest {
+
+    private static final String POLICY_NAME = "RaceTestPolicy";
+    private static final String POLICY_VERSION = "v1";
+    private static final int THREADS = 16;
+    private static final int ROUNDS = 6;
+
+    @Test(timeout = 120000)
+    public void concurrentSamePolicyExportsPreservePerInvocationContent() throws Exception {
+
+        for (int round = 0; round < ROUNDS; round++) {
+            ExecutorService pool = Executors.newFixedThreadPool(THREADS);
+            CountDownLatch startGate = new CountDownLatch(1);
+            List<Future<Export>> futures = new ArrayList<>();
+            for (int i = 0; i < THREADS; i++) {
+                final String marker = "PAYLOAD-MARKER-r" + round + "-t" + i + "-UNIQUE";
+                futures.add(pool.submit((Callable<Export>) () -> {
+                    startGate.await();
+                    OperationPolicyData policyData = buildPolicyData(marker);
+                    File archive = RestApiPublisherUtils.exportOperationPolicyData(policyData, "YAML", true);
+                    return new Export(marker, archive);
+                }));
+            }
+            // Release every thread at once so they contend for the same policy identity simultaneously.
+            startGate.countDown();
+
+            List<Export> exports = new ArrayList<>();
+            for (Future<Export> future : futures) {
+                try {
+                    exports.add(future.get());
+                } catch (Exception e) {
+                    pool.shutdownNow();
+                    fail("A concurrent export failed (round " + round + "): " + rootCause(e));
+                }
+            }
+            pool.shutdown();
+            pool.awaitTermination(30, TimeUnit.SECONDS);
+
+            try {
+                for (Export export : exports) {
+                    File archive = export.archive;
+                    assertTrue("Exported archive is missing or empty: " + archive,
+                            archive != null && archive.isFile() && archive.length() > 0);
+                    assertTrue("Exported archive is corrupt/incomplete - policy specification entry missing: "
+                                    + archive,
+                            zipContainsEntrySuffix(archive, ".yaml"));
+                    // Per-invocation content: each archive must carry ITS OWN payload marker, never a sibling's.
+                    assertTrue("Cross-contamination: archive " + archive + " does not contain its own payload marker "
+                                    + export.marker,
+                            zipContainsText(archive, export.marker));
+                }
+            } finally {
+                // The per-request method hands back an archive under a caller-owned unique parent; delete it.
+                for (Export export : exports) {
+                    if (export.archive != null) {
+                        deleteRecursively(export.archive.getParentFile());
+                    }
+                }
+            }
+        }
+    }
+
+    private OperationPolicyData buildPolicyData(String marker) {
+
+        OperationPolicySpecification specification = new OperationPolicySpecification();
+        specification.setName(POLICY_NAME);
+        specification.setVersion(POLICY_VERSION);
+        specification.setDisplayName(POLICY_NAME);
+        specification.setDescription("policy used by the concurrent-export race regression test");
+
+        // Distinct, sizeable definition per invocation: the unique marker plus bulk to widen the write/zip window.
+        StringBuilder content = new StringBuilder();
+        content.append("<marker>").append(marker).append("</marker>\n");
+        for (int i = 0; i < 8000; i++) {
+            content.append("<sequence>").append(marker).append("-line-").append(i).append("</sequence>\n");
+        }
+        OperationPolicyDefinition synapseDefinition = new OperationPolicyDefinition();
+        synapseDefinition.setContent(content.toString());
+
+        OperationPolicyData policyData = new OperationPolicyData();
+        policyData.setSpecification(specification);
+        policyData.setSynapsePolicyDefinition(synapseDefinition);
+        return policyData;
+    }
+
+    private static boolean zipContainsEntrySuffix(File zip, String suffix) {
+        try (ZipFile zipFile = new ZipFile(zip)) {
+            Enumeration<? extends ZipEntry> entries = zipFile.entries();
+            while (entries.hasMoreElements()) {
+                if (entries.nextElement().getName().endsWith(suffix)) {
+                    return true;
+                }
+            }
+            return false;
+        } catch (Exception e) {
+            // A ZipException here means the archive was truncated/overwritten by a concurrent export.
+            return false;
+        }
+    }
+
+    private static boolean zipContainsText(File zip, String text) {
+        try (ZipFile zipFile = new ZipFile(zip)) {
+            Enumeration<? extends ZipEntry> entries = zipFile.entries();
+            while (entries.hasMoreElements()) {
+                ZipEntry entry = entries.nextElement();
+                if (entry.isDirectory()) {
+                    continue;
+                }
+                try (InputStream in = zipFile.getInputStream(entry)) {
+                    String content = new String(in.readAllBytes(), StandardCharsets.UTF_8);
+                    if (content.contains(text)) {
+                        return true;
+                    }
+                }
+            }
+            return false;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    private static Throwable rootCause(Throwable throwable) {
+        Throwable cause = throwable;
+        while (cause.getCause() != null && cause.getCause() != cause) {
+            cause = cause.getCause();
+        }
+        return cause;
+    }
+
+    private static void deleteRecursively(File file) {
+        if (file == null || !file.exists()) {
+            return;
+        }
+        File[] children = file.listFiles();
+        if (children != null) {
+            for (File child : children) {
+                deleteRecursively(child);
+            }
+        }
+        file.delete();
+    }
+
+    /** Pairs an invocation's unique payload marker with the archive it produced. */
+    private static final class Export {
+        private final String marker;
+        private final File archive;
+
+        private Export(String marker, File archive) {
+            this.marker = marker;
+            this.archive = archive;
+        }
+    }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.service.catalog/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.service.catalog/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt</artifactId>
-        <version>9.33.163-SNAPSHOT</version>
+        <version>9.33.163</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.service.catalog/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.service.catalog/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt</artifactId>
-        <version>9.33.163</version>
+        <version>9.33.164-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt</artifactId>
-        <version>9.33.163-SNAPSHOT</version>
+        <version>9.33.163</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt</artifactId>
-        <version>9.33.163</version>
+        <version>9.33.164-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.util/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.util/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt</artifactId>
-        <version>9.33.163-SNAPSHOT</version>
+        <version>9.33.163</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.util/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.util/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt</artifactId>
-        <version>9.33.163</version>
+        <version>9.33.164-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/apimgt/org.wso2.carbon.apimgt.solace/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.solace/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>apimgt</artifactId>
         <groupId>org.wso2.carbon.apimgt</groupId>
-        <version>9.33.163-SNAPSHOT</version>
+        <version>9.33.163</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/apimgt/org.wso2.carbon.apimgt.solace/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.solace/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>apimgt</artifactId>
         <groupId>org.wso2.carbon.apimgt</groupId>
-        <version>9.33.163</version>
+        <version>9.33.164-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/apimgt/org.wso2.carbon.apimgt.spec.parser/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.spec.parser/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt</artifactId>
-        <version>9.33.163-SNAPSHOT</version>
+        <version>9.33.163</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/apimgt/org.wso2.carbon.apimgt.spec.parser/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.spec.parser/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt</artifactId>
-        <version>9.33.163</version>
+        <version>9.33.164-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/apimgt/org.wso2.carbon.apimgt.throttle.policy.deployer/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.throttle.policy.deployer/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>apimgt</artifactId>
         <groupId>org.wso2.carbon.apimgt</groupId>
-        <version>9.33.163</version>
+        <version>9.33.164-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>bundle</packaging>

--- a/components/apimgt/org.wso2.carbon.apimgt.throttle.policy.deployer/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.throttle.policy.deployer/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>apimgt</artifactId>
         <groupId>org.wso2.carbon.apimgt</groupId>
-        <version>9.33.163-SNAPSHOT</version>
+        <version>9.33.163</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>bundle</packaging>

--- a/components/apimgt/org.wso2.carbon.apimgt.throttling.siddhi.extension/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.throttling.siddhi.extension/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt</artifactId>
-        <version>9.33.163-SNAPSHOT</version>
+        <version>9.33.163</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/apimgt/org.wso2.carbon.apimgt.throttling.siddhi.extension/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.throttling.siddhi.extension/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt</artifactId>
-        <version>9.33.163</version>
+        <version>9.33.164-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/apimgt/org.wso2.carbon.apimgt.tokenmgt/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.tokenmgt/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt</artifactId>
-        <version>9.33.163-SNAPSHOT</version>
+        <version>9.33.163</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/apimgt/org.wso2.carbon.apimgt.tokenmgt/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.tokenmgt/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt</artifactId>
-        <version>9.33.163</version>
+        <version>9.33.164-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/apimgt/org.wso2.carbon.apimgt.tracing/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.tracing/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt</artifactId>
-        <version>9.33.163</version>
+        <version>9.33.164-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/apimgt/org.wso2.carbon.apimgt.tracing/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.tracing/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt</artifactId>
-        <version>9.33.163-SNAPSHOT</version>
+        <version>9.33.163</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/apimgt/pom.xml
+++ b/components/apimgt/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>carbon-apimgt</artifactId>
-        <version>9.33.163-SNAPSHOT</version>
+        <version>9.33.163</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/apimgt/pom.xml
+++ b/components/apimgt/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>carbon-apimgt</artifactId>
-        <version>9.33.163</version>
+        <version>9.33.164-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/apimgt/samples/org.wso2.carbon.apimgt.samples.calculator/pom.xml
+++ b/components/apimgt/samples/org.wso2.carbon.apimgt.samples.calculator/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>apimgt</artifactId>
         <groupId>org.wso2.carbon.apimgt</groupId>
-        <version>9.33.163-SNAPSHOT</version>
+        <version>9.33.163</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/apimgt/samples/org.wso2.carbon.apimgt.samples.calculator/pom.xml
+++ b/components/apimgt/samples/org.wso2.carbon.apimgt.samples.calculator/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>apimgt</artifactId>
         <groupId>org.wso2.carbon.apimgt</groupId>
-        <version>9.33.163</version>
+        <version>9.33.164-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/apimgt/samples/org.wso2.carbon.apimgt.samples.pizzashack/pom.xml
+++ b/components/apimgt/samples/org.wso2.carbon.apimgt.samples.pizzashack/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apimgt</artifactId>
         <groupId>org.wso2.carbon.apimgt</groupId>
-        <version>9.33.163</version>
+        <version>9.33.164-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/apimgt/samples/org.wso2.carbon.apimgt.samples.pizzashack/pom.xml
+++ b/components/apimgt/samples/org.wso2.carbon.apimgt.samples.pizzashack/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apimgt</artifactId>
         <groupId>org.wso2.carbon.apimgt</groupId>
-        <version>9.33.163-SNAPSHOT</version>
+        <version>9.33.163</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/encryption/org.wso2.carbon.apimgt.encryption.key.generator/pom.xml
+++ b/components/encryption/org.wso2.carbon.apimgt.encryption.key.generator/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>encryption</artifactId>
-        <version>9.33.163-SNAPSHOT</version>
+        <version>9.33.163</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/encryption/org.wso2.carbon.apimgt.encryption.key.generator/pom.xml
+++ b/components/encryption/org.wso2.carbon.apimgt.encryption.key.generator/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>encryption</artifactId>
-        <version>9.33.163</version>
+        <version>9.33.164-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/encryption/pom.xml
+++ b/components/encryption/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>carbon-apimgt</artifactId>
-        <version>9.33.163-SNAPSHOT</version>
+        <version>9.33.163</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/encryption/pom.xml
+++ b/components/encryption/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>carbon-apimgt</artifactId>
-        <version>9.33.163</version>
+        <version>9.33.164-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/governance/org.wso2.carbon.apimgt.governance.engine/pom.xml
+++ b/components/governance/org.wso2.carbon.apimgt.governance.engine/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>governance</artifactId>
-        <version>9.33.163</version>
+        <version>9.33.164-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/governance/org.wso2.carbon.apimgt.governance.engine/pom.xml
+++ b/components/governance/org.wso2.carbon.apimgt.governance.engine/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>governance</artifactId>
-        <version>9.33.163-SNAPSHOT</version>
+        <version>9.33.163</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/governance/pom.xml
+++ b/components/governance/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>carbon-apimgt</artifactId>
-        <version>9.33.163-SNAPSHOT</version>
+        <version>9.33.163</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/governance/pom.xml
+++ b/components/governance/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>carbon-apimgt</artifactId>
-        <version>9.33.163</version>
+        <version>9.33.164-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/features/apimgt/org.wso2.carbon.apimgt.cache.invalidation.feature/pom.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.cache.invalidation.feature/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt-feature</artifactId>
-        <version>9.33.163</version>
+        <version>9.33.164-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/apimgt/org.wso2.carbon.apimgt.cache.invalidation.feature/pom.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.cache.invalidation.feature/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt-feature</artifactId>
-        <version>9.33.163-SNAPSHOT</version>
+        <version>9.33.163</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/apimgt/org.wso2.carbon.apimgt.core.feature/pom.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.core.feature/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt-feature</artifactId>
-        <version>9.33.163</version>
+        <version>9.33.164-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/apimgt/org.wso2.carbon.apimgt.core.feature/pom.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.core.feature/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt-feature</artifactId>
-        <version>9.33.163-SNAPSHOT</version>
+        <version>9.33.163</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/apimgt/org.wso2.carbon.apimgt.eventing.feature/pom.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.eventing.feature/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apimgt-feature</artifactId>
         <groupId>org.wso2.carbon.apimgt</groupId>
-        <version>9.33.163-SNAPSHOT</version>
+        <version>9.33.163</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/apimgt/org.wso2.carbon.apimgt.eventing.feature/pom.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.eventing.feature/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apimgt-feature</artifactId>
         <groupId>org.wso2.carbon.apimgt</groupId>
-        <version>9.33.163</version>
+        <version>9.33.164-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/apimgt/org.wso2.carbon.apimgt.eventing.hub.feature/pom.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.eventing.hub.feature/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apimgt-feature</artifactId>
         <groupId>org.wso2.carbon.apimgt</groupId>
-        <version>9.33.163-SNAPSHOT</version>
+        <version>9.33.163</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/apimgt/org.wso2.carbon.apimgt.eventing.hub.feature/pom.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.eventing.hub.feature/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apimgt-feature</artifactId>
         <groupId>org.wso2.carbon.apimgt</groupId>
-        <version>9.33.163</version>
+        <version>9.33.164-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/apimgt/org.wso2.carbon.apimgt.feature/pom.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.feature/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt-feature</artifactId>
-        <version>9.33.163</version>
+        <version>9.33.164-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/apimgt/org.wso2.carbon.apimgt.feature/pom.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.feature/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt-feature</artifactId>
-        <version>9.33.163-SNAPSHOT</version>
+        <version>9.33.163</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/apimgt/org.wso2.carbon.apimgt.federated.gateway.feature/pom.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.federated.gateway.feature/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>carbon-apimgt</artifactId>
-        <version>9.33.163-SNAPSHOT</version>
+        <version>9.33.163</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
 

--- a/features/apimgt/org.wso2.carbon.apimgt.federated.gateway.feature/pom.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.federated.gateway.feature/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>carbon-apimgt</artifactId>
-        <version>9.33.163</version>
+        <version>9.33.164-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
 

--- a/features/apimgt/org.wso2.carbon.apimgt.gateway.feature/pom.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.gateway.feature/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt-feature</artifactId>
-        <version>9.33.163</version>
+        <version>9.33.164-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/apimgt/org.wso2.carbon.apimgt.gateway.feature/pom.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.gateway.feature/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt-feature</artifactId>
-        <version>9.33.163-SNAPSHOT</version>
+        <version>9.33.163</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/apimgt/org.wso2.carbon.apimgt.governance.feature/pom.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.governance.feature/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>carbon-apimgt</artifactId>
-        <version>9.33.163</version>
+        <version>9.33.164-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
 

--- a/features/apimgt/org.wso2.carbon.apimgt.governance.feature/pom.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.governance.feature/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>carbon-apimgt</artifactId>
-        <version>9.33.163-SNAPSHOT</version>
+        <version>9.33.163</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
 

--- a/features/apimgt/org.wso2.carbon.apimgt.internal.service.feature/pom.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.internal.service.feature/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt-feature</artifactId>
-        <version>9.33.163</version>
+        <version>9.33.164-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/apimgt/org.wso2.carbon.apimgt.internal.service.feature/pom.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.internal.service.feature/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt-feature</artifactId>
-        <version>9.33.163-SNAPSHOT</version>
+        <version>9.33.163</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/apimgt/org.wso2.carbon.apimgt.jms.listener.feature/pom.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.jms.listener.feature/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt-feature</artifactId>
-        <version>9.33.163</version>
+        <version>9.33.164-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/apimgt/org.wso2.carbon.apimgt.jms.listener.feature/pom.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.jms.listener.feature/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt-feature</artifactId>
-        <version>9.33.163-SNAPSHOT</version>
+        <version>9.33.163</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/apimgt/org.wso2.carbon.apimgt.keymanager.feature/pom.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.keymanager.feature/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt-feature</artifactId>
-        <version>9.33.163</version>
+        <version>9.33.164-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/apimgt/org.wso2.carbon.apimgt.keymanager.feature/pom.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.keymanager.feature/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt-feature</artifactId>
-        <version>9.33.163-SNAPSHOT</version>
+        <version>9.33.163</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/apimgt/org.wso2.carbon.apimgt.multitenant.auth.feature/pom.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.multitenant.auth.feature/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt-feature</artifactId>
-        <version>9.33.163</version>
+        <version>9.33.164-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/apimgt/org.wso2.carbon.apimgt.multitenant.auth.feature/pom.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.multitenant.auth.feature/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt-feature</artifactId>
-        <version>9.33.163-SNAPSHOT</version>
+        <version>9.33.163</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/apimgt/org.wso2.carbon.apimgt.persistence.feature/pom.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.persistence.feature/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt-feature</artifactId>
-        <version>9.33.163</version>
+        <version>9.33.164-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/apimgt/org.wso2.carbon.apimgt.persistence.feature/pom.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.persistence.feature/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt-feature</artifactId>
-        <version>9.33.163-SNAPSHOT</version>
+        <version>9.33.163</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/apimgt/org.wso2.carbon.apimgt.rest.api.admin.feature/pom.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.rest.api.admin.feature/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt-feature</artifactId>
-        <version>9.33.163-SNAPSHOT</version>
+        <version>9.33.163</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/apimgt/org.wso2.carbon.apimgt.rest.api.admin.feature/pom.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.rest.api.admin.feature/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt-feature</artifactId>
-        <version>9.33.163</version>
+        <version>9.33.164-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/apimgt/org.wso2.carbon.apimgt.rest.api.dcr.feature/pom.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.rest.api.dcr.feature/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt-feature</artifactId>
-        <version>9.33.163-SNAPSHOT</version>
+        <version>9.33.163</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/apimgt/org.wso2.carbon.apimgt.rest.api.dcr.feature/pom.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.rest.api.dcr.feature/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt-feature</artifactId>
-        <version>9.33.163</version>
+        <version>9.33.164-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/apimgt/org.wso2.carbon.apimgt.rest.api.devops.feature/pom.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.rest.api.devops.feature/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt-feature</artifactId>
-        <version>9.33.163-SNAPSHOT</version>
+        <version>9.33.163</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/apimgt/org.wso2.carbon.apimgt.rest.api.devops.feature/pom.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.rest.api.devops.feature/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt-feature</artifactId>
-        <version>9.33.163</version>
+        <version>9.33.164-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/apimgt/org.wso2.carbon.apimgt.rest.api.gateway.feature/pom.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.rest.api.gateway.feature/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt-feature</artifactId>
-        <version>9.33.163-SNAPSHOT</version>
+        <version>9.33.163</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/apimgt/org.wso2.carbon.apimgt.rest.api.gateway.feature/pom.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.rest.api.gateway.feature/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt-feature</artifactId>
-        <version>9.33.163</version>
+        <version>9.33.164-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.feature/pom.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.feature/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt-feature</artifactId>
-        <version>9.33.163-SNAPSHOT</version>
+        <version>9.33.163</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.feature/pom.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.feature/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt-feature</artifactId>
-        <version>9.33.163</version>
+        <version>9.33.164-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/apimgt/org.wso2.carbon.apimgt.rest.api.service.catalog.feature/pom.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.rest.api.service.catalog.feature/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt-feature</artifactId>
-        <version>9.33.163-SNAPSHOT</version>
+        <version>9.33.163</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/apimgt/org.wso2.carbon.apimgt.rest.api.service.catalog.feature/pom.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.rest.api.service.catalog.feature/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt-feature</artifactId>
-        <version>9.33.163</version>
+        <version>9.33.164-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/apimgt/org.wso2.carbon.apimgt.rest.api.store.feature/pom.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.rest.api.store.feature/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt-feature</artifactId>
-        <version>9.33.163-SNAPSHOT</version>
+        <version>9.33.163</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/apimgt/org.wso2.carbon.apimgt.rest.api.store.feature/pom.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.rest.api.store.feature/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt-feature</artifactId>
-        <version>9.33.163</version>
+        <version>9.33.164-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/apimgt/org.wso2.carbon.apimgt.scxml.feature/pom.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.scxml.feature/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt-feature</artifactId>
-        <version>9.33.163</version>
+        <version>9.33.164-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/apimgt/org.wso2.carbon.apimgt.scxml.feature/pom.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.scxml.feature/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt-feature</artifactId>
-        <version>9.33.163-SNAPSHOT</version>
+        <version>9.33.163</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/apimgt/org.wso2.carbon.apimgt.throttle.policy.deployer.feature/pom.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.throttle.policy.deployer.feature/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt-feature</artifactId>
-        <version>9.33.163</version>
+        <version>9.33.164-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/apimgt/org.wso2.carbon.apimgt.throttle.policy.deployer.feature/pom.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.throttle.policy.deployer.feature/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt-feature</artifactId>
-        <version>9.33.163-SNAPSHOT</version>
+        <version>9.33.163</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/apimgt/org.wso2.carbon.apimgt.throttling.siddhi.extension.feature/pom.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.throttling.siddhi.extension.feature/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt-feature</artifactId>
-        <version>9.33.163</version>
+        <version>9.33.164-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/apimgt/org.wso2.carbon.apimgt.throttling.siddhi.extension.feature/pom.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.throttling.siddhi.extension.feature/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt-feature</artifactId>
-        <version>9.33.163-SNAPSHOT</version>
+        <version>9.33.163</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/apimgt/org.wso2.carbon.apimgt.tokenmgt.feature/pom.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.tokenmgt.feature/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt-feature</artifactId>
-        <version>9.33.163</version>
+        <version>9.33.164-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/apimgt/org.wso2.carbon.apimgt.tokenmgt.feature/pom.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.tokenmgt.feature/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt-feature</artifactId>
-        <version>9.33.163-SNAPSHOT</version>
+        <version>9.33.163</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/apimgt/org.wso2.carbon.apimgt.tracing.feature/pom.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.tracing.feature/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apimgt-feature</artifactId>
         <groupId>org.wso2.carbon.apimgt</groupId>
-        <version>9.33.163</version>
+        <version>9.33.164-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/features/apimgt/org.wso2.carbon.apimgt.tracing.feature/pom.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.tracing.feature/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apimgt-feature</artifactId>
         <groupId>org.wso2.carbon.apimgt</groupId>
-        <version>9.33.163-SNAPSHOT</version>
+        <version>9.33.163</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/features/apimgt/pom.xml
+++ b/features/apimgt/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>carbon-apimgt</artifactId>
-        <version>9.33.163-SNAPSHOT</version>
+        <version>9.33.163</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/features/apimgt/pom.xml
+++ b/features/apimgt/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>carbon-apimgt</artifactId>
-        <version>9.33.163</version>
+        <version>9.33.164-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.wso2.carbon.apimgt</groupId>
     <artifactId>carbon-apimgt</artifactId>
     <packaging>pom</packaging>
-    <version>9.33.163-SNAPSHOT</version>
+    <version>9.33.163</version>
     <name>WSO2 Carbon - API Management Aggregator POM</name>
     <url>https://wso2.org</url>
 
@@ -21,7 +21,7 @@
         <url>https://github.com/wso2/carbon-apimgt.git</url>
         <developerConnection>scm:git:https://github.com/wso2/carbon-apimgt.git</developerConnection>
         <connection>scm:git:https://github.com/wso2/carbon-apimgt.git</connection>
-        <tag>HEAD</tag>
+        <tag>v9.33.163</tag>
     </scm>
 
     <modules>
@@ -2094,7 +2094,7 @@
 
         <!-- APIM Component Version -->
         <hamcrest.version>1.3</hamcrest.version>
-        <carbon.apimgt.version>9.33.163-SNAPSHOT</carbon.apimgt.version>
+        <carbon.apimgt.version>9.33.163</carbon.apimgt.version>
         <carbon.apimgt.imp.pkg.version>[9.0.0, 10.0.0)</carbon.apimgt.imp.pkg.version>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.wso2.carbon.apimgt</groupId>
     <artifactId>carbon-apimgt</artifactId>
     <packaging>pom</packaging>
-    <version>9.33.163</version>
+    <version>9.33.164-SNAPSHOT</version>
     <name>WSO2 Carbon - API Management Aggregator POM</name>
     <url>https://wso2.org</url>
 
@@ -21,7 +21,7 @@
         <url>https://github.com/wso2/carbon-apimgt.git</url>
         <developerConnection>scm:git:https://github.com/wso2/carbon-apimgt.git</developerConnection>
         <connection>scm:git:https://github.com/wso2/carbon-apimgt.git</connection>
-        <tag>v9.33.163</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <modules>
@@ -2094,7 +2094,7 @@
 
         <!-- APIM Component Version -->
         <hamcrest.version>1.3</hamcrest.version>
-        <carbon.apimgt.version>9.33.163</carbon.apimgt.version>
+        <carbon.apimgt.version>9.33.164-SNAPSHOT</carbon.apimgt.version>
         <carbon.apimgt.imp.pkg.version>[9.0.0, 10.0.0)</carbon.apimgt.imp.pkg.version>
 
 

--- a/service-stubs/apimgt/org.wso2.carbon.apimgt.keymgt.stub/pom.xml
+++ b/service-stubs/apimgt/org.wso2.carbon.apimgt.keymgt.stub/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt-stubs</artifactId>
-        <version>9.33.163-SNAPSHOT</version>
+        <version>9.33.163</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/service-stubs/apimgt/org.wso2.carbon.apimgt.keymgt.stub/pom.xml
+++ b/service-stubs/apimgt/org.wso2.carbon.apimgt.keymgt.stub/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt-stubs</artifactId>
-        <version>9.33.163</version>
+        <version>9.33.164-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/service-stubs/apimgt/pom.xml
+++ b/service-stubs/apimgt/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>carbon-apimgt</artifactId>
-        <version>9.33.163-SNAPSHOT</version>
+        <version>9.33.163</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/service-stubs/apimgt/pom.xml
+++ b/service-stubs/apimgt/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>carbon-apimgt</artifactId>
-        <version>9.33.163</version>
+        <version>9.33.164-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
## Description

This pull request improves the way temporary directories are created during export operations to prevent conflicts and data corruption when multiple exports of the same artifact occur concurrently. The main change is to nest each export's working directory under a unique random parent directory, ensuring that concurrent exports do not interfere with each other while preserving the expected output filenames.

**Improvements to temporary directory creation for exports:**

* Updated `createTempDirectory` in `CommonUtil.java` to nest the identifier-named directory under a unique random parent directory, preventing concurrent exports of the same artifact from sharing a temp directory and corrupting archives.
* Updated `createTempDirectoryFromName` in `CommonUtil.java` to use the same random parent directory approach for named directories, ensuring safe concurrent exports.
* Updated `createTempApplicationDirectory` in `ExportUtils.java` to nest the application export directory under a unique random parent, preventing conflicts during concurrent exports of the same application.

**Dependency update:**

* Added import for `RandomStringUtils` in `ExportUtils.java` to support generation of random directory names.