### PR TITLE
Fix malformed JMSTaskManager XML tag

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/templates/repository/conf/api-manager.xml.j2
+++ b/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/templates/repository/conf/api-manager.xml.j2
@@ -1292,7 +1292,7 @@
                 {% elif apim.throttling.jms.job_queue_size is defined %}
                 <JobQueueSize>{{apim.throttling.jms.job_queue_size}}</JobQueueSize>
                 {% endif %}
-            <JMSTaskManager>
+            </JMSTaskManager>
             {% endif %}
             <JMSConnectionParameters>
                 <transport.jms.ConnectionFactoryJNDIName>{{apim.throttling.jms.conn_jndi_name}}</transport.jms.ConnectionFactoryJNDIName>


### PR DESCRIPTION
Summary

- Fixes the incorrect closing tag `<JMSTaskManager>` to `</JMSTaskManager>` in `api-manager.xml.j2`.
- The malformed tag caused `api-manager.xml` to contain invalid XML when JMS thread pool configuration was enabled.
- The issue occurs when `[apim.event_hub.listener]` or `[apim.throttling.jms]` thread pool configurations are defined in `deployment.toml`.
- Default deployments are unaffected because the problematic XML is inside a conditional Jinja block.

Test Steps

1. Configure the following in `deployment.toml`:

```toml
[apim.event_hub.listener]
min_thread_pool_size = 10
max_thread_pool_size = 100
keep_alive_time_in_millis = 1000
job_queue_size = 10