### PR TITLE
Add unit tests for analytics request/response body capture

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/test/java/org/wso2/carbon/apimgt/gateway/handlers/analytics/AnalyticsPayloadUtilTestCase.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/test/java/org/wso2/carbon/apimgt/gateway/handlers/analytics/AnalyticsPayloadUtilTestCase.java
@@ -1,0 +1,582 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.apimgt.gateway.handlers.analytics;
+
+import org.apache.axiom.om.OMAbstractFactory;
+import org.apache.axiom.om.OMElement;
+import org.apache.axiom.om.OMNamespace;
+import org.apache.axiom.soap.SOAPEnvelope;
+import org.apache.axiom.soap.SOAPFactory;
+import org.apache.axis2.builder.Builder;
+import org.apache.axis2.context.ConfigurationContext;
+import org.apache.axis2.engine.AxisConfiguration;
+import org.apache.axis2.transport.base.BaseConstants;
+import org.apache.commons.codec.binary.Base64;
+import org.apache.http.HttpHeaders;
+import org.apache.synapse.MessageContext;
+import org.apache.synapse.commons.json.JsonUtil;
+import org.apache.synapse.config.SynapseConfiguration;
+import org.apache.synapse.core.axis2.Axis2MessageContext;
+import org.apache.synapse.core.axis2.Axis2SynapseEnvironment;
+import org.apache.synapse.transport.passthru.PassThroughConstants;
+import org.apache.synapse.transport.passthru.util.RelayUtils;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.wso2.carbon.apimgt.impl.APIConstants;
+import org.wso2.carbon.apimgt.impl.APIManagerConfiguration;
+import org.wso2.carbon.apimgt.impl.utils.APIUtil;
+
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.TreeMap;
+
+import javax.xml.namespace.QName;
+
+/**
+ * Tests for {@link AnalyticsPayloadUtil} — the opt-in request/response body capture used by the Moesif
+ * analytics integration, plus the shared sensitive-header predicate.
+ *
+ * <p>Body capture must never disrupt the proxied call, so most of the surface here is about deciding
+ * <em>not</em> to capture: entity-less messages, excluded content types, content types with no registered
+ * message builder, and bodies that cannot be size-bounded before building.</p>
+ */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({APIManagerConfiguration.class, APIUtil.class, RelayUtils.class, JsonUtil.class,
+        AnalyticsPayloadUtil.class})
+public class AnalyticsPayloadUtilTestCase {
+
+    private static final String JSON_CONTENT_TYPE = "application/json";
+    private static final String JSON_BODY = "{\"a\":1}";
+    private static final String TEXT_BODY = "hello world";
+
+    private boolean previousInvalidLimitWarned;
+
+    /**
+     * {@code getPayloadSizeLimit} logs its warning at most once by flipping a static flag, which would
+     * otherwise make these tests order-dependent. Snapshot and reset it around every test, mirroring the
+     * static-state fixture in {@link SynapseAnalyticsDataProviderTestCase}.
+     */
+    @Before
+    public void resetStaticState() throws Exception {
+        previousInvalidLimitWarned = (boolean) invalidLimitWarnedField().get(null);
+        invalidLimitWarnedField().set(null, false);
+    }
+
+    @After
+    public void restoreStaticState() throws Exception {
+        invalidLimitWarnedField().set(null, previousInvalidLimitWarned);
+    }
+
+    // ----- isSensitiveHeader -----
+
+    @Test
+    public void testIsSensitiveHeaderMatchesCredentialHeaders() {
+        Assert.assertTrue(AnalyticsPayloadUtil.isSensitiveHeader(APIConstants.AUTHORIZATION_HEADER_DEFAULT));
+        Assert.assertTrue(AnalyticsPayloadUtil.isSensitiveHeader(APIConstants.API_KEY_HEADER_DEFAULT));
+    }
+
+    @Test
+    public void testIsSensitiveHeaderMatchesSessionHeaders() {
+        Assert.assertTrue(AnalyticsPayloadUtil.isSensitiveHeader(APIConstants.COOKIE));
+        Assert.assertTrue(AnalyticsPayloadUtil.isSensitiveHeader("Set-Cookie"));
+    }
+
+    @Test
+    public void testIsSensitiveHeaderIsCaseInsensitive() {
+        // HTTP/2 delivers header names in lower case, so a case-sensitive match would leak credentials.
+        Assert.assertTrue(AnalyticsPayloadUtil.isSensitiveHeader("authorization"));
+        Assert.assertTrue(AnalyticsPayloadUtil.isSensitiveHeader("AUTHORIZATION"));
+        Assert.assertTrue(AnalyticsPayloadUtil.isSensitiveHeader("set-cookie"));
+        Assert.assertTrue(AnalyticsPayloadUtil.isSensitiveHeader("cookie"));
+    }
+
+    @Test
+    public void testIsSensitiveHeaderAllowsOrdinaryHeaders() {
+        Assert.assertFalse(AnalyticsPayloadUtil.isSensitiveHeader(HttpHeaders.CONTENT_TYPE));
+        Assert.assertFalse(AnalyticsPayloadUtil.isSensitiveHeader("user-agent"));
+        Assert.assertFalse(AnalyticsPayloadUtil.isSensitiveHeader("X-Custom"));
+    }
+
+    @Test
+    public void testIsSensitiveHeaderHandlesNull() {
+        Assert.assertFalse(AnalyticsPayloadUtil.isSensitiveHeader(null));
+    }
+
+    // ----- CapturedBody -----
+
+    @Test
+    public void testCapturedBodyExposesBodyAndEncoding() {
+        AnalyticsPayloadUtil.CapturedBody captured =
+                new AnalyticsPayloadUtil.CapturedBody(JSON_BODY, Constants.TRANSFER_ENCODING_BASE64);
+
+        Assert.assertEquals(JSON_BODY, captured.getBody());
+        Assert.assertEquals(Constants.TRANSFER_ENCODING_BASE64, captured.getTransferEncoding());
+    }
+
+    // ----- shouldSendPayloads -----
+
+    @Test
+    public void testShouldSendPayloadsFalseWhenAnalyticsDisabled() {
+        mockAnalyticsEnabled(false);
+        mockAnalyticsProperties(singleProperty(Constants.SEND_PAYLOAD, "true"));
+
+        Assert.assertFalse("capture must not run when analytics is off; nothing would be published",
+                AnalyticsPayloadUtil.shouldSendPayloads());
+    }
+
+    @Test
+    public void testShouldSendPayloadsFalseWhenPropertiesNull() {
+        mockAnalyticsEnabled(true);
+        mockAnalyticsProperties(null);
+
+        Assert.assertFalse(AnalyticsPayloadUtil.shouldSendPayloads());
+    }
+
+    @Test
+    public void testShouldSendPayloadsFalseWhenPropertyAbsent() {
+        mockAnalyticsEnabled(true);
+        mockAnalyticsProperties(new HashMap<>());
+
+        Assert.assertFalse("body capture is opt-in and must default to off",
+                AnalyticsPayloadUtil.shouldSendPayloads());
+    }
+
+    @Test
+    public void testShouldSendPayloadsFalseWhenPropertyFalse() {
+        mockAnalyticsEnabled(true);
+        mockAnalyticsProperties(singleProperty(Constants.SEND_PAYLOAD, "false"));
+
+        Assert.assertFalse(AnalyticsPayloadUtil.shouldSendPayloads());
+    }
+
+    @Test
+    public void testShouldSendPayloadsTrueWhenPropertyTrue() {
+        mockAnalyticsEnabled(true);
+        mockAnalyticsProperties(singleProperty(Constants.SEND_PAYLOAD, "true"));
+
+        Assert.assertTrue(AnalyticsPayloadUtil.shouldSendPayloads());
+    }
+
+    // ----- getPayloadSizeLimit -----
+
+    @Test
+    public void testGetPayloadSizeLimitDefaultsWhenPropertiesNull() {
+        mockAnalyticsProperties(null);
+
+        Assert.assertEquals(Constants.DEFAULT_PAYLOAD_SIZE_LIMIT_BYTES, AnalyticsPayloadUtil.getPayloadSizeLimit());
+    }
+
+    @Test
+    public void testGetPayloadSizeLimitDefaultsWhenPropertyAbsent() {
+        mockAnalyticsProperties(new HashMap<>());
+
+        Assert.assertEquals(Constants.DEFAULT_PAYLOAD_SIZE_LIMIT_BYTES, AnalyticsPayloadUtil.getPayloadSizeLimit());
+    }
+
+    @Test
+    public void testGetPayloadSizeLimitReadsConfiguredValue() {
+        mockAnalyticsProperties(singleProperty(Constants.PAYLOAD_SIZE_LIMIT, "2048"));
+
+        Assert.assertEquals(2048, AnalyticsPayloadUtil.getPayloadSizeLimit());
+    }
+
+    @Test
+    public void testGetPayloadSizeLimitDefaultsWhenZero() {
+        // A zero limit would silently drop every body, so it is treated as misconfiguration.
+        mockAnalyticsProperties(singleProperty(Constants.PAYLOAD_SIZE_LIMIT, "0"));
+
+        Assert.assertEquals(Constants.DEFAULT_PAYLOAD_SIZE_LIMIT_BYTES, AnalyticsPayloadUtil.getPayloadSizeLimit());
+    }
+
+    @Test
+    public void testGetPayloadSizeLimitDefaultsWhenNegative() {
+        mockAnalyticsProperties(singleProperty(Constants.PAYLOAD_SIZE_LIMIT, "-1"));
+
+        Assert.assertEquals(Constants.DEFAULT_PAYLOAD_SIZE_LIMIT_BYTES, AnalyticsPayloadUtil.getPayloadSizeLimit());
+    }
+
+    @Test
+    public void testGetPayloadSizeLimitDefaultsWhenNotANumber() {
+        mockAnalyticsProperties(singleProperty(Constants.PAYLOAD_SIZE_LIMIT, "not-a-number"));
+
+        Assert.assertEquals(Constants.DEFAULT_PAYLOAD_SIZE_LIMIT_BYTES, AnalyticsPayloadUtil.getPayloadSizeLimit());
+    }
+
+    @Test
+    public void testGetPayloadSizeLimitRecoversAfterInvalidValue() throws Exception {
+        mockAnalyticsProperties(singleProperty(Constants.PAYLOAD_SIZE_LIMIT, "oops"));
+        Assert.assertEquals(Constants.DEFAULT_PAYLOAD_SIZE_LIMIT_BYTES, AnalyticsPayloadUtil.getPayloadSizeLimit());
+        Assert.assertTrue("an invalid value must arm the warn-once flag",
+                (boolean) invalidLimitWarnedField().get(null));
+
+        mockAnalyticsProperties(singleProperty(Constants.PAYLOAD_SIZE_LIMIT, "512"));
+        Assert.assertEquals(512, AnalyticsPayloadUtil.getPayloadSizeLimit());
+        Assert.assertFalse("a later valid value must re-arm warning for a future misconfiguration",
+                (boolean) invalidLimitWarnedField().get(null));
+    }
+
+    // ----- shouldCapturePayloadsWithoutContentLength -----
+
+    @Test
+    public void testShouldCapturePayloadsWithoutContentLengthDefaultsFalse() {
+        mockAnalyticsProperties(new HashMap<>());
+
+        Assert.assertFalse("skipping unbounded bodies keeps the default configuration memory-safe",
+                AnalyticsPayloadUtil.shouldCapturePayloadsWithoutContentLength());
+    }
+
+    @Test
+    public void testShouldCapturePayloadsWithoutContentLengthFalseWhenPropertiesNull() {
+        mockAnalyticsProperties(null);
+
+        Assert.assertFalse(AnalyticsPayloadUtil.shouldCapturePayloadsWithoutContentLength());
+    }
+
+    @Test
+    public void testShouldCapturePayloadsWithoutContentLengthTrueWhenConfigured() {
+        mockAnalyticsProperties(singleProperty(Constants.CAPTURE_PAYLOADS_WITHOUT_CONTENT_LENGTH, "true"));
+
+        Assert.assertTrue(AnalyticsPayloadUtil.shouldCapturePayloadsWithoutContentLength());
+    }
+
+    // ----- extractPayload: cases that must not capture -----
+
+    @Test
+    public void testExtractPayloadSkipsWhenNoEntityBody() throws Exception {
+        MessageContext messageContext = messageContext(JSON_CONTENT_TYPE, "10", JSON_CONTENT_TYPE);
+        axis2Of(messageContext).setProperty(PassThroughConstants.NO_ENTITY_BODY, Boolean.TRUE);
+
+        Assert.assertNull("GET/DELETE style messages have nothing to capture",
+                AnalyticsPayloadUtil.extractPayload(messageContext, 1024, "request"));
+    }
+
+    @Test
+    public void testExtractPayloadSkipsEventStreamContentType() throws Exception {
+        assertNotCaptured("text/event-stream");
+    }
+
+    @Test
+    public void testExtractPayloadSkipsMultipartContentType() throws Exception {
+        assertNotCaptured("multipart/form-data; boundary=abc");
+    }
+
+    @Test
+    public void testExtractPayloadSkipsFormUrlEncodedContentType() throws Exception {
+        assertNotCaptured("application/x-www-form-urlencoded");
+    }
+
+    @Test
+    public void testExtractPayloadSkipsWhenNoMessageBuilderRegistered() throws Exception {
+        // image/png has no registered builder, so building would fall back to the XML/SOAP builder and
+        // fail on binary data — corrupting the body being forwarded. It must be left unbuilt.
+        MessageContext messageContext = messageContext("image/png", "10", JSON_CONTENT_TYPE);
+
+        Assert.assertNull(AnalyticsPayloadUtil.extractPayload(messageContext, 1024, "request"));
+    }
+
+    @Test
+    public void testExtractPayloadSkipsWhenContentTypeMissing() throws Exception {
+        MessageContext messageContext = messageContext(null, "10", JSON_CONTENT_TYPE);
+
+        Assert.assertNull(AnalyticsPayloadUtil.extractPayload(messageContext, 1024, "request"));
+    }
+
+    @Test
+    public void testExtractPayloadDropsWhenDeclaredLengthExceedsLimit() throws Exception {
+        MessageContext messageContext = messageContext(JSON_CONTENT_TYPE, "5000", JSON_CONTENT_TYPE);
+        mockJsonPayload(JSON_BODY);
+
+        Assert.assertNull("an oversized body must be dropped before it is ever built",
+                AnalyticsPayloadUtil.extractPayload(messageContext, 1024, "request"));
+        PowerMockito.verifyStatic(RelayUtils.class, Mockito.never());
+        RelayUtils.buildMessage(axis2Of(messageContext));
+    }
+
+    @Test
+    public void testExtractPayloadSkipsWhenNoContentLengthAndNotOptedIn() throws Exception {
+        mockAnalyticsProperties(new HashMap<>());
+        MessageContext messageContext = messageContext(JSON_CONTENT_TYPE, null, JSON_CONTENT_TYPE);
+        mockJsonPayload(JSON_BODY);
+
+        Assert.assertNull("a chunked body cannot be size-bounded, so it is skipped by default",
+                AnalyticsPayloadUtil.extractPayload(messageContext, 1024, "request"));
+    }
+
+    @Test
+    public void testExtractPayloadCapturesWithoutContentLengthWhenOptedIn() throws Exception {
+        mockAnalyticsProperties(singleProperty(Constants.CAPTURE_PAYLOADS_WITHOUT_CONTENT_LENGTH, "true"));
+        MessageContext messageContext = messageContext(JSON_CONTENT_TYPE, null, JSON_CONTENT_TYPE);
+        mockJsonPayload(JSON_BODY);
+
+        AnalyticsPayloadUtil.CapturedBody captured =
+                AnalyticsPayloadUtil.extractPayload(messageContext, 1024, "request");
+
+        Assert.assertNotNull(captured);
+        Assert.assertEquals(JSON_BODY, captured.getBody());
+    }
+
+    @Test
+    public void testExtractPayloadCapturesWithoutContentLengthWhenAlreadyBuilt() throws Exception {
+        // The memory was already spent by an upstream mediator, so skipping would drop the body for free.
+        mockAnalyticsProperties(new HashMap<>());
+        MessageContext messageContext = messageContext(JSON_CONTENT_TYPE, null, JSON_CONTENT_TYPE);
+        axis2Of(messageContext).setProperty(PassThroughConstants.MESSAGE_BUILDER_INVOKED, Boolean.TRUE);
+        mockJsonPayload(JSON_BODY);
+
+        AnalyticsPayloadUtil.CapturedBody captured =
+                AnalyticsPayloadUtil.extractPayload(messageContext, 1024, "request");
+
+        Assert.assertNotNull(captured);
+        Assert.assertEquals(JSON_BODY, captured.getBody());
+    }
+
+    // ----- extractPayload: captured payloads by kind -----
+
+    @Test
+    public void testExtractPayloadCapturesJsonPayload() throws Exception {
+        MessageContext messageContext = messageContext(JSON_CONTENT_TYPE, "7", JSON_CONTENT_TYPE);
+        mockJsonPayload(JSON_BODY);
+
+        AnalyticsPayloadUtil.CapturedBody captured =
+                AnalyticsPayloadUtil.extractPayload(messageContext, 1024, "request");
+
+        Assert.assertNotNull(captured);
+        Assert.assertEquals(JSON_BODY, captured.getBody());
+        Assert.assertNull("JSON is published as-is; the publisher decides how to render it",
+                captured.getTransferEncoding());
+    }
+
+    @Test
+    public void testExtractPayloadDropsOversizedJsonPayload() throws Exception {
+        String oversized = "{\"a\":\"" + repeat('x', 200) + "\"}";
+        // No declared Content-Length here, so the pre-build gate cannot fire; the post-build byte check must.
+        mockAnalyticsProperties(singleProperty(Constants.CAPTURE_PAYLOADS_WITHOUT_CONTENT_LENGTH, "true"));
+        MessageContext messageContext = messageContext(JSON_CONTENT_TYPE, null, JSON_CONTENT_TYPE);
+        mockJsonPayload(oversized);
+
+        Assert.assertNull(AnalyticsPayloadUtil.extractPayload(messageContext, 100, "response"));
+    }
+
+    @Test
+    public void testExtractPayloadCapturesBinaryPayloadAsBase64() throws Exception {
+        byte[] raw = new byte[] {0x00, 0x01, 0x02, (byte) 0xFF};
+        MessageContext messageContext = messageContext(JSON_CONTENT_TYPE, "4", JSON_CONTENT_TYPE);
+        mockNonJsonPayload();
+        axis2Of(messageContext).setEnvelope(
+                envelopeWithWrapper(BaseConstants.DEFAULT_BINARY_WRAPPER, Base64.encodeBase64String(raw)));
+
+        AnalyticsPayloadUtil.CapturedBody captured =
+                AnalyticsPayloadUtil.extractPayload(messageContext, 1024, "request");
+
+        Assert.assertNotNull(captured);
+        Assert.assertArrayEquals(raw, Base64.decodeBase64(captured.getBody()));
+        Assert.assertEquals(Constants.TRANSFER_ENCODING_BASE64, captured.getTransferEncoding());
+    }
+
+    @Test
+    public void testExtractPayloadDropsOversizedBinaryPayload() throws Exception {
+        byte[] raw = new byte[256];
+        MessageContext messageContext = messageContext(JSON_CONTENT_TYPE, null, JSON_CONTENT_TYPE);
+        mockAnalyticsProperties(singleProperty(Constants.CAPTURE_PAYLOADS_WITHOUT_CONTENT_LENGTH, "true"));
+        mockNonJsonPayload();
+        axis2Of(messageContext).setEnvelope(
+                envelopeWithWrapper(BaseConstants.DEFAULT_BINARY_WRAPPER, Base64.encodeBase64String(raw)));
+
+        Assert.assertNull("the limit is compared against the decoded byte count",
+                AnalyticsPayloadUtil.extractPayload(messageContext, 100, "request"));
+    }
+
+    @Test
+    public void testExtractPayloadCapturesTextPayload() throws Exception {
+        MessageContext messageContext = messageContext(JSON_CONTENT_TYPE, "11", JSON_CONTENT_TYPE);
+        mockNonJsonPayload();
+        axis2Of(messageContext).setEnvelope(
+                envelopeWithWrapper(BaseConstants.DEFAULT_TEXT_WRAPPER, TEXT_BODY));
+
+        AnalyticsPayloadUtil.CapturedBody captured =
+                AnalyticsPayloadUtil.extractPayload(messageContext, 1024, "request");
+
+        Assert.assertNotNull(captured);
+        Assert.assertEquals(TEXT_BODY, captured.getBody());
+        Assert.assertNull(captured.getTransferEncoding());
+    }
+
+    @Test
+    public void testExtractPayloadCapturesAllXmlChildElements() throws Exception {
+        MessageContext messageContext = messageContext(JSON_CONTENT_TYPE, "40", JSON_CONTENT_TYPE);
+        mockNonJsonPayload();
+
+        SOAPFactory factory = OMAbstractFactory.getSOAP11Factory();
+        SOAPEnvelope envelope = factory.getDefaultEnvelope();
+        envelope.getBody().addChild(element(factory, "first", "one"));
+        envelope.getBody().addChild(element(factory, "second", "two"));
+        axis2Of(messageContext).setEnvelope(envelope);
+
+        AnalyticsPayloadUtil.CapturedBody captured =
+                AnalyticsPayloadUtil.extractPayload(messageContext, 1024, "request");
+
+        Assert.assertNotNull(captured);
+        Assert.assertTrue("a multi-element body must not be truncated to its first element",
+                captured.getBody().contains("one") && captured.getBody().contains("two"));
+        Assert.assertFalse("the synthetic SOAP Body wrapper must not be serialised",
+                captured.getBody().contains("Body"));
+    }
+
+    @Test
+    public void testExtractPayloadReturnsNullWhenBodyIsEmpty() throws Exception {
+        MessageContext messageContext = messageContext(JSON_CONTENT_TYPE, "0", JSON_CONTENT_TYPE);
+        mockNonJsonPayload();
+        axis2Of(messageContext).setEnvelope(OMAbstractFactory.getSOAP11Factory().getDefaultEnvelope());
+
+        Assert.assertNull(AnalyticsPayloadUtil.extractPayload(messageContext, 1024, "request"));
+    }
+
+    @Test
+    public void testExtractPayloadFailsSafeWhenBuildThrows() throws Exception {
+        MessageContext messageContext = messageContext(JSON_CONTENT_TYPE, "7", JSON_CONTENT_TYPE);
+        PowerMockito.mockStatic(JsonUtil.class);
+        PowerMockito.mockStatic(RelayUtils.class);
+        PowerMockito.doThrow(new IllegalStateException("boom")).when(RelayUtils.class);
+        RelayUtils.buildMessage(axis2Of(messageContext));
+
+        Assert.assertNull("capture must never propagate a failure into the proxied call",
+                AnalyticsPayloadUtil.extractPayload(messageContext, 1024, "request"));
+    }
+
+    // ----- helpers -----
+
+    private static Field invalidLimitWarnedField() throws Exception {
+        Field field = AnalyticsPayloadUtil.class.getDeclaredField("invalidLimitWarned");
+        field.setAccessible(true);
+        return field;
+    }
+
+    private static void mockAnalyticsEnabled(boolean enabled) {
+        PowerMockito.mockStatic(APIUtil.class);
+        PowerMockito.when(APIUtil.isAnalyticsEnabled()).thenReturn(enabled);
+    }
+
+    private static void mockAnalyticsProperties(Map<String, String> properties) {
+        PowerMockito.mockStatic(APIManagerConfiguration.class);
+        PowerMockito.when(APIManagerConfiguration.getAnalyticsProperties()).thenReturn(properties);
+    }
+
+    private static Map<String, String> singleProperty(String key, String value) {
+        Map<String, String> properties = new HashMap<>();
+        properties.put(key, value);
+        return properties;
+    }
+
+    /**
+     * Stubs the JSON detection so {@code extractPayload} takes the JSON branch, and neutralises
+     * {@code RelayUtils.buildMessage} (the real one would consume a pass-through pipe that does not exist).
+     */
+    private static void mockJsonPayload(String payload) {
+        PowerMockito.mockStatic(RelayUtils.class);
+        PowerMockito.mockStatic(JsonUtil.class);
+        PowerMockito.when(JsonUtil.hasAJsonPayload(Mockito.any(org.apache.axis2.context.MessageContext.class)))
+                .thenReturn(true);
+        PowerMockito.when(JsonUtil.jsonPayloadToString(Mockito.any(org.apache.axis2.context.MessageContext.class)))
+                .thenReturn(payload);
+    }
+
+    /** Neutralises the build and makes the JSON check fall through to the SOAP envelope branches. */
+    private static void mockNonJsonPayload() {
+        PowerMockito.mockStatic(RelayUtils.class);
+        PowerMockito.mockStatic(JsonUtil.class);
+        PowerMockito.when(JsonUtil.hasAJsonPayload(Mockito.any(org.apache.axis2.context.MessageContext.class)))
+                .thenReturn(false);
+    }
+
+    private void assertNotCaptured(String contentType) throws Exception {
+        MessageContext messageContext = messageContext(contentType, "10", JSON_CONTENT_TYPE);
+
+        Assert.assertNull("content type '" + contentType + "' must never be captured",
+                AnalyticsPayloadUtil.extractPayload(messageContext, 1024, "request"));
+    }
+
+    /**
+     * Builds a real {@link Axis2MessageContext} rather than a mock, so the message-builder registry that
+     * {@code hasRegisteredBuilder} consults is genuinely present: a builder is registered for
+     * {@code registeredContentType} and for nothing else.
+     *
+     * @param contentType           the message's {@code Content-Type} transport header, or {@code null} for none
+     * @param contentLength         the {@code Content-Length} transport header, or {@code null} for none
+     * @param registeredContentType the single content type that gets a registered message builder
+     */
+    private static MessageContext messageContext(String contentType, String contentLength,
+                                                 String registeredContentType) throws Exception {
+        AxisConfiguration axisConfiguration = new AxisConfiguration();
+        axisConfiguration.addMessageBuilder(registeredContentType, Mockito.mock(Builder.class));
+        ConfigurationContext configurationContext = new ConfigurationContext(axisConfiguration);
+        SynapseConfiguration synapseConfiguration = new SynapseConfiguration();
+        org.apache.axis2.context.MessageContext axis2MessageContext =
+                new org.apache.axis2.context.MessageContext();
+        axis2MessageContext.setConfigurationContext(configurationContext);
+
+        // Real transport headers are case-insensitive; mirror that so lookups behave as they do in production.
+        Map<String, Object> transportHeaders = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+        if (contentType != null) {
+            transportHeaders.put(HttpHeaders.CONTENT_TYPE, contentType);
+        }
+        if (contentLength != null) {
+            transportHeaders.put(HttpHeaders.CONTENT_LENGTH, contentLength);
+        }
+        axis2MessageContext.setProperty(org.apache.axis2.context.MessageContext.TRANSPORT_HEADERS, transportHeaders);
+
+        return new Axis2MessageContext(axis2MessageContext, synapseConfiguration,
+                new Axis2SynapseEnvironment(configurationContext, synapseConfiguration));
+    }
+
+    private static org.apache.axis2.context.MessageContext axis2Of(MessageContext messageContext) {
+        return ((Axis2MessageContext) messageContext).getAxis2MessageContext();
+    }
+
+    private static SOAPEnvelope envelopeWithWrapper(QName wrapper, String text) {
+        SOAPFactory factory = OMAbstractFactory.getSOAP11Factory();
+        SOAPEnvelope envelope = factory.getDefaultEnvelope();
+        OMNamespace namespace = factory.createOMNamespace(wrapper.getNamespaceURI(), wrapper.getPrefix());
+        OMElement element = factory.createOMElement(wrapper.getLocalPart(), namespace);
+        element.setText(text);
+        envelope.getBody().addChild(element);
+        return envelope;
+    }
+
+    private static OMElement element(SOAPFactory factory, String localName, String text) {
+        OMElement element = factory.createOMElement(localName, factory.createOMNamespace("http://test", "t"));
+        element.setText(text);
+        return element;
+    }
+
+    private static String repeat(char character, int count) {
+        StringBuilder builder = new StringBuilder(count);
+        for (int i = 0; i < count; i++) {
+            builder.append(character);
+        }
+        return builder.toString();
+    }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/test/java/org/wso2/carbon/apimgt/gateway/handlers/analytics/SynapseAnalyticsDataProviderBodyTestCase.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/test/java/org/wso2/carbon/apimgt/gateway/handlers/analytics/SynapseAnalyticsDataProviderBodyTestCase.java
@@ -1,0 +1,326 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.apimgt.gateway.handlers.analytics;
+
+import org.apache.axis2.context.MessageContext;
+import org.apache.http.HttpHeaders;
+import org.apache.synapse.core.axis2.Axis2MessageContext;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.wso2.carbon.apimgt.gateway.internal.ServiceReferenceHolder;
+import org.wso2.carbon.apimgt.impl.APIConstants;
+import org.wso2.carbon.apimgt.impl.APIManagerAnalyticsConfiguration;
+import org.wso2.carbon.apimgt.impl.APIManagerConfigurationService;
+
+import java.lang.reflect.Field;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.TreeMap;
+
+/**
+ * Tests for the request/response body wiring in {@link SynapseAnalyticsDataProvider#getProperties()}: the
+ * request body stashed on the message context during the request flow is republished under the wire keys, the
+ * response body is captured at event-collection time, and neither appears when body capture is disabled.
+ *
+ * <p>Kept separate from {@link SynapseAnalyticsDataProviderTestCase}, which deliberately uses plain Mockito;
+ * these tests need PowerMock to stub the static {@link AnalyticsPayloadUtil} seam.</p>
+ */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({AnalyticsPayloadUtil.class, SynapseAnalyticsDataProvider.class, ServiceReferenceHolder.class})
+public class SynapseAnalyticsDataProviderBodyTestCase {
+
+    private static final String REQUEST_BODY = "{\"in\":1}";
+    private static final String RESPONSE_BODY = "{\"out\":2}";
+
+    // Held as Object: it is only ever written straight back into the field, so there is nothing to gain from
+    // an unchecked cast to Map<String, String>.
+    private Object previousReporterProperties;
+
+    /**
+     * {@code reporterProperties} is a static cache that would otherwise leak between tests, and the provider
+     * loads it (plus the mask configuration) from {@link ServiceReferenceHolder}, which has no OSGi service in a
+     * unit test. Reset the cache and stand up a minimal configuration with headers off; the header tests
+     * override it via {@link #configureHeaders}.
+     */
+    @Before
+    public void resetStaticState() throws Exception {
+        Field field = SynapseAnalyticsDataProvider.class.getDeclaredField("reporterProperties");
+        field.setAccessible(true);
+        previousReporterProperties = field.get(null);
+        field.set(null, null);
+        configureHeaders(false);
+    }
+
+    /**
+     * Points {@link ServiceReferenceHolder} at an analytics configuration that reports the given
+     * {@code send_headers} value and declares no header masks.
+     */
+    private static void configureHeaders(boolean sendHeaders) {
+        APIManagerAnalyticsConfiguration analyticsConfiguration =
+                Mockito.mock(APIManagerAnalyticsConfiguration.class);
+        Mockito.when(analyticsConfiguration.getReporterProperties())
+                .thenReturn(singleStringProperty(Constants.SEND_HEADER, String.valueOf(sendHeaders)));
+        Mockito.when(analyticsConfiguration.getMaskDataProperties()).thenReturn(new HashMap<>());
+
+        APIManagerConfigurationService configurationService = Mockito.mock(APIManagerConfigurationService.class);
+        Mockito.when(configurationService.getAPIAnalyticsConfiguration()).thenReturn(analyticsConfiguration);
+
+        ServiceReferenceHolder holder = Mockito.mock(ServiceReferenceHolder.class);
+        Mockito.when(holder.getApiManagerConfigurationService()).thenReturn(configurationService);
+
+        PowerMockito.mockStatic(ServiceReferenceHolder.class);
+        PowerMockito.when(ServiceReferenceHolder.getInstance()).thenReturn(holder);
+    }
+
+    @After
+    public void restoreStaticState() throws Exception {
+        Field field = SynapseAnalyticsDataProvider.class.getDeclaredField("reporterProperties");
+        field.setAccessible(true);
+        field.set(null, previousReporterProperties);
+    }
+
+    // ----- request body -----
+
+    @Test
+    public void testGetPropertiesPublishesStashedRequestBody() throws Exception {
+        mockPayloadUtil(true);
+        Map<String, Object> properties = new HashMap<>();
+        properties.put(Constants.REQUEST_BODY_PROPERTY, REQUEST_BODY);
+        properties.put(Constants.REQUEST_BODY_TRANSFER_ENCODING_PROPERTY, Constants.TRANSFER_ENCODING_BASE64);
+
+        Map<String, Object> custom = collect(properties, Collections.emptyMap(), new HashMap<>());
+
+        Assert.assertEquals(REQUEST_BODY, custom.get(Constants.REQUEST_BODY));
+        Assert.assertEquals(Constants.TRANSFER_ENCODING_BASE64,
+                custom.get(Constants.REQUEST_BODY_TRANSFER_ENCODING));
+    }
+
+    @Test
+    public void testGetPropertiesOmitsRequestEncodingWhenNotStashed() throws Exception {
+        mockPayloadUtil(true);
+        Map<String, Object> properties = new HashMap<>();
+        properties.put(Constants.REQUEST_BODY_PROPERTY, REQUEST_BODY);
+
+        Map<String, Object> custom = collect(properties, Collections.emptyMap(), new HashMap<>());
+
+        Assert.assertEquals(REQUEST_BODY, custom.get(Constants.REQUEST_BODY));
+        Assert.assertFalse(custom.containsKey(Constants.REQUEST_BODY_TRANSFER_ENCODING));
+    }
+
+    @Test
+    public void testGetPropertiesIgnoresNonStringStashedRequestBody() throws Exception {
+        mockPayloadUtil(true);
+        Map<String, Object> properties = new HashMap<>();
+        properties.put(Constants.REQUEST_BODY_PROPERTY, 42);
+
+        Map<String, Object> custom = collect(properties, Collections.emptyMap(), new HashMap<>());
+
+        Assert.assertFalse(custom.containsKey(Constants.REQUEST_BODY));
+    }
+
+    @Test
+    public void testGetPropertiesPublishesRequestContentTypeCaseInsensitively() throws Exception {
+        mockPayloadUtil(true);
+        Map<String, Object> properties = new HashMap<>();
+        properties.put(Constants.REQUEST_BODY_PROPERTY, REQUEST_BODY);
+
+        // Lower-case header name, as delivered over HTTP/2.
+        Map<String, Object> requestHeaders = new HashMap<>();
+        requestHeaders.put("content-type", "application/xml");
+        Map<String, Object> analyticsMetadata = new HashMap<>();
+        analyticsMetadata.put(Constants.REQUEST_HEADERS, requestHeaders);
+
+        Map<String, Object> custom = collect(properties, Collections.emptyMap(), analyticsMetadata);
+
+        Assert.assertEquals("the body's content type must ride along even when send_headers is off",
+                "application/xml", custom.get(Constants.REQUEST_CONTENT_TYPE));
+    }
+
+    @Test
+    public void testGetPropertiesOmitsRequestContentTypeWhenHeaderAbsent() throws Exception {
+        mockPayloadUtil(true);
+        Map<String, Object> properties = new HashMap<>();
+        properties.put(Constants.REQUEST_BODY_PROPERTY, REQUEST_BODY);
+
+        Map<String, Object> analyticsMetadata = new HashMap<>();
+        analyticsMetadata.put(Constants.REQUEST_HEADERS, new HashMap<String, Object>());
+
+        Map<String, Object> custom = collect(properties, Collections.emptyMap(), analyticsMetadata);
+
+        Assert.assertFalse(custom.containsKey(Constants.REQUEST_CONTENT_TYPE));
+    }
+
+    // ----- response body -----
+
+    @Test
+    public void testGetPropertiesPublishesResponseBody() throws Exception {
+        mockPayloadUtil(true);
+        stubExtractedResponseBody(new AnalyticsPayloadUtil.CapturedBody(RESPONSE_BODY,
+                Constants.TRANSFER_ENCODING_BASE64));
+
+        Map<String, Object> custom = collect(new HashMap<>(), Collections.emptyMap(), new HashMap<>());
+
+        Assert.assertEquals(RESPONSE_BODY, custom.get(Constants.RESPONSE_BODY));
+        Assert.assertEquals(Constants.TRANSFER_ENCODING_BASE64,
+                custom.get(Constants.RESPONSE_BODY_TRANSFER_ENCODING));
+    }
+
+    @Test
+    public void testGetPropertiesOmitsResponseEncodingWhenNull() throws Exception {
+        mockPayloadUtil(true);
+        stubExtractedResponseBody(new AnalyticsPayloadUtil.CapturedBody(RESPONSE_BODY, null));
+
+        Map<String, Object> custom = collect(new HashMap<>(), Collections.emptyMap(), new HashMap<>());
+
+        Assert.assertEquals(RESPONSE_BODY, custom.get(Constants.RESPONSE_BODY));
+        Assert.assertFalse(custom.containsKey(Constants.RESPONSE_BODY_TRANSFER_ENCODING));
+    }
+
+    @Test
+    public void testGetPropertiesOmitsResponseBodyWhenNothingCaptured() throws Exception {
+        mockPayloadUtil(true);
+        stubExtractedResponseBody(null);
+
+        Map<String, Object> custom = collect(new HashMap<>(), Collections.emptyMap(), new HashMap<>());
+
+        Assert.assertFalse(custom.containsKey(Constants.RESPONSE_BODY));
+        Assert.assertFalse(custom.containsKey(Constants.RESPONSE_BODY_TRANSFER_ENCODING));
+    }
+
+    // ----- disabled -----
+
+    @Test
+    public void testGetPropertiesPublishesNoBodiesWhenCaptureDisabled() throws Exception {
+        mockPayloadUtil(false);
+        Map<String, Object> properties = new HashMap<>();
+        properties.put(Constants.REQUEST_BODY_PROPERTY, REQUEST_BODY);
+        properties.put(Constants.REQUEST_BODY_TRANSFER_ENCODING_PROPERTY, Constants.TRANSFER_ENCODING_BASE64);
+
+        Map<String, Object> custom = collect(properties, Collections.emptyMap(), new HashMap<>());
+
+        Assert.assertFalse("body capture is opt-in; a stashed body must stay unpublished",
+                custom.containsKey(Constants.REQUEST_BODY));
+        Assert.assertFalse(custom.containsKey(Constants.REQUEST_BODY_TRANSFER_ENCODING));
+        Assert.assertFalse(custom.containsKey(Constants.RESPONSE_BODY));
+    }
+
+    // ----- response header sanitising -----
+
+    /**
+     * Uses the real {@link AnalyticsPayloadUtil#isSensitiveHeader} rather than a PowerMock stub: the production
+     * call site is a method reference, which PowerMock does not reliably intercept. Body capture stays off here
+     * because {@code shouldSendPayloads()} needs analytics to be enabled, which it is not in a unit test.
+     */
+    @Test
+    public void testGetPropertiesStripsSensitiveResponseHeaders() throws Exception {
+        configureHeaders(true);
+
+        Map<String, Object> transportHeaders = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+        transportHeaders.put(APIConstants.AUTHORIZATION_HEADER_DEFAULT, "Bearer secret");
+        transportHeaders.put(APIConstants.API_KEY_HEADER_DEFAULT, "key-secret");
+        transportHeaders.put(APIConstants.COOKIE, "session=abc");
+        transportHeaders.put(HttpHeaders.CONTENT_TYPE, "application/json");
+
+        Map<String, Object> custom = collect(new HashMap<>(), transportHeaders, new HashMap<>());
+
+        Map<?, ?> published = (Map<?, ?>) custom.get(Constants.RESPONSE_HEADERS);
+        Assert.assertNotNull(published);
+        Assert.assertFalse("Authorization must never reach analytics",
+                published.containsKey(APIConstants.AUTHORIZATION_HEADER_DEFAULT));
+        Assert.assertFalse(published.containsKey(APIConstants.API_KEY_HEADER_DEFAULT));
+        Assert.assertFalse(published.containsKey(APIConstants.COOKIE));
+        Assert.assertTrue("ordinary headers must still be published",
+                published.containsKey(HttpHeaders.CONTENT_TYPE));
+    }
+
+    @Test
+    public void testGetPropertiesLeavesLiveTransportHeaderMapUntouched() throws Exception {
+        configureHeaders(true);
+
+        Map<String, Object> transportHeaders = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+        transportHeaders.put(APIConstants.AUTHORIZATION_HEADER_DEFAULT, "Bearer secret");
+        transportHeaders.put(HttpHeaders.CONTENT_TYPE, "application/json");
+
+        collect(new HashMap<>(), transportHeaders, new HashMap<>());
+
+        Assert.assertTrue("the headers are copied before stripping; the live map must not be mutated",
+                transportHeaders.containsKey(APIConstants.AUTHORIZATION_HEADER_DEFAULT));
+    }
+
+    // ----- helpers -----
+
+    /** Stubs the static config seam so body capture can be switched on without a real analytics configuration. */
+    private static void mockPayloadUtil(boolean sendPayloads) {
+        PowerMockito.mockStatic(AnalyticsPayloadUtil.class);
+        PowerMockito.when(AnalyticsPayloadUtil.shouldSendPayloads()).thenReturn(sendPayloads);
+        PowerMockito.when(AnalyticsPayloadUtil.getPayloadSizeLimit())
+                .thenReturn(Constants.DEFAULT_PAYLOAD_SIZE_LIMIT_BYTES);
+    }
+
+    private static void stubExtractedResponseBody(AnalyticsPayloadUtil.CapturedBody captured) {
+        PowerMockito.when(AnalyticsPayloadUtil.extractPayload(Mockito.any(org.apache.synapse.MessageContext.class),
+                Mockito.anyInt(), Mockito.anyString())).thenReturn(captured);
+    }
+
+    private static Map<String, Object> collect(Map<String, Object> properties, Map<String, Object> transportHeaders,
+                                               Map<String, Object> analyticsMetadata) throws Exception {
+        Axis2MessageContext messageContext = mockAxis2MessageContext(properties, transportHeaders, analyticsMetadata);
+        SynapseAnalyticsDataProvider provider = new SynapseAnalyticsDataProvider(messageContext);
+        setBuildResponseMessage(provider, false);
+        return provider.getProperties();
+    }
+
+    private static Axis2MessageContext mockAxis2MessageContext(Map<String, Object> properties,
+                                                               Map<String, Object> transportHeaders,
+                                                               Map<String, Object> analyticsMetadata) {
+        Axis2MessageContext messageContext = Mockito.mock(Axis2MessageContext.class);
+        org.apache.axis2.context.MessageContext axis2MessageContext =
+                Mockito.mock(org.apache.axis2.context.MessageContext.class);
+
+        Mockito.when(messageContext.getAxis2MessageContext()).thenReturn(axis2MessageContext);
+        Mockito.when(axis2MessageContext.getProperty(MessageContext.TRANSPORT_HEADERS)).thenReturn(transportHeaders);
+        Mockito.when(messageContext.getPropertyKeySet()).thenAnswer(invocation -> properties.keySet());
+        Mockito.when(messageContext.getProperty(Mockito.anyString()))
+                .thenAnswer(invocation -> properties.get((String) invocation.getArguments()[0]));
+        Mockito.doReturn(analyticsMetadata).when(messageContext).getAnalyticsMetadata();
+
+        return messageContext;
+    }
+
+    private static Map<String, String> singleStringProperty(String key, String value) {
+        Map<String, String> map = new HashMap<>();
+        map.put(key, value);
+        return map;
+    }
+
+    private static void setBuildResponseMessage(SynapseAnalyticsDataProvider provider, boolean value)
+            throws Exception {
+        Field field = SynapseAnalyticsDataProvider.class.getDeclaredField("buildResponseMessage");
+        field.setAccessible(true);
+        field.set(provider, value);
+    }
+}


### PR DESCRIPTION
## Purpose

- **Related issue:** https://github.com/wso2/api-manager/issues/5128
- **Feature PR this covers:** https://github.com/wso2/carbon-apimgt/pull/13927/

Adds unit tests for the analytics request/response body capture merged in #13927.

### Problem

`AnalyticsPayloadUtil` is almost entirely a set of decisions about when *not* to capture a body, and each of those guards exists to protect the proxied call:

- Content types with no registered Axis2 message builder must be left unbuilt: building them falls back to the XML/SOAP builder, which throws on binary data, and because building consumes the pass-through pipe that failure would corrupt the body being forwarded.
- Oversized bodies must be dropped **before** `RelayUtils.buildMessage`, or an oversized payload gets buffered into memory only to be discarded.
- Bodies with no `Content-Length` must be skipped by default, since their size cannot be bounded before building.
- Any unexpected failure must fail safe and return `null`.

None of that was covered, so a regression in any guard would surface as corrupted proxied traffic or an OOM under load rather than a failing test. The sensitive-header predicate was likewise untested despite being the single point that keeps `Authorization` / `ApiKey` / `Cookie` out of analytics.

### Intended outcome

Every skip/drop guard, every capture path, and the credential-stripping predicate are covered, so a regression shows up as a test failure.

## Goals

- Cover `isSensitiveHeader` including the case-insensitive match (the HTTP/2 lower-case header fix) and the `null` guard.
- Cover the three configuration readers, including invalid `payload_size_limit` values and the warn-once flag's reset behaviour.
- Cover `extractPayload` end to end: each skip reason, the pre-build size gate, the no-`Content-Length` policy and both of its opt-in escapes, and the JSON / binary / text / XML capture paths with their size limits.
- Cover the `SynapseAnalyticsDataProvider` wiring: bodies republished under the wire keys, the `requestContentType` lookup, and the response-header copy-and-strip.

## Approach

| File | Change |
|------|--------|
| `AnalyticsPayloadUtilTestCase.java` **(new)** | 39 JUnit 4 tests, tiered: plain assertions for `isSensitiveHeader` / `CapturedBody`, PowerMock for the config statics, and a **real** `Axis2MessageContext` for `extractPayload`. |
| `SynapseAnalyticsDataProviderBodyTestCase.java` **(new)** | 11 tests driving `getProperties()` for the body publish, the `requestContentType` lookup, and response-header sanitising. |

Some deliberate choices:

**PowerMock is unavoidable here.** The gateway module is on `mockito-core` 2.23.4, which has no`Mockito.mockStatic`, and every seam in this code is static (`APIUtil.isAnalyticsEnabled`,`APIManagerConfiguration.getAnalyticsProperties`, `RelayUtils.buildMessage`, `JsonUtil`). The idiom follows the existing precedents in this module (`AzureUMIMediatorTest`, `APIStatusHandlerTest`,`APIMgtLatencyStatsHandlerTest`).

**`extractPayload` uses a real message context, not mocks.** `hasRegisteredBuilder` consults `getConfigurationContext().getAxisConfiguration().getMessageBuilder(type, false)`, so the tests build a real `AxisConfiguration` and register a builder for exactly one content type. That is both shorter than stubbing three levels of mocks and a truer test  (it exercises the real registry lookup). Transport headers are a `TreeMap(CASE_INSENSITIVE_ORDER)`, matching the transport's real behaviour.

**A separate DataProvider test class rather than extending `SynapseAnalyticsDataProviderTestCase`.** That class deliberately uses plain Mockito with no runner; the body tests need PowerMock to stub the static `AnalyticsPayloadUtil` seam, and adding a runner to it would put its nine existing tests at risk for no benefit. One caveat is documented in the new class: the production response-header strip uses a **method reference** (`AnalyticsPayloadUtil::isSensitiveHeader`), which PowerMock does not reliably intercept, so that test exercises the real predicate instead of a stub.