### PR TITLE
Fix API document deletion to remove content and metadata

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/RegistryPersistenceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/RegistryPersistenceImpl.java
@@ -2985,9 +2985,10 @@ public class RegistryPersistenceImpl implements APIPersistence {
                 }
             } catch (RegistryException ex) {
                 log.error("Error while rolling back the transaction for documentation delete of API: " + apiId, ex);
-            }
-            if (isTenantFlowStarted) {
-                PrivilegedCarbonContext.endTenantFlow();
+            } finally {
+                if (isTenantFlowStarted) {
+                    PrivilegedCarbonContext.endTenantFlow();
+                }
             }
         }
     }

--- a/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/RegistryPersistenceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/RegistryPersistenceImpl.java
@@ -2990,15 +2990,26 @@ public class RegistryPersistenceImpl implements APIPersistence {
         Documentation documentation = RegistryPersistenceDocUtil.getDocumentation(artifact);
         if (documentation.getSourceType().equals(Documentation.DocumentSourceType.FILE)) {
             String resource = documentation.getFilePath();
-            if (resource != null) {
-                String[] resourceSplitPath = resource.split(RegistryConstants.GOVERNANCE_REGISTRY_BASE_PATH);
-                if (resourceSplitPath.length == 2 && registry.resourceExists(resourceSplitPath[1])) {
+            if (resource == null) {
+                throw new DocumentationPersistenceException("Invalid resource Path " + resource);
+            }
+
+            String[] resourceSplitPath = resource.split(RegistryConstants.GOVERNANCE_REGISTRY_BASE_PATH);
+            if (resourceSplitPath.length == 2) {
+                if (registry.resourceExists(resourceSplitPath[1])) {
                     registry.delete(resourceSplitPath[1]);
                 }
+            } else {
+                throw new DocumentationPersistenceException("Invalid resource Path " + resource);
             }
         } else if (documentation.getSourceType().equals(Documentation.DocumentSourceType.INLINE)
                 || documentation.getSourceType().equals(Documentation.DocumentSourceType.MARKDOWN)) {
-            String contentPath = artifact.getPath()
+            String artifactPath = artifact.getPath();
+            if (artifactPath == null) {
+                throw new DocumentationPersistenceException("Invalid resource Path " + artifactPath);
+            }
+
+            String contentPath = artifactPath
                     .replace(RegistryConstants.PATH_SEPARATOR + documentation.getName(), "")
                     + RegistryConstants.PATH_SEPARATOR + APIConstants.INLINE_DOCUMENT_CONTENT_DIR
                     + RegistryConstants.PATH_SEPARATOR + documentation.getName();

--- a/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/RegistryPersistenceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/RegistryPersistenceImpl.java
@@ -3009,8 +3009,13 @@ public class RegistryPersistenceImpl implements APIPersistence {
                 throw new DocumentationPersistenceException("Invalid resource Path " + artifactPath);
             }
 
-            String contentPath = artifactPath
-                    .replace(RegistryConstants.PATH_SEPARATOR + documentation.getName(), "")
+            String docNameSuffix = RegistryConstants.PATH_SEPARATOR + documentation.getName();
+            int docNameIndex = artifactPath.lastIndexOf(docNameSuffix);
+            if (docNameIndex == -1) {
+                throw new DocumentationPersistenceException("Invalid resource Path " + artifactPath);
+            }
+            String docBasePath = artifactPath.substring(0, docNameIndex);
+            String contentPath = docBasePath
                     + RegistryConstants.PATH_SEPARATOR + APIConstants.INLINE_DOCUMENT_CONTENT_DIR
                     + RegistryConstants.PATH_SEPARATOR + documentation.getName();
             if (registry.resourceExists(contentPath)) {

--- a/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/RegistryPersistenceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/RegistryPersistenceImpl.java
@@ -2967,7 +2967,7 @@ public class RegistryPersistenceImpl implements APIPersistence {
                 log.error(errorMessage);
                 throw new DocumentationPersistenceException(errorMessage, ExceptionCodes.DOCUMENT_NOT_FOUND);
             }
-            deleteDocumentationContent(registry, artifact);
+            deleteDocumentationContent(registry, artifact, apiId, docId);
             String docPath = artifact.getPath();
             if (docPath != null) {
                 if (registry.resourceExists(docPath)) {
@@ -3000,16 +3000,19 @@ public class RegistryPersistenceImpl implements APIPersistence {
      *
      * @param registry Registry
      * @param artifact GenericArtifact of the documentation
+     * @param apiId    API identifier, used to give context in error messages
+     * @param docId    Document identifier, used to give context in error messages
      * @throws RegistryException                on failure
      * @throws DocumentationPersistenceException on failure
      */
-    private void deleteDocumentationContent(Registry registry, GenericArtifact artifact)
+    private void deleteDocumentationContent(Registry registry, GenericArtifact artifact, String apiId, String docId)
             throws RegistryException, DocumentationPersistenceException {
         Documentation documentation = RegistryPersistenceDocUtil.getDocumentation(artifact);
         if (documentation.getSourceType().equals(Documentation.DocumentSourceType.FILE)) {
             String resource = documentation.getFilePath();
             if (resource == null) {
-                throw new DocumentationPersistenceException("Invalid resource Path " + resource);
+                throw new DocumentationPersistenceException("Invalid file resource path for API " + apiId
+                        + " Document ID " + docId);
             }
 
             String[] resourceSplitPath = resource.split(RegistryConstants.GOVERNANCE_REGISTRY_BASE_PATH);
@@ -3018,19 +3021,22 @@ public class RegistryPersistenceImpl implements APIPersistence {
                     registry.delete(resourceSplitPath[1]);
                 }
             } else {
-                throw new DocumentationPersistenceException("Invalid resource Path " + resource);
+                throw new DocumentationPersistenceException("Invalid file resource path " + resource + " for API "
+                        + apiId + " Document ID " + docId);
             }
         } else if (documentation.getSourceType().equals(Documentation.DocumentSourceType.INLINE)
                 || documentation.getSourceType().equals(Documentation.DocumentSourceType.MARKDOWN)) {
             String artifactPath = artifact.getPath();
             if (artifactPath == null) {
-                throw new DocumentationPersistenceException("Invalid resource Path " + artifactPath);
+                throw new DocumentationPersistenceException("Invalid artifact path for API " + apiId
+                        + " Document ID " + docId);
             }
 
             String docNameSuffix = RegistryConstants.PATH_SEPARATOR + documentation.getName();
             int docNameIndex = artifactPath.lastIndexOf(docNameSuffix);
             if (docNameIndex == -1) {
-                throw new DocumentationPersistenceException("Invalid resource Path " + artifactPath);
+                throw new DocumentationPersistenceException("Invalid artifact path " + artifactPath + " for API "
+                        + apiId + " Document ID " + docId);
             }
             String docBasePath = artifactPath.substring(0, docNameIndex);
             String contentPath = docBasePath

--- a/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/RegistryPersistenceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/RegistryPersistenceImpl.java
@@ -2969,11 +2969,19 @@ public class RegistryPersistenceImpl implements APIPersistence {
             }
             deleteDocumentationContent(registry, artifact, apiId, docId);
             String docPath = artifact.getPath();
-            if (docPath != null) {
-                if (registry.resourceExists(docPath)) {
-                    registry.delete(docPath);
-                }
+            if (docPath == null) {
+                String errorMessage = "Failed to retrieve path of documentation artifact for API " + apiId
+                        + " Document ID " + docId;
+                log.error(errorMessage);
+                throw new DocumentationPersistenceException(errorMessage);
             }
+            if (!registry.resourceExists(docPath)) {
+                String errorMessage = "Failed to retrieve documentation artifact for API " + apiId
+                        + " Document ID " + docId;
+                log.error(errorMessage);
+                throw new DocumentationPersistenceException(errorMessage, ExceptionCodes.DOCUMENT_NOT_FOUND);
+            }
+            registry.delete(docPath);
             registry.commitTransaction();
             transactionCommitted = true;
         } catch (RegistryException | APIPersistenceException e) {

--- a/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/RegistryPersistenceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/RegistryPersistenceImpl.java
@@ -2946,10 +2946,13 @@ public class RegistryPersistenceImpl implements APIPersistence {
     public void deleteDocumentation(Organization org, String apiId, String docId)
             throws DocumentationPersistenceException {
         boolean isTenantFlowStarted = false;
+        boolean transactionCommitted = false;
+        Registry registry = null;
         try {
             RegistryHolder holder = getRegistry(org.getName());
-            Registry registry = holder.getRegistry();
+            registry = holder.getRegistry();
             isTenantFlowStarted = holder.isTenantFlowStarted();
+            registry.beginTransaction();
             GenericArtifactManager artifactManager = RegistryPersistenceDocUtil.getDocumentArtifactManager(registry);
             if (artifactManager == null) {
                 String errorMessage = "Failed to retrieve artifact manager when removing documentation of " + apiId
@@ -2965,10 +2968,18 @@ public class RegistryPersistenceImpl implements APIPersistence {
                     registry.delete(docPath);
                 }
             }
-
+            registry.commitTransaction();
+            transactionCommitted = true;
         } catch (RegistryException | APIPersistenceException e) {
             throw new DocumentationPersistenceException("Failed to delete documentation", e);
         } finally {
+            try {
+                if (registry != null && !transactionCommitted) {
+                    registry.rollbackTransaction();
+                }
+            } catch (RegistryException ex) {
+                log.error("Error while rolling back the transaction for documentation delete of API: " + apiId, ex);
+            }
             if (isTenantFlowStarted) {
                 PrivilegedCarbonContext.endTenantFlow();
             }

--- a/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/RegistryPersistenceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/RegistryPersistenceImpl.java
@@ -2958,6 +2958,7 @@ public class RegistryPersistenceImpl implements APIPersistence {
                 throw new DocumentationPersistenceException(errorMessage);
             }
             GenericArtifact artifact = artifactManager.getGenericArtifact(docId);
+            deleteDocumentationContent(registry, artifact);
             String docPath = artifact.getPath();
             if (docPath != null) {
                 if (registry.resourceExists(docPath)) {
@@ -2970,6 +2971,39 @@ public class RegistryPersistenceImpl implements APIPersistence {
         } finally {
             if (isTenantFlowStarted) {
                 PrivilegedCarbonContext.endTenantFlow();
+            }
+        }
+    }
+
+    /**
+     * Deletes the content resource of a documentation artifact, if one exists. FILE and INLINE/MARKDOWN documents
+     * store their content in a separate registry resource from the artifact itself; URL documents have no such
+     * resource.
+     *
+     * @param registry Registry
+     * @param artifact GenericArtifact of the documentation
+     * @throws RegistryException                on failure
+     * @throws DocumentationPersistenceException on failure
+     */
+    private void deleteDocumentationContent(Registry registry, GenericArtifact artifact)
+            throws RegistryException, DocumentationPersistenceException {
+        Documentation documentation = RegistryPersistenceDocUtil.getDocumentation(artifact);
+        if (documentation.getSourceType().equals(Documentation.DocumentSourceType.FILE)) {
+            String resource = documentation.getFilePath();
+            if (resource != null) {
+                String[] resourceSplitPath = resource.split(RegistryConstants.GOVERNANCE_REGISTRY_BASE_PATH);
+                if (resourceSplitPath.length == 2 && registry.resourceExists(resourceSplitPath[1])) {
+                    registry.delete(resourceSplitPath[1]);
+                }
+            }
+        } else if (documentation.getSourceType().equals(Documentation.DocumentSourceType.INLINE)
+                || documentation.getSourceType().equals(Documentation.DocumentSourceType.MARKDOWN)) {
+            String contentPath = artifact.getPath()
+                    .replace(RegistryConstants.PATH_SEPARATOR + documentation.getName(), "")
+                    + RegistryConstants.PATH_SEPARATOR + APIConstants.INLINE_DOCUMENT_CONTENT_DIR
+                    + RegistryConstants.PATH_SEPARATOR + documentation.getName();
+            if (registry.resourceExists(contentPath)) {
+                registry.delete(contentPath);
             }
         }
     }

--- a/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/RegistryPersistenceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/RegistryPersistenceImpl.java
@@ -2987,16 +2987,15 @@ public class RegistryPersistenceImpl implements APIPersistence {
         } catch (RegistryException | APIPersistenceException e) {
             throw new DocumentationPersistenceException("Failed to delete documentation", e);
         } finally {
+            if (isTenantFlowStarted) {
+                PrivilegedCarbonContext.endTenantFlow();
+            }
             try {
                 if (registry != null && !transactionCommitted) {
                     registry.rollbackTransaction();
                 }
             } catch (RegistryException ex) {
                 log.error("Error while rolling back the transaction for documentation delete of API: " + apiId, ex);
-            } finally {
-                if (isTenantFlowStarted) {
-                    PrivilegedCarbonContext.endTenantFlow();
-                }
             }
         }
     }

--- a/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/RegistryPersistenceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/RegistryPersistenceImpl.java
@@ -2961,6 +2961,12 @@ public class RegistryPersistenceImpl implements APIPersistence {
                 throw new DocumentationPersistenceException(errorMessage);
             }
             GenericArtifact artifact = artifactManager.getGenericArtifact(docId);
+            if (artifact == null) {
+                String errorMessage = "Failed to retrieve documentation artifact for API " + apiId
+                        + " Document ID " + docId;
+                log.error(errorMessage);
+                throw new DocumentationPersistenceException(errorMessage, ExceptionCodes.DOCUMENT_NOT_FOUND);
+            }
             deleteDocumentationContent(registry, artifact);
             String docPath = artifact.getPath();
             if (docPath != null) {

--- a/components/apimgt/org.wso2.carbon.apimgt.persistence/src/test/java/org/wso2/carbon/apimgt/persistence/RegistryPersistenceDocumentContentDeletionTestCase.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.persistence/src/test/java/org/wso2/carbon/apimgt/persistence/RegistryPersistenceDocumentContentDeletionTestCase.java
@@ -1,0 +1,224 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com)
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.wso2.carbon.apimgt.persistence;
+
+import static org.mockito.ArgumentMatchers.anyString;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.powermock.reflect.Whitebox;
+import org.wso2.carbon.apimgt.persistence.dto.Documentation;
+import org.wso2.carbon.apimgt.persistence.dto.DocumentationType;
+import org.wso2.carbon.apimgt.persistence.exceptions.DocumentationPersistenceException;
+import org.wso2.carbon.apimgt.persistence.utils.RegistryPersistenceDocUtil;
+import org.wso2.carbon.governance.api.generic.dataobjects.GenericArtifact;
+import org.wso2.carbon.registry.core.Registry;
+import org.wso2.carbon.registry.core.RegistryConstants;
+
+/**
+ * Tests for the private {@code deleteDocumentationContent} helper of {@link RegistryPersistenceImpl}, which
+ * removes the separate registry resource backing FILE and INLINE/MARKDOWN documentation content (URL documents
+ * have no such resource). The helper is invoked via reflection since it is private; {@link RegistryPersistenceDocUtil}
+ * is static-mocked so each case can drive the branch under test directly, without needing a real registry artifact.
+ */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({ RegistryPersistenceDocUtil.class })
+public class RegistryPersistenceDocumentContentDeletionTestCase {
+
+    private static final String API_ID = "admin-TestAPI-1.0.0";
+    private static final String DOC_ID = "doc-id-1234";
+    private static final String DOC_NAME = "TestDoc";
+    private static final String METHOD_NAME = "deleteDocumentationContent";
+
+    private RegistryPersistenceImpl persistence;
+    private Registry registry;
+    private GenericArtifact artifact;
+
+    @Before
+    public void setUp() {
+        persistence = new RegistryPersistenceImpl();
+        registry = Mockito.mock(Registry.class);
+        artifact = Mockito.mock(GenericArtifact.class);
+        PowerMockito.mockStatic(RegistryPersistenceDocUtil.class);
+    }
+
+    private Documentation newDocumentation(Documentation.DocumentSourceType sourceType) {
+        Documentation documentation = new Documentation(DocumentationType.HOWTO, DOC_NAME);
+        documentation.setSourceType(sourceType);
+        return documentation;
+    }
+
+    private void mockDocumentation(Documentation documentation) throws Exception {
+        PowerMockito.when(RegistryPersistenceDocUtil.getDocumentation(artifact)).thenReturn(documentation);
+    }
+
+    private void invokeDeleteContent() throws Exception {
+        Whitebox.invokeMethod(persistence, METHOD_NAME, registry, artifact, API_ID, DOC_ID);
+    }
+
+    // =====================================================================
+    // FILE source type
+    // =====================================================================
+
+    @Test
+    public void testDeleteDocumentationContent_FileTypeResourceExists() throws Exception {
+        String contentSuffix = "/apimgt/applicationdata/admin/apis/TestAPI1.0.0/docs/sample.txt";
+        Documentation documentation = newDocumentation(Documentation.DocumentSourceType.FILE);
+        documentation.setFilePath(RegistryConstants.GOVERNANCE_REGISTRY_BASE_PATH + contentSuffix);
+        mockDocumentation(documentation);
+        Mockito.when(registry.resourceExists(contentSuffix)).thenReturn(true);
+
+        invokeDeleteContent();
+
+        Mockito.verify(registry, Mockito.times(1)).delete(contentSuffix);
+    }
+
+    @Test
+    public void testDeleteDocumentationContent_FileTypeResourceMissing() throws Exception {
+        String contentSuffix = "/apimgt/applicationdata/admin/apis/TestAPI1.0.0/docs/sample.txt";
+        Documentation documentation = newDocumentation(Documentation.DocumentSourceType.FILE);
+        documentation.setFilePath(RegistryConstants.GOVERNANCE_REGISTRY_BASE_PATH + contentSuffix);
+        mockDocumentation(documentation);
+        Mockito.when(registry.resourceExists(anyString())).thenReturn(false);
+
+        invokeDeleteContent();
+
+        Mockito.verify(registry, Mockito.never()).delete(anyString());
+    }
+
+    @Test(expected = DocumentationPersistenceException.class)
+    public void testDeleteDocumentationContent_FileTypeNullFilePath() throws Exception {
+        Documentation documentation = newDocumentation(Documentation.DocumentSourceType.FILE);
+        documentation.setFilePath(null);
+        mockDocumentation(documentation);
+
+        invokeDeleteContent();
+    }
+
+    @Test(expected = DocumentationPersistenceException.class)
+    public void testDeleteDocumentationContent_FileTypeInvalidResourcePath() throws Exception {
+        Documentation documentation = newDocumentation(Documentation.DocumentSourceType.FILE);
+        documentation.setFilePath("/some/unrelated/path/sample.txt");
+        mockDocumentation(documentation);
+
+        invokeDeleteContent();
+    }
+
+    // =====================================================================
+    // INLINE / MARKDOWN source types
+    // =====================================================================
+
+    @Test
+    public void testDeleteDocumentationContent_InlineTypeResourceExists() throws Exception {
+        String artifactPath = "/_system/governance/apimgt/applicationdata/admin/apis/TestAPI1.0.0/documentation/"
+                + DOC_NAME;
+        String expectedContentPath = "/_system/governance/apimgt/applicationdata/admin/apis/TestAPI1.0.0/documentation"
+                + RegistryConstants.PATH_SEPARATOR + APIConstants.INLINE_DOCUMENT_CONTENT_DIR
+                + RegistryConstants.PATH_SEPARATOR + DOC_NAME;
+
+        Documentation documentation = newDocumentation(Documentation.DocumentSourceType.INLINE);
+        mockDocumentation(documentation);
+        Mockito.when(artifact.getPath()).thenReturn(artifactPath);
+        Mockito.when(registry.resourceExists(expectedContentPath)).thenReturn(true);
+
+        invokeDeleteContent();
+
+        Mockito.verify(registry, Mockito.times(1)).delete(expectedContentPath);
+    }
+
+    @Test
+    public void testDeleteDocumentationContent_MarkdownTypeResourceExists() throws Exception {
+        String artifactPath = "/_system/governance/apimgt/applicationdata/admin/apis/TestAPI1.0.0/documentation/"
+                + DOC_NAME;
+        String expectedContentPath = "/_system/governance/apimgt/applicationdata/admin/apis/TestAPI1.0.0/documentation"
+                + RegistryConstants.PATH_SEPARATOR + APIConstants.INLINE_DOCUMENT_CONTENT_DIR
+                + RegistryConstants.PATH_SEPARATOR + DOC_NAME;
+
+        Documentation documentation = newDocumentation(Documentation.DocumentSourceType.MARKDOWN);
+        mockDocumentation(documentation);
+        Mockito.when(artifact.getPath()).thenReturn(artifactPath);
+        Mockito.when(registry.resourceExists(expectedContentPath)).thenReturn(true);
+
+        invokeDeleteContent();
+
+        Mockito.verify(registry, Mockito.times(1)).delete(expectedContentPath);
+    }
+
+    /**
+     * Regression test: the document name here ("docs") also occurs as an earlier path segment (the provider name).
+     * A naive String.replace("/docs", "") would strip both occurrences and corrupt the base path; only the
+     * trailing occurrence (the actual doc name segment) must be stripped.
+     */
+    @Test
+    public void testDeleteDocumentationContent_InlineTypeDocNameCollidesWithPathSegment() throws Exception {
+        String docName = "docs";
+        String artifactPath = "/_system/governance/apimgt/applicationdata/docs/docsAPI/1.0.0/documentation/" + docName;
+        String expectedContentPath = "/_system/governance/apimgt/applicationdata/docs/docsAPI/1.0.0/documentation"
+                + RegistryConstants.PATH_SEPARATOR + APIConstants.INLINE_DOCUMENT_CONTENT_DIR
+                + RegistryConstants.PATH_SEPARATOR + docName;
+
+        Documentation documentation = new Documentation(DocumentationType.HOWTO, docName);
+        documentation.setSourceType(Documentation.DocumentSourceType.INLINE);
+        mockDocumentation(documentation);
+        Mockito.when(artifact.getPath()).thenReturn(artifactPath);
+        Mockito.when(registry.resourceExists(anyString())).thenReturn(true);
+
+        invokeDeleteContent();
+
+        Mockito.verify(registry, Mockito.times(1)).delete(expectedContentPath);
+    }
+
+    @Test(expected = DocumentationPersistenceException.class)
+    public void testDeleteDocumentationContent_InlineTypeNullArtifactPath() throws Exception {
+        Documentation documentation = newDocumentation(Documentation.DocumentSourceType.INLINE);
+        mockDocumentation(documentation);
+        Mockito.when(artifact.getPath()).thenReturn(null);
+
+        invokeDeleteContent();
+    }
+
+    @Test(expected = DocumentationPersistenceException.class)
+    public void testDeleteDocumentationContent_InlineTypeMissingDocNameSegment() throws Exception {
+        Documentation documentation = newDocumentation(Documentation.DocumentSourceType.INLINE);
+        mockDocumentation(documentation);
+        Mockito.when(artifact.getPath())
+                .thenReturn("/_system/governance/apimgt/applicationdata/admin/apis/TestAPI1.0.0/documentation/"
+                        + "SomeOtherDocName");
+
+        invokeDeleteContent();
+    }
+
+    // =====================================================================
+    // URL source type
+    // =====================================================================
+
+    @Test
+    public void testDeleteDocumentationContent_UrlTypeNoContent() throws Exception {
+        Documentation documentation = newDocumentation(Documentation.DocumentSourceType.URL);
+        documentation.setSourceUrl("https://example.org/doc");
+        mockDocumentation(documentation);
+
+        invokeDeleteContent();
+
+        Mockito.verify(registry, Mockito.never()).delete(anyString());
+        Mockito.verify(registry, Mockito.never()).resourceExists(anyString());
+    }
+}


### PR DESCRIPTION
## Overview
This pull request fixes documentation deletion leaving orphaned content resources in the registry, by also deleting the associated content before removing the artifact.

## Key Changes
* Added the `deleteDocumentationContent` private method to handle deleting the content resource for documentation artifacts, covering both file-based and inline/markdown documentation types.
* Updated the `deleteDocumentation` method to call `deleteDocumentationContent` before deleting the artifact itself, ensuring associated content is properly cleaned up.

## Related Issue
Fixes: https://github.com/wso2/api-manager/issues/5162