### PR TITLE
Resolve the reference API of an MCP Server at import time

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/ExceptionCodes.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/ExceptionCodes.java
@@ -927,6 +927,9 @@ public enum ExceptionCodes implements ErrorHandler {
             "One or more MCP tools are duplicated."),
     INVALID_MCP_BACKEND_OPERATION(904014, "Invalid MCP backend operation", 400,
             "The backend operation '%s %s' does not match any resource in the referenced API '%s'."),
+    REFERENCE_API_NOT_FOUND(904015, "Reference API not found", 400,
+            "The API this MCP Server is built on (name '%s', version '%s', id '%s') does not exist in this "
+                    + "environment. Create that API here before importing the MCP Server."),
 
     // gateway notification related codes
     GATEWAY_NOTIFICATION_BAD_REQUEST(902052, "Invalid request for gateway notification", 400,

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ImportUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ImportUtils.java
@@ -94,12 +94,14 @@ import org.wso2.carbon.apimgt.rest.api.common.RestApiConstants;
 import org.wso2.carbon.apimgt.rest.api.publisher.v1.common.internal.ServiceReferenceHolder;
 import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.APIDTO;
 import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.APIInfoAdditionalPropertiesDTO;
+import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.APIOperationMappingDTO;
 import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.APIOperationsDTO;
 import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.APIProductDTO;
 import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.DocumentDTO;
 import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.GraphQLQueryComplexityInfoDTO;
 import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.GraphQLValidationResponseDTO;
 import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.MCPServerDTO;
+import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.MCPServerOperationDTO;
 import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.OperationPolicyDataDTO;
 import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.ProductAPIDTO;
 import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.SubtypeConfigurationDTO;
@@ -767,6 +769,8 @@ public class ImportUtils {
             final String currentTenantDomain =
                     MultitenantUtils.getTenantDomain(APIUtil.replaceEmailDomainBack(userName));
 
+            updateReferencedApiUuids(importedApiDTO, apiProvider, currentTenantDomain, organization);
+
             targetStatus = importedApiDTO.getLifeCycleStatus();
             APIUtil.validateAPIContext(importedApiDTO.getContext(), importedApiDTO.getName());
 
@@ -1025,7 +1029,46 @@ public class ImportUtils {
                 throw new APIManagementException("Error while importing API: " + e.getMessage(),
                         ExceptionCodes.from(ExceptionCodes.API_CONTEXT_MALFORMED_EXCEPTION, e.getMessage()));
             }
-            throw new APIManagementException(errorMessage + StringUtils.SPACE + e.getMessage(), e);
+            // Carry the original error handler forward. Otherwise every import failure is reported as a generic
+            // server error, hiding the actual reason (for example a referenced API missing in this environment).
+            ErrorHandler errorHandler = e.getErrorHandler() != null
+                    ? e.getErrorHandler()
+                    : ExceptionCodes.INTERNAL_ERROR;
+            throw new APIManagementException(errorMessage + StringUtils.SPACE + e.getMessage(), e, errorHandler);
+        }
+    }
+
+    /**
+     * This method updates the UUIDs of the APIs referenced by an MCP Server, when the referenced APIs are already
+     * inside APIM. The exported artifact carries the UUID of the source environment, which does not resolve in
+     * another environment, hence the referenced API is looked up by its name and version.
+     *
+     * @param importedMCPServerDTO MCP Server DTO
+     * @param apiProvider          API Provider
+     * @param currentTenantDomain  Current tenant domain
+     * @param organization         Identifier of the organization
+     * @throws APIManagementException If failed when checking the existence of an API
+     */
+    private static void updateReferencedApiUuids(MCPServerDTO importedMCPServerDTO, APIProvider apiProvider,
+                                                 String currentTenantDomain, String organization)
+            throws APIManagementException {
+
+        if (importedMCPServerDTO.getOperations() == null) {
+            return;
+        }
+        for (MCPServerOperationDTO operation : importedMCPServerDTO.getOperations()) {
+            APIOperationMappingDTO apiOperationMapping = operation.getApiOperationMapping();
+            // The name and the version are the key the referenced API is looked up by. When they are not available,
+            // the UUID carried by the artifact is left untouched and resolved as before.
+            if (apiOperationMapping == null || StringUtils.isBlank(apiOperationMapping.getApiName())
+                    || StringUtils.isBlank(apiOperationMapping.getApiVersion())) {
+                continue;
+            }
+            API referencedApi = retrieveApiToOverwrite(apiOperationMapping.getApiName(),
+                    apiOperationMapping.getApiVersion(), currentTenantDomain, apiProvider, Boolean.TRUE, organization);
+            if (referencedApi != null) {
+                apiOperationMapping.setApiId(referencedApi.getUuid());
+            }
         }
     }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/PublisherCommonUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/PublisherCommonUtils.java
