### PR TITLE
Fix incorrect JMSTaskManager closing tag in api-manager.xml.j2

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/templates/repository/conf/api-manager.xml.j2
+++ b/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/templates/repository/conf/api-manager.xml.j2
@@ -1292,7 +1292,7 @@
                 {% elif apim.throttling.jms.job_queue_size is defined %}
                 <JobQueueSize>{{apim.throttling.jms.job_queue_size}}</JobQueueSize>
                 {% endif %}
-            <JMSTaskManager>
+            </JMSTaskManager>
             {% endif %}
             <JMSConnectionParameters>
                 <transport.jms.ConnectionFactoryJNDIName>{{apim.throttling.jms.conn_jndi_name}}</transport.jms.ConnectionFactoryJNDIName>


### PR DESCRIPTION
## Summary
- Fixes incorrect closing tag `<JMSTaskManager>` → `</JMSTaskManager>` in `features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/templates/repository/conf/api-manager.xml.j2`
- The malformed tag caused `api-manager.xml` to be generated with invalid XML when any `[apim.event_hub.listener]` or `[apim.throttling.jms]` thread pool config was set in `deployment.toml`, resulting in server startup failure
- The bug is hidden in a Jinja `{% if %}` block so default deployments are unaffected

## Test Steps
1. Add to `deployment.toml`:
   ```toml
   [apim.event_hub.listener]
   min_thread_pool_size = 10
   max_thread_pool_size = 100
   keep_alive_time_in_millis = 1000
   job_queue_size = 10
   ```
2. Start the server — should start successfully without XML parse errors.

Fixes https://github.com/wso2/api-manager/issues/5177