### PR TITLE
Fix missing SUBSCRIPTIONS_DELETE event for API Product subscriptions on application delete

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConsumerImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConsumerImpl.java
@@ -2610,7 +2610,8 @@ public class APIConsumerImpl extends AbstractAPIManager implements APIConsumer {
             application = apiMgtDAO.getApplicationByUUID(uuid);
         }
         Set<APIKey> keyMappingsFromApplicationId = apiMgtDAO.getKeyMappingsFromApplicationId(application.getId());
-        Set<SubscribedAPI> subscribedAPIsByApplication = apiMgtDAO.getSubscribedAPIsByApplication(application);
+        Set<SubscribedAPI> subscribedAPIsByApplication =
+                apiMgtDAO.getSubscribedAPIsAndAPIProductsByApplication(application);
         boolean isTenantFlowStarted = false;
         int applicationId = application.getId();
 
@@ -2762,8 +2763,8 @@ public class APIConsumerImpl extends AbstractAPIManager implements APIConsumer {
                                 subscribedAPI.getUUID(), subscribedAPI.getApiId(), subscribedAPI.getAPIUUId(),
                                 subscribedAPI.getApplication().getId(), subscribedAPI.getApplication().getUUID(),
                                 subscribedAPI.getTier().getName(), subscribedAPI.getSubCreatedStatus(),
-                                subscribedAPI.getAPIIdentifier().getApiName(),
-                                subscribedAPI.getAPIIdentifier().getVersion());
+                                subscribedAPI.getIdentifier().getName(),
+                                subscribedAPI.getIdentifier().getVersion());
                 APIUtil.sendNotification(subscriptionEvent, APIConstants.NotifierType.SUBSCRIPTIONS.name());
             }
         }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/ApiMgtDAO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/ApiMgtDAO.java
@@ -23006,6 +23006,44 @@ public class ApiMgtDAO {
         return subscribedAPIs;
     }
 
