### PR TITLE
Fix malformed devportal redirect URL for external API stores

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/publishers/WSO2APIPublisher.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/publishers/WSO2APIPublisher.java
@@ -615,14 +615,48 @@ public class WSO2APIPublisher implements APIPublisher {
      * @param apiId    API UUID of the API to redirect
      * @return Exact redirect URL for the API in external store
      */
-    private String getExternalStoreRedirectURLForAPI(int tenantId, String apiId) throws APIManagementException {
+    protected String getExternalStoreRedirectURLForAPI(int tenantId, String apiId) throws APIManagementException {
 
         String redirectURL = getExternalStoreRedirectURL(tenantId);
-        if (redirectURL.split(APIConstants.EXTERNAL_API_DEVPORTAL_URL_REGEX).length == 0) {
+        if (StringUtils.isBlank(redirectURL)) {
             return redirectURL;
         }
-        return redirectURL.split(APIConstants.EXTERNAL_API_DEVPORTAL_URL_REGEX)[0]
-                + APIConstants.RestApiConstants.REST_API_PUB_RESOURCE_PATH_APIS + "/" + apiId;
+        try {
+            //Query parameters of the configured Store URL (Eg: ?tenant=<tenantDomain>) have to be preserved in the
+            //redirect URL. Otherwise the link resolves to the super tenant's Developer Portal instead of the
+            //Developer Portal of the tenant which published the API.
+            URIBuilder uriBuilder = new URIBuilder(redirectURL.trim());
+            uriBuilder.setPath(getDevPortalBasePath(uriBuilder.getPath())
+                    + APIConstants.RestApiConstants.REST_API_PUB_RESOURCE_PATH_APIS + "/" + apiId);
+            return uriBuilder.build().toString();
+        } catch (URISyntaxException e) {
+            String errorMessage = "Error while building the redirect URL for API: " + apiId
+                    + " from the configured Store URL: " + redirectURL;
+            log.error(errorMessage, e);
+            throw new APIManagementException(errorMessage, e);
+        }
+    }
+
+    /**
+     * Get the Developer Portal base path from the path of the configured Store URL. The Store URL can be configured
+     * either as the Developer Portal context (Eg: /devportal) or as the API listing page of the Developer Portal
+     * (Eg: /devportal/apis) as documented.
+     *
+     * @param storeURLPath Path of the configured Store URL
+     * @return Developer Portal base path without a trailing slash or the "/apis" suffix
+     */
+    private String getDevPortalBasePath(String storeURLPath) {
+
+        if (StringUtils.isBlank(storeURLPath)) {
+            return StringUtils.EMPTY;
+        }
+        String basePath = StringUtils.stripEnd(storeURLPath.trim(), "/");
+        //Drop the "/apis" suffix if present, so that the API path is not duplicated (Eg: /devportal/apis/apis/<uuid>)
+        if (StringUtils.endsWith(basePath, APIConstants.RestApiConstants.REST_API_PUB_RESOURCE_PATH_APIS)) {
+            basePath = basePath.substring(0,
+                    basePath.length() - APIConstants.RestApiConstants.REST_API_PUB_RESOURCE_PATH_APIS.length());
+        }
+        return basePath;
     }
 
     /**

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/publishers/WSO2APIPublisherTestCase.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/publishers/WSO2APIPublisherTestCase.java
@@ -84,6 +84,7 @@ public class WSO2APIPublisherTestCase {
     private StatusLine statusLine;
     private ImportExportAPI importExportAPI;
     private CloseableHttpClient defaultHttpClient;
+    private APIManagerConfiguration apiManagerConfiguration;
 
     @Before
     public void init() throws Exception {
@@ -109,7 +110,7 @@ public class WSO2APIPublisherTestCase {
         PowerMockito.mockStatic(EntityUtils.class);
         APIManagerConfigurationService apiManagerConfigurationService = Mockito.mock(APIManagerConfigurationService.class);
         Mockito.when(serviceReferenceHolder.getAPIManagerConfigurationService()).thenReturn(apiManagerConfigurationService);
-        APIManagerConfiguration apiManagerConfiguration = Mockito.mock(APIManagerConfiguration.class);
+        apiManagerConfiguration = Mockito.mock(APIManagerConfiguration.class);
         Mockito.when(apiManagerConfigurationService.getAPIManagerConfiguration()).thenReturn(apiManagerConfiguration);
         Mockito.when(apiManagerConfiguration.getFirstProperty(APIConstants.EXTERNAL_API_STORES + "."
                 + APIConstants.EXTERNAL_API_STORES_STORE_URL)).thenReturn(storeRedirectURL);
@@ -144,6 +145,37 @@ public class WSO2APIPublisherTestCase {
                     "Cannot proceed with publishing API to the APIStore - " + nullStore.getDisplayName();
             Assert.assertEquals(msg, e.getMessage());
         }
+    }
+
+    @Test
+    public void testGetExternalStoreRedirectURLForAPI() throws Exception {
+
+        String apiUUID = "0b1e4a5b-4d1d-4b53-9c9f-4f7a9d8e1a2b";
+        //Store URL configured as the Developer Portal context of the super tenant
+        Assert.assertEquals("https://localhost:9443/devportal/apis/" + apiUUID,
+                getRedirectURLForStoreURL("https://localhost:9443/devportal", apiUUID));
+        //Store URL configured with a trailing slash
+        Assert.assertEquals("https://localhost:9443/devportal/apis/" + apiUUID,
+                getRedirectURLForStoreURL("https://localhost:9443/devportal/", apiUUID));
+        //Store URL configured as the API listing page as documented. The tenant query parameter has to be preserved
+        Assert.assertEquals("https://localhost:9443/devportal/apis/" + apiUUID + "?tenant=tenant1.com",
+                getRedirectURLForStoreURL("https://localhost:9443/devportal/apis?tenant=tenant1.com", apiUUID));
+        //Store URL configured as the Developer Portal context of a tenant
+        Assert.assertEquals("https://localhost:9443/devportal/apis/" + apiUUID + "?tenant=tenant1.com",
+                getRedirectURLForStoreURL("https://localhost:9443/devportal?tenant=tenant1.com", apiUUID));
+        //Store URL configured as the API listing page of a Developer Portal hosted in a custom domain
+        Assert.assertEquals("https://developer.wso2.com/apis/" + apiUUID,
+                getRedirectURLForStoreURL("https://developer.wso2.com/apis", apiUUID));
+        //Store URL configured as a custom domain without a path, where the Developer Portal is hosted in the root
+        Assert.assertEquals("https://developer.wso2.com/apis/" + apiUUID,
+                getRedirectURLForStoreURL("https://developer.wso2.com", apiUUID));
+    }
+
+    private String getRedirectURLForStoreURL(String configuredStoreURL, String apiUUID) throws Exception {
+
+        Mockito.when(apiManagerConfiguration.getFirstProperty(APIConstants.EXTERNAL_API_STORES + "."
+                + APIConstants.EXTERNAL_API_STORES_STORE_URL)).thenReturn(configuredStoreURL);
+        return wso2APIPublisher.getExternalStoreRedirectURLForAPI(tenantID, apiUUID);
     }
 
     @Test


### PR DESCRIPTION
### Root cause and fix

- `getExternalStoreRedirectURLForAPI` split the configured `<StoreURL>` on `EXTERNAL_API_DEVPORTAL_URL_REGEX` (`^./devportal$`), a pattern anchored at both ends that can never match a real store URL. The split therefore returned the whole URL unchanged and `/apis/<uuid>` was concatenated onto the end of it, stranding any existing query string in the middle of the path (e.g. `.../devportal/apis?tenant=tenant1.com/apis/<uuid>`). The `length == 0` guard was dead code.
- Replaced the string surgery with `URIBuilder`, setting the API path via `setPath` so the query string (and any other URL component) is preserved. Cross-tenant links now keep `?tenant=<domain>` and resolve to the Developer Portal of the tenant that published the API instead of the super tenant.
- Added `getDevPortalBasePath`, which normalises the two documented ways of configuring the store URL (the Dev Portal context `/devportal`, or the API listing page `/devportal/apis`) by stripping a trailing slash and a trailing `/apis`, so the API path is not duplicated as `/apis/apis/<uuid>`.
- Widened the method to `protected` for direct unit testing and added `testGetExternalStoreRedirectURLForAPI`, covering six store-URL shapes including tenant query parameters and custom domains.


### Git issue

https://github.com/wso2/api-manager/issues/5160