@@ -41,6 +41,7 @@ import io.swagger.v3.parser.ObjectMapperFactory;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.http.HttpResponse;
@@ -57,6 +58,7 @@ import org.wso2.carbon.apimgt.api.APIComplianceException;
 import org.wso2.carbon.apimgt.api.APIDefinition;
 import org.wso2.carbon.apimgt.api.APIDefinitionValidationResponse;
 import org.wso2.carbon.apimgt.api.APIManagementException;
+import org.wso2.carbon.apimgt.api.APIMgtResourceNotFoundException;
 import org.wso2.carbon.apimgt.api.APIProvider;
 import org.wso2.carbon.apimgt.api.ErrorHandler;
 import org.wso2.carbon.apimgt.api.ExceptionCodes;
@@ -193,6 +195,7 @@ import static org.wso2.carbon.apimgt.impl.APIConstants.REPUBLISH;
 public class PublisherCommonUtils {
 
     private static final Log log = LogFactory.getLog(PublisherCommonUtils.class);
+    private static final String UNKNOWN_REFERENCE = "UNKNOWN";
     public static final String SESSION_TIMEOUT_CONFIG_KEY = "sessionTimeOut";
     static APIMGovernanceService apimGovernanceService = ServiceReferenceHolder.getInstance()
             .getAPIMGovernanceService();
@@ -2547,15 +2550,37 @@ public class PublisherCommonUtils {
             return apiToAdd.getUriTemplates();
         }
 
-        String backendApiUuid = template.getAPIOperationMapping().getApiUuid();
+        APIOperationMapping apiOperationMapping = template.getAPIOperationMapping();
+        String backendApiUuid = apiOperationMapping.getApiUuid();
 
-        API refApi = StringUtils.isNotEmpty(backendApiUuid)
-                ? apiProvider.getAPIbyUUID(backendApiUuid, organization)
-                : null;
+        API refApi = null;
+        if (StringUtils.isNotEmpty(backendApiUuid)) {
+            try {
+                refApi = apiProvider.getAPIbyUUID(backendApiUuid, organization);
+            } catch (APIManagementException e) {
+                // A referenced API that does not exist in this environment surfaces as a retrieval failure caused by
+                // an APIMgtResourceNotFoundException. It is reported below against the API the artifact names, which
+                // is more useful than the UUID alone since the UUID is environment specific. Any other failure is a
+                // genuine retrieval error and is left untouched.
+                Throwable cause = ExceptionUtils.getRootCause(e);
+                cause = cause == null ? e : cause;
+                if (!(cause instanceof APIMgtResourceNotFoundException)) {
+                    throw e;
+                }
+                if (log.isDebugEnabled()) {
+                    log.debug("Referenced API not found for UUID: " + backendApiUuid, e);
+                }
+            }
+        }
         if (refApi == null) {
-            String error = "Referenced API not found. UUID: " + backendApiUuid;
+            String refApiName = StringUtils.defaultIfBlank(apiOperationMapping.getApiName(), UNKNOWN_REFERENCE);
+            String refApiVersion = StringUtils.defaultIfBlank(apiOperationMapping.getApiVersion(), UNKNOWN_REFERENCE);
+            String refApiUuid = StringUtils.defaultIfBlank(backendApiUuid, UNKNOWN_REFERENCE);
+            String error = "Referenced API not found. Name: " + refApiName + ", version: " + refApiVersion
+                    + ", UUID: " + refApiUuid;
             log.error(error);
-            throw new APIManagementException(error, ExceptionCodes.API_NOT_FOUND);
+            throw new APIManagementException(error, ExceptionCodes.from(ExceptionCodes.REFERENCE_API_NOT_FOUND,
+                    refApiName, refApiVersion, refApiUuid));
         }
         if (!APIConstants.API_TYPE_HTTP.equalsIgnoreCase(refApi.getType())
                 || APIConstants.API_SUBTYPE_AI_API.equalsIgnoreCase(refApi.getSubtype())) {

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/test/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ImportUtilsMCPServerTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/test/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ImportUtilsMCPServerTest.java
@@ -29,6 +29,7 @@ import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 import org.wso2.carbon.apimgt.api.APIManagementException;
 import org.wso2.carbon.apimgt.api.APIProvider;
+import org.wso2.carbon.apimgt.api.ExceptionCodes;
 import org.wso2.carbon.apimgt.api.model.API;
 import org.wso2.carbon.apimgt.api.model.APIIdentifier;
 import org.wso2.carbon.apimgt.api.model.APIRevisionDeployment;
@@ -36,7 +37,9 @@ import org.wso2.carbon.apimgt.api.model.Backend;
 import org.wso2.carbon.apimgt.impl.APIConstants;
 import org.wso2.carbon.apimgt.impl.utils.APIUtil;
 import org.wso2.carbon.apimgt.rest.api.common.RestApiCommonUtil;
+import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.APIOperationMappingDTO;
 import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.MCPServerDTO;
+import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.MCPServerOperationDTO;
 import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.SubtypeConfigurationDTO;
 import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
 
@@ -374,6 +377,110 @@ public class ImportUtilsMCPServerTest {
                     + "for SERVER_PROXY subtype");
         } catch (APIManagementException e) {
             Assert.assertTrue(e.getMessage().contains("No backends found to update for API"));
+        }
+    }
+
+    /**
+     * Builds an EXISTING_API subtype MCP Server carrying a single tool mapped onto a referenced API.
+     *
+     * @param referencedApiId      UUID the artifact carries for the referenced API
+     * @param referencedApiName    name of the referenced API, null when the artifact does not carry it
+     * @param referencedApiVersion version of the referenced API, null when the artifact does not carry it
+     * @return the operation mapping held by the MCP Server, so that it can be asserted on after the import
+     */
+    private APIOperationMappingDTO withReferencedApi(String referencedApiId, String referencedApiName,
+                                                     String referencedApiVersion) {
+
+        SubtypeConfigurationDTO subtypeConfig = new SubtypeConfigurationDTO();
+        subtypeConfig.setSubtype(APIConstants.API_SUBTYPE_EXISTING_API);
+        mcpServerDTO.setSubtypeConfiguration(subtypeConfig);
+
+        APIOperationMappingDTO apiOperationMapping = new APIOperationMappingDTO();
+        apiOperationMapping.setApiId(referencedApiId);
+        apiOperationMapping.setApiName(referencedApiName);
+        apiOperationMapping.setApiVersion(referencedApiVersion);
+
+        MCPServerOperationDTO operation = new MCPServerOperationDTO();
+        operation.setTarget("getMenu");
+        operation.setApiOperationMapping(apiOperationMapping);
+        mcpServerDTO.setOperations(Collections.singletonList(operation));
+
+        return apiOperationMapping;
+    }
+
+    /**
+     * The UUID carried by the artifact belongs to the environment it was exported from. When the referenced API is
+     * present here under the same name and version, the mapping is moved onto the UUID of this environment.
+     */
+    @Test
+    public void testImportMCPServerResolvesReferencedApiUuidOfThisEnvironment() throws Exception {
+
+        APIOperationMappingDTO apiOperationMapping =
+                withReferencedApi("uuid-of-the-source-environment", "BackendPizzaAPI", "1.0.0");
+        setupMCPServerDTOMock(mcpServerDTO);
+
+        ImportUtils.importMCPServer(EXTRACTED_PATH, mcpServerDTO, true, false, true,
+                false, false, tokenScopes, null, ORGANIZATION);
+
+        Assert.assertEquals("The referenced API should be resolved to the UUID of this environment",
+                API_UUID, apiOperationMapping.getApiId());
+    }
+
+    /**
+     * The name and the version are the key the referenced API is looked up by. An artifact that does not carry them
+     * keeps the UUID it came with, so that it is resolved the way it was before the lookup was introduced.
+     */
+    @Test
+    public void testImportMCPServerKeepsReferencedApiUuidWhenNameAndVersionAreMissing() throws Exception {
+
+        APIOperationMappingDTO apiOperationMapping = withReferencedApi("uuid-carried-by-the-artifact", null, null);
+        setupMCPServerDTOMock(mcpServerDTO);
+
+        // Match a lookup made with no name and no version too, so that the assertion fails if one is ever made.
+        PowerMockito.doReturn(targetApi).when(ImportUtils.class, "retrieveApiToOverwrite",
+                ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.anyString(),
+                ArgumentMatchers.any(APIProvider.class), ArgumentMatchers.any(Boolean.class),
+                ArgumentMatchers.anyString());
+
+        ImportUtils.importMCPServer(EXTRACTED_PATH, mcpServerDTO, true, false, true,
+                false, false, tokenScopes, null, ORGANIZATION);
+
+        Assert.assertEquals("The UUID carried by the artifact should be left untouched",
+                "uuid-carried-by-the-artifact", apiOperationMapping.getApiId());
+    }
+
+    /**
+     * An import failure is reported with the error of the failure that caused it. Reporting it as a generic server
+     * error hides the reason, such as a referenced API that is absent from this environment.
+     */
+    @Test
+    public void testImportMCPServerReportsTheErrorOfTheUnderlyingFailure() throws Exception {
+
+        withReferencedApi("uuid-of-the-source-environment", "BackendPizzaAPI", "1.0.0");
+        setupMCPServerDTOMock(mcpServerDTO);
+
+        // Take the creation path, where the reference is resolved while the MCP Server is being added.
+        PowerMockito.doReturn(null).when(ImportUtils.class, "retrieveApiToOverwrite",
+                ArgumentMatchers.anyString(), ArgumentMatchers.anyString(),
+                ArgumentMatchers.anyString(), ArgumentMatchers.any(APIProvider.class),
+                ArgumentMatchers.any(Boolean.class), ArgumentMatchers.anyString());
+
+        Mockito.when(PublisherCommonUtils.addAPIWithGeneratedSwaggerDefinition(
+                        ArgumentMatchers.any(APIDTOTypeWrapper.class), ArgumentMatchers.anyString(),
+                        ArgumentMatchers.anyString(), ArgumentMatchers.anyString(), ArgumentMatchers.any()))
+                .thenThrow(new APIManagementException("Referenced API not found",
+                        ExceptionCodes.from(ExceptionCodes.REFERENCE_API_NOT_FOUND,
+                                "BackendPizzaAPI", "1.0.0", "uuid-of-the-source-environment")));
+
+        try {
+            ImportUtils.importMCPServer(EXTRACTED_PATH, mcpServerDTO, true, false, false,
+                    false, false, tokenScopes, null, ORGANIZATION);
+            Assert.fail("Should throw APIManagementException when the referenced API cannot be resolved");
+        } catch (APIManagementException e) {
+            Assert.assertEquals("The error of the underlying failure should be reported",
+                    ExceptionCodes.REFERENCE_API_NOT_FOUND.getErrorCode(), e.getErrorHandler().getErrorCode());
+            Assert.assertEquals("A reference that cannot be resolved is a bad request",
+                    400, e.getErrorHandler().getHttpStatusCode());
         }
     }
 }


