### PR TITLE
Improve request/response header and body capture for Moesif analytics

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/analytics/AnalyticsMetricsHandler.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/analytics/AnalyticsMetricsHandler.java
@@ -33,8 +33,8 @@ import org.wso2.carbon.apimgt.gateway.utils.GatewayUtils;
 import org.wso2.carbon.apimgt.impl.APIConstants;
 import org.wso2.carbon.inbound.endpoint.protocol.websocket.InboundWebsocketConstants;
 
-import java.util.HashMap;
 import java.util.Map;
+import java.util.TreeMap;
 
 /**
  * Global synapse handler to publish analytics data to analytics cloud.
@@ -91,9 +91,10 @@ public class AnalyticsMetricsHandler extends AbstractExtendedSynapseHandler {
     /**
      * Whether the request payload should be captured (and the message therefore built) on the
      * request-out flow. Mirrors the skip conditions {@code handleResponseOutFlow} applies so we never
-     * build/re-serialize a request for a call that will not publish an analytics event: websocket
-     * subscriptions, file-based API contexts, and requests explicitly flagged {@code SKIP_METRICS_PUBLISHING}.
-     * Cheap checks are evaluated first and the file-based-context lookup last.
+     * build/re-serialize a request for a call that will not publish it: websocket subscriptions,
+     * async/streaming APIs, file-based API contexts, and requests explicitly flagged
+     * {@code SKIP_METRICS_PUBLISHING}. Cheap checks are evaluated first and the file-based-context
+     * lookup last.
      */
     private boolean shouldCaptureRequestPayload(MessageContext messageContext) {
         if (messageContext.getPropertyKeySet().contains(InboundWebsocketConstants.WEBSOCKET_SUBSCRIBER_PATH)
@@ -102,6 +103,12 @@ public class AnalyticsMetricsHandler extends AbstractExtendedSynapseHandler {
         }
         Object skipPublishMetrics = messageContext.getProperty(Constants.SKIP_METRICS_PUBLISHING);
         if (Boolean.TRUE.equals(skipPublishMetrics)) {
+            return false;
+        }
+        // Async/streaming APIs (SSE, webhooks) publish via AsyncAnalyticsDataProvider, which never
+        // reads the captured request body, so building it here would be pure waste. IS_ASYNC_API is
+        // set upstream (SseApiHandler / SubscribersPersistMediator) before this request-out flow.
+        if (Boolean.TRUE.equals(messageContext.getProperty(Constants.IS_ASYNC_API))) {
             return false;
         }
         return !GatewayUtils.checkForFileBasedApiContexts(ApiUtils.getFullRequestPath(messageContext),
@@ -193,14 +200,18 @@ public class AnalyticsMetricsHandler extends AbstractExtendedSynapseHandler {
             return null; // no headers available
         }
 
-        Map<String, Object> headers = new HashMap<>((Map<String, ?>) transportHeadersObj);
+        // Copy into a case-insensitive map: the live transport-headers map is case-insensitive, and a
+        // plain HashMap copy would break exact-case lookups such as User-Agent for HTTP/2 clients
+        // (which send header names in lowercase).
+        Map<String, Object> headers = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+        headers.putAll((Map<String, ?>) transportHeadersObj);
 
         if (!headers.isEmpty()) {
             if (log.isDebugEnabled()) {
                 log.debug("Processing " + headers.size() + " request headers for analytics");
             }
-            headers.keySet().removeIf(APIConstants.AUTHORIZATION_HEADER_DEFAULT::equalsIgnoreCase);
-            headers.keySet().removeIf(APIConstants.API_KEY_HEADER_DEFAULT::equalsIgnoreCase);
+            // Strip credential/session headers before storing them as analytics metadata.
+            headers.keySet().removeIf(AnalyticsPayloadUtil::isSensitiveHeader);
             axis2mc.setAnalyticsMetadata(Constants.REQUEST_HEADERS, headers);
             return (String) headers.get(APIConstants.USER_AGENT);
         }

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/analytics/AnalyticsPayloadUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/analytics/AnalyticsPayloadUtil.java
@@ -30,6 +30,7 @@ import org.apache.synapse.commons.json.JsonUtil;
 import org.apache.synapse.core.axis2.Axis2MessageContext;
 import org.apache.synapse.transport.passthru.PassThroughConstants;
 import org.apache.synapse.transport.passthru.util.RelayUtils;
+import org.wso2.carbon.apimgt.impl.APIConstants;
 import org.wso2.carbon.apimgt.impl.APIManagerConfiguration;
 import org.wso2.carbon.apimgt.impl.utils.APIUtil;
 
@@ -38,6 +39,8 @@ import java.nio.charset.StandardCharsets;
 import java.util.Iterator;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
 
 import javax.xml.stream.XMLStreamException;
 
@@ -55,6 +58,13 @@ import static org.apache.axis2.context.MessageContext.TRANSPORT_HEADERS;
  * {@code transferEncoding=base64}). A payload larger than the configurable size limit is dropped
  * (not truncated) so the publisher only ever receives a whole, valid body or nothing; the backend
  * always receives the full body regardless.</p>
+ *
+ * <p><b>Re-serialization caveat:</b> capturing a body requires building the pass-through message
+ * ({@link RelayUtils#buildMessage}), which sets {@code MESSAGE_BUILDER_INVOKED} and makes the engine
+ * re-serialize the built message when forwarding it. The forwarded body stays semantically equivalent
+ * but is not guaranteed byte-identical (whitespace, attribute/namespace ordering, JSON key formatting,
+ * chunking), so a signature computed over the raw bytes (JWS, an HMAC-signed body, WS-Security) may
+ * fail to verify at the recipient while {@code send_payloads} is enabled.</p>
  */
 public final class AnalyticsPayloadUtil {
 
@@ -64,7 +74,33 @@ public final class AnalyticsPayloadUtil {
     // on every capture attempt (getPayloadSizeLimit is called per request/response).
     private static volatile boolean invalidLimitWarned = false;
 
+    // Header names whose values carry credentials or session state and must never be published to
+    // analytics (matched case-insensitively): the default Authorization/ApiKey headers plus
+    // Cookie/Set-Cookie. A per-API custom auth-header name is not resolvable at this layer and remains
+    // a known gap.
+    private static final Set<String> SENSITIVE_HEADERS = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
+
+    static {
+        SENSITIVE_HEADERS.add(APIConstants.AUTHORIZATION_HEADER_DEFAULT);
+        SENSITIVE_HEADERS.add(APIConstants.API_KEY_HEADER_DEFAULT);
+        SENSITIVE_HEADERS.add(APIConstants.COOKIE);
+        SENSITIVE_HEADERS.add("Set-Cookie");
+    }
+
     private AnalyticsPayloadUtil() {
+    }
+
+    /**
+     * Whether a header carries credentials or session state and so must never be published to
+     * analytics. Matched case-insensitively. Shared by the request-header capture
+     * ({@code AnalyticsMetricsHandler}) and the response-header publish
+     * ({@code SynapseAnalyticsDataProvider}) so the two directions cannot drift.
+     *
+     * @param name the header name
+     * @return {@code true} if the header must be stripped before publishing
+     */
+    public static boolean isSensitiveHeader(String name) {
+        return name != null && SENSITIVE_HEADERS.contains(name);
     }
 
     /**

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/analytics/Constants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/analytics/Constants.java
@@ -84,8 +84,8 @@ public class Constants {
     public static final String CERTIFICATE_COMMON_NAME = "commonName";
     public static final String NOT_APPLICABLE_VALUE = "N/A";
     public static final String SEND_HEADER = "send_headers";
-    public static final String REQUEST_HEADERS= "requestHeaders";
-    public static final String RESPONSE_HEADERS= "responseHeaders";
+    public static final String REQUEST_HEADERS = "requestHeaders";
+    public static final String RESPONSE_HEADERS = "responseHeaders";
     public static final String RESPONSE_HEADER_MASK = "response_headers";
     public static final String REQUEST_HEADER_MASK = "request_headers";
     public static final String MASK_VALUE = "*****";

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/analytics/SynapseAnalyticsDataProvider.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/analytics/SynapseAnalyticsDataProvider.java
@@ -498,10 +498,14 @@ public class SynapseAnalyticsDataProvider implements AnalyticsDataProvider {
                     }
                 }
 
-                // Response headers via Axis2 transport property
+                // Response headers via Axis2 transport property. Strip credential/session headers
+                // first: on a fault path this map can still be the inbound request map, so publishing
+                // it raw would leak Authorization/ApiKey/Cookie. Copy before stripping so the live
+                // transport map is left untouched.
                 Object respHeadersObj = axis2.getAxis2MessageContext().getProperty(TRANSPORT_HEADERS);
                 if (respHeadersObj instanceof Map) {
-                    Map<String, Object> respHeaders = (Map<String, Object>) respHeadersObj;
+                    Map<String, Object> respHeaders = new LinkedHashMap<>((Map<String, Object>) respHeadersObj);
+                    respHeaders.keySet().removeIf(AnalyticsPayloadUtil::isSensitiveHeader);
                     Map<String, Object> maskedResp =
                             applyMask(respHeaders, parseMaskSet(getMaskProperties().get(RESPONSE_HEADER_MASK)));
                     if (!maskedResp.isEmpty()) {
@@ -1001,7 +1005,7 @@ public class SynapseAnalyticsDataProvider implements AnalyticsDataProvider {
         }
         for (Map.Entry<String, Object> e : headers.entrySet()) {
             String key = String.valueOf(e.getKey());
-            boolean masked =maskSet.contains(key.toLowerCase(java.util.Locale.ROOT));
+            boolean masked = maskSet.contains(key.toLowerCase(java.util.Locale.ROOT));
             out.put(key, masked ? MASK_VALUE : e.getValue());
         }
         return out;


### PR DESCRIPTION
## Purpose

Fix security and reliability issues in the Moesif analytics header/body capture: when capture is enabled, credentials could be sent to the external analytics service, headers were captured unreliably for HTTP/2, and request bodies were built for flows that never publish them.

- **Public issue:** https://github.com/wso2/api-manager/issues/5128

A follow-up improvement of the body-capture feature added in https://github.com/wso2/carbon-apimgt/pull/13927 and the unbuildable content types guard added in https://github.com/wso2/carbon-apimgt/pull/13951.

## Goals

- Stop credential/session headers from being exported to the analytics service.
- Capture headers correctly regardless of header-name case.
- Avoid building request bodies for flows that don't use them.

## Approach

- Strip credential/session headers (`Authorization`, `ApiKey`, `Cookie`, `Set-Cookie`) on both the request and response paths via a shared case-insensitive `isSensitiveHeader` check, applied before masking. This closes the leak on fault responses (where the response map can still hold the inbound request credentials) and keeps the two directions consistent.
- Copy request headers into a case-insensitive map, so `User-Agent` resolves and sensitive-header matching works for HTTP/2 (lowercase) clients.
- Skip request-body capture for async/streaming APIs (`IS_ASYNC_API`), which publish via `AsyncAnalyticsDataProvider` and never read the captured body.
- Document the `send_payloads` re-serialization caveat for signed payloads (JWS/HMAC/WS-Security), and fix a whitespace issue on the header constants.