+    public Set<SubscribedAPI> getSubscribedAPIsAndAPIProductsByApplication(Application application)
+            throws APIManagementException {
+        Set<SubscribedAPI> subscribedAPIs = new LinkedHashSet<>();
+
+        try (Connection connection = APIMgtDBUtil.getConnection();
+             PreparedStatement ps =
+                     connection.prepareStatement(SQLConstants.GET_SUBSCRIBED_APIS_BY_APP_ID_SQL)) {
+            ps.setInt(1, application.getId());
+            try (ResultSet result = ps.executeQuery()) {
+                while (result.next()) {
+                    String apiType = result.getString("TYPE");
+                    SubscribedAPI subscribedAPI;
+                    if (APIConstants.API_PRODUCT.equalsIgnoreCase(apiType)) {
+                        APIProductIdentifier identifier = new APIProductIdentifier(
+                                APIUtil.replaceEmailDomain(result.getString("API_PROVIDER")),
+                                result.getString("API_NAME"), result.getString("API_VERSION"));
+                        identifier.setUuid(result.getString("API_UUID"));
+                        subscribedAPI = new SubscribedAPI(application.getSubscriber(), identifier);
+                    } else {
+                        APIIdentifier identifier = new APIIdentifier(APIUtil.replaceEmailDomain(result.getString
+                                ("API_PROVIDER")), result.getString("API_NAME"),
+                                result.getString("API_VERSION"));
+                        identifier.setUuid(result.getString("API_UUID"));
+                        subscribedAPI = new SubscribedAPI(application.getSubscriber(), identifier);
+                    }
+                    subscribedAPI.setApplication(application);
+                    subscribedAPI.setOrganization(result.getString("ORGANIZATION"));
+                    initSubscribedAPI(subscribedAPI, result);
+                    subscribedAPIs.add(subscribedAPI);
+                }
+            }
+        } catch (SQLException e) {
+            handleException("Failed to get SubscribedAPIs and API Products of application :"
+                    + application.getName(), e);
+        }
+        return subscribedAPIs;
+    }
+
     public Set<SubscribedAPI> getPaginatedSubscribedAPIsByApplication(Application application, Integer offset,
                                                                       Integer limit, String organization)
             throws APIManagementException {

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/ApiMgtDAO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/ApiMgtDAO.java
@@ -23006,6 +23006,18 @@ public class ApiMgtDAO {
         return subscribedAPIs;
     }
 
+    /**
+     * Retrieves all the subscriptions of the given application, including both plain API subscriptions and
+     * API Product subscriptions. Each returned {@link SubscribedAPI} is backed by the identifier type matching
+     * its subscription (APIIdentifier or APIProductIdentifier).
+     * <p>
+     * Unlike {@link #getSubscribedAPIsByApplication(Application)}, which filters out API Product subscriptions
+     * for backward compatibility with its existing callers, this method returns the complete set of subscriptions.
+     *
+     * @param application Application for which the subscriptions should be retrieved.
+     * @return a set of {@link SubscribedAPI} containing both API and API Product subscriptions of the application.
+     * @throws APIManagementException if an error occurs while retrieving the subscriptions.
+     */
     public Set<SubscribedAPI> getSubscribedAPIsAndAPIProductsByApplication(Application application)
             throws APIManagementException {
         Set<SubscribedAPI> subscribedAPIs = new LinkedHashSet<>();

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/APIConsumerImplTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/APIConsumerImplTest.java
@@ -33,6 +33,7 @@ import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.core.classloader.annotations.SuppressStaticInitializationFor;
 import org.powermock.modules.junit4.PowerMockRunner;
+import org.powermock.reflect.Whitebox;
 import org.wso2.carbon.apimgt.api.APIManagementException;
 import org.wso2.carbon.apimgt.api.ExceptionCodes;
 import org.wso2.carbon.apimgt.api.WorkflowStatus;
@@ -40,6 +41,7 @@ import org.wso2.carbon.apimgt.api.dto.KeyManagerConfigurationDTO;
 import org.wso2.carbon.apimgt.api.model.API;
 import org.wso2.carbon.apimgt.api.model.APIIdentifier;
 import org.wso2.carbon.apimgt.api.model.APIKey;
+import org.wso2.carbon.apimgt.api.model.APIProductIdentifier;
 import org.wso2.carbon.apimgt.api.model.APIRating;
 import org.wso2.carbon.apimgt.api.model.AccessTokenInfo;
 import org.wso2.carbon.apimgt.api.model.AccessTokenRequest;
@@ -60,6 +62,7 @@ import org.wso2.carbon.apimgt.impl.dto.SubscriptionWorkflowDTO;
 import org.wso2.carbon.apimgt.impl.dto.WorkflowDTO;
 import org.wso2.carbon.apimgt.impl.factory.KeyManagerHolder;
 import org.wso2.carbon.apimgt.impl.internal.ServiceReferenceHolder;
+import org.wso2.carbon.apimgt.impl.notifier.events.SubscriptionEvent;
 import org.wso2.carbon.apimgt.impl.utils.APIUtil;
 import org.wso2.carbon.apimgt.impl.utils.ApplicationUtils;
 import org.wso2.carbon.apimgt.impl.workflow.AbstractApplicationRegistrationWorkflowExecutor;
@@ -455,8 +458,46 @@ public class APIConsumerImplTest {
         assertNotNull(apiConsumer.getSubscribedAPIs(subscriber, "testApplication","testID"));
     }
 
+    @Test
+    public void testSendApplicationDeletionEventForApiAndApiProductSubscriptions() throws Exception {
+        APIConsumerImpl apiConsumer = new APIConsumerImplWrapper(apiMgtDAO);
 
+        Subscriber subscriber = new Subscriber("productSubscriber");
+        Application application = new Application("APIPRODUCT_SUB_APP", subscriber);
+        application.setId(1);
+        application.setUUID(UUID.randomUUID().toString());
+        Tier tier = new Tier("Gold");
 
+        APIIdentifier apiIdentifier = new APIIdentifier(API_PROVIDER, SAMPLE_API_NAME, SAMPLE_API_VERSION);
+        SubscribedAPI apiSubscription = new SubscribedAPI(subscriber, apiIdentifier);
+        apiSubscription.setApplication(application);
+        apiSubscription.setTier(tier);
+        apiSubscription.setSubscriptionId(1);
+        apiSubscription.setUUID(UUID.randomUUID().toString());
+
+        APIProductIdentifier productIdentifier = new APIProductIdentifier(API_PROVIDER, "SampleProduct",
+                SAMPLE_API_VERSION);
+        SubscribedAPI productSubscription = new SubscribedAPI(subscriber, productIdentifier);
+        productSubscription.setApplication(application);
+        productSubscription.setTier(tier);
+        productSubscription.setSubscriptionId(2);
+        productSubscription.setUUID(UUID.randomUUID().toString());
+
+        // Regression guard for the API Product SUBSCRIPTIONS_DELETE fix: previously this set would only ever
+        // contain plain-API SubscribedAPI entries; now it also carries API Product ones. This must not NPE
+        // (subscribedAPI.getIdentifier(), not the API-only getAPIIdentifier(), is required downstream) and both
+        // subscriptions must be individually notified.
+        Set<SubscribedAPI> subscribedAPIs = new HashSet<>();
+        subscribedAPIs.add(apiSubscription);
+        subscribedAPIs.add(productSubscription);
+
+        Whitebox.invokeMethod(apiConsumer, "sendApplicationDeletionEvent", application,
+                new HashSet<APIKey>(), subscribedAPIs);
+
+        PowerMockito.verifyStatic(APIUtil.class, Mockito.times(2));
+        APIUtil.sendNotification(Mockito.any(SubscriptionEvent.class),
+                Mockito.eq(APIConstants.NotifierType.SUBSCRIPTIONS.name()));
+    }
 
     @Test
     public void testGetApplicationById() throws APIManagementException {

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/dao/test/APIMgtDAOTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/dao/test/APIMgtDAOTest.java
@@ -399,6 +399,61 @@ public class APIMgtDAOTest {
     }
 
     @Test
+    public void testGetSubscribedAPIsAndAPIProductsByApplication() throws Exception {
+        Subscriber subscriber = new Subscriber("sub_apiproduct_user");
+        subscriber.setEmail("apiproductuser@wso2.com");
+        subscriber.setSubscribedDate(new Date());
+        subscriber.setTenantId(MultitenantConstants.SUPER_TENANT_ID);
+        apiMgtDAO.addSubscriber(subscriber, null);
+
+        Application application = new Application("APIPRODUCT_SUB_APP", subscriber);
+        int applicationId = apiMgtDAO.addApplication(application, subscriber.getName(), "testOrg");
+        application.setId(applicationId);
+
+        APIIdentifier apiIdentifier = new APIIdentifier("subProductProvider", "SubProductTestAPI", "V1.0.0");
+        API api = new API(apiIdentifier);
+        api.setContext("/subProductTestApi");
+        api.setContextTemplate("/subProductTestApi/{version}");
+        api.setVersionTimestamp(String.valueOf(System.currentTimeMillis()));
+        api.getId().setId(apiMgtDAO.addAPI(api, MultitenantConstants.SUPER_TENANT_ID, "testOrg"));
+        apiMgtDAO.addSubscription(new ApiTypeWrapper(api), application,
+                APIConstants.SubscriptionStatus.UNBLOCKED, subscriber.getName());
+
+        APIProductIdentifier productIdentifier = new APIProductIdentifier("subProductProvider",
+                "SubProductTestProduct", "V1.0.0");
+        APIProduct apiProduct = new APIProduct(productIdentifier);
+        apiProduct.setContext("/subProductTestProduct");
+        apiProduct.setContextTemplate("/subProductTestProduct/{version}");
+        apiProduct.setVersionTimestamp(String.valueOf(System.currentTimeMillis()));
+        apiProduct.setUuid(UUID.randomUUID().toString());
+        apiMgtDAO.addAPIProduct(apiProduct, "testOrg");
+        // addAPIProduct() does not write the generated id back onto the APIProduct (unlike addAPI()), so it must
+        // be looked up explicitly; AM_API_PRODUCT rows live in the same AM_API table keyed by uuid.
+        apiProduct.setProductId(apiMgtDAO.getAPIID(apiProduct.getUuid()));
+        apiMgtDAO.addSubscription(new ApiTypeWrapper(apiProduct), application,
+                APIConstants.SubscriptionStatus.UNBLOCKED, subscriber.getName());
+
+        Set<SubscribedAPI> result = apiMgtDAO.getSubscribedAPIsAndAPIProductsByApplication(application);
+        assertEquals(2, result.size());
+
+        boolean foundApi = false;
+        boolean foundProduct = false;
+        for (SubscribedAPI subscribedAPI : result) {
+            if (subscribedAPI.getAPIIdentifier() != null) {
+                assertEquals("SubProductTestAPI", subscribedAPI.getAPIIdentifier().getApiName());
+                assertNull(subscribedAPI.getProductId());
+                foundApi = true;
+            } else {
+                assertNotNull(subscribedAPI.getProductId());
+                assertEquals("SubProductTestProduct", subscribedAPI.getProductId().getName());
+                foundProduct = true;
+            }
+        }
+        assertTrue("Expected a subscription backed by a plain API", foundApi);
+        assertTrue("Expected a subscription backed by an API Product", foundProduct);
+    }
+
+    @Test
     public void testForwardingBlockedAndProdOnlyBlockedSubscriptionsToNewAPIVersion() throws APIManagementException {
         List<API> oldApiVersionList = new ArrayList<>();
 


### PR DESCRIPTION
### Purpose

Fixes an inconsistency where deleting an Application published SUBSCRIPTIONS_DELETE notification events only for its plain-API subscriptions, silently dropping the event for any API Product subscriptions on that same application — even though deleting a subscription directly (not via app deletion) already worked correctly for both types.

### Goal
Fixes: https://github.com/wso2/api-manager/issues/5157

#### Root cause

`APIConsumerImpl.removeApplication()` fetched subscriptions via `ApiMgtDAO.getSubscribedAPIsByApplication()`, which explicitly filters out rows where `TYPE == API_PRODUCT`. That method is a shipped public API (originally added for Solace key-gen integration) and is left unchanged to avoid a backward-compatibility break for its other caller (`SolaceKeyGenNotifier`).

#### Implementation

- Added `ApiMgtDAO.getSubscribedAPIsAndAPIProductsByApplication()`: a new method that returns both API and API Product subscriptions, each correctly backed by its proper identifier type (APIIdentifier vs APIProductIdentifier).
- `removeApplication()` now calls this new method instead of the filtered one.
- Fixed a related latent NPE in `sendApplicationDeletionEvent()`: it read the subscription's name/version via `getAPIIdentifier()`, which is null for API Product-backed subscriptions. Switched to the type-agnostic `getIdentifier()` accessor (mirrors the existing fallback pattern already used by `getApiId()/getAPIUUId()`).

### Testing

- Unit tests added:
  - `APIMgtDAOTest#testGetSubscribedAPIsAndAPIProductsByApplication`: verifies the new DAO method returns both subscription types, each backed by the correct identifier class.
  - `APIConsumerImplTest#testSendApplicationDeletionEventForApiAndApiProductSubscriptions`: verifies `SUBSCRIPTIONS_DELETE` is dispatched exactly once per subscription (API + Product) with no NPE.
  - Full regression run of both test classes and the full module suite: 728/728 passing.
- Manual verification on a local wso2am-4.3.0 pack: created an Application subscribed to both a regular API and an API Product, deleted the application, and confirmed both `SUBSCRIPTIONS_DELETE` events fire (previously only one did).

### Backward compatibility

`getSubscribedAPIsByApplication()` (public, already shipped, used by SolaceKeyGenNotifier) is untouched; no behavior change for existing callers.