### PR DESCRIPTION
## Purpose

Importing an `EXISTING_API` subtype MCP Server into an environment other than the one it was exported from always failed, even when the API it is built on was present in the target environment.

Fixes: https://github.com/wso2/api-manager/issues/5174

## Problem

The exported `mcp_server.yaml` carries the reference API under `apiOperationMapping`:

```yaml
apiOperationMapping:
  apiId: edf6c2dd-bfc4-4d9f-bf0c-acd2615fc7ec   # UUID of the source environment
  apiName: BackendPizzaAPI
  apiVersion: 1.0.0
  apiContext: /backendpizza/1.0.0
```

The UUID belongs to the environment the artifact was exported from, and nothing resolved it against the target environment, so the import failed with an opaque error:

```
{"code":900967,"message":"General Error","description":"Server Error Occurred"}
```

```
WARN  - ApiMgtDAO Unable to find provider for API: testAPIsMCP in the database
INFO  - ImportUtils Cannot find : testAPIsMCP-1.0. Creating it.
ERROR - GlobalThrowableMapper Error while importing API:  Failed to get API
```

Two further defects kept the reason hidden:

- `resolveExistingMCPBackendAPI` guarded on `getAPIbyUUID` returning null, but that method throws for an API that does not exist and only returns null when the UUID is blank. The guard, and the message it carried, were unreachable for the case they were written for.
- `importMCPServer` rethrew through `APIManagementException(String, Throwable)`, a constructor that hardcodes `ExceptionCodes.INTERNAL_ERROR`, flattening every import failure into a generic server error.

## Approach

**Resolve the reference.** The reference API is looked up by its name and version in the importing environment and the mapping is updated with the local UUID. This is the same resolution already used for the dependent APIs of an API Product (`updateDependentApiUuids`), and it runs before the create and the update paths so both are covered. When the artifact does not carry a name and a version, the UUID it came with is left untouched and resolved as before.

**Report the reason.** A retrieval failure whose root cause is an `APIMgtResourceNotFoundException` now leaves the reference unresolved so the existing guard is reached; any other failure keeps propagating untouched. The guard reports the new `REFERENCE_API_NOT_FOUND` (904015), a 400 that names the API, the version and the id the artifact points at, in line with the other MCP codes that report an unusable artifact. `importMCPServer` carries the original error handler forward.

```
{"code":904015,"message":"Reference API not found",
 "description":"The API this MCP Server is built on (name 'BackendPizzaAPI', version '1.0.0', id '6958d589-...') does not exist in this environment. Create that API here before importing the MCP Server."}
```

## Testing

Three unit tests added to `ImportUtilsMCPServerTest`, each verified to fail without the change it covers.

Verified on a 4.7.0-SNAPSHOT pack by running a 27 case battery against an unpatched pack and a patched pack and diffing the two. The only difference is the intended one:

```
< IMPORT mcp, referenced API gone   | 500 | 900967 | General Error
> IMPORT mcp, referenced API gone   | 400 | 904015 | Reference API not found
```

API import, API Product import (with a present and with a missing dependent API), MCP Server import, corrupt archives, a request with no file, and every read, write, delete and export against a non existent UUID are unchanged.

Cases covered end to end:

| Case | Result |
|---|---|
| Reference UUID stale, name and version present | 200, mapping moved onto the local UUID |
| Reference UUID valid, name and version absent | 200, UUID left untouched |
| Reference UUID invalid, name and version absent | 400, the id is named |
| Name and version present, no such API here | 400, the API, the version and the id are named |
