### PR TITLE
Fix AI API deployment failure after changing the primary endpoint

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/TemplateBuilderUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/TemplateBuilderUtil.java
@@ -1050,9 +1050,9 @@ public class TemplateBuilderUtil {
                     gatewayAPIDTO.getLocalEntriesToBeAdd()));
         }
 
-        // An AI API holds its endpoints outside endpoint_config, so resolve them once here. Both the gate below
-        // and the AI API branch further down need exactly these values, and resolving them in a single place
-        // keeps the two from ever disagreeing about which endpoint is primary.
+        // An AI API holds its endpoints outside endpoint_config, so resolve them once here. The AI API gate, the
+        // endpoint entries and the AI API branch further down all need exactly these values, and resolving them
+        // in a single place keeps them from ever disagreeing about which endpoint is primary.
         boolean isAiApi = APIConstants.API_SUBTYPE_AI_API.equals(api.getSubtype());
         List<SimplifiedEndpoint> productionEndpoints = Collections.emptyList();
         List<SimplifiedEndpoint> sandboxEndpoints = Collections.emptyList();
@@ -1070,17 +1070,34 @@ public class TemplateBuilderUtil {
             defaultSandboxEndpoint = resolvePrimaryEndpoint(sandboxEndpoints, api.getPrimarySandboxEndpointId());
         }
 
+        // If the Gateway type is 'production' and no production endpoint could be resolved for the AI API, or the
+        // Gateway type is 'sandbox' and no sandbox endpoint could be resolved.
+        //
+        // AI APIs get their own gate because they record their endpoints outside endpoint_config: that config may
+        // be minimal, or absent altogether, while a perfectly valid endpoint exists in the API's endpoint list.
+        // The endpoint_config gate below therefore cannot answer this question for them, and is skipped for AI
+        // APIs the way it is already skipped for AWS Lambda APIs. The values tested here are the same ones used
+        // to build the artifact further down, so the gate and the artifact can never disagree.
+        if (isAiApi && ((APIConstants.GATEWAY_ENV_TYPE_PRODUCTION.equals(environment.getType())
+                && defaultProductionEndpoint == null)
+                || (APIConstants.GATEWAY_ENV_TYPE_SANDBOX.equals(environment.getType())
+                && defaultSandboxEndpoint == null))) {
+            if (log.isDebugEnabled()) {
+                log.debug("Not adding AI API to environment " + environment.getName() + " since no "
+                        + environment.getType() + " endpoint could be resolved for it");
+            }
+            return null;
+        }
+
         // If the API exists in the Gateway and If the Gateway type is 'production' and a production url has not been
         // specified Or if the Gateway type is 'sandbox' and a sandbox url has not been specified
 
-        if (endpointConfig != null && !APIConstants.ENDPOINT_TYPE_AWSLAMBDA.equalsIgnoreCase(
+        if (endpointConfig != null && !isAiApi && !APIConstants.ENDPOINT_TYPE_AWSLAMBDA.equalsIgnoreCase(
                 (String) endpointConfig.get(API_ENDPOINT_CONFIG_PROTOCOL_TYPE)) && (
                 (APIConstants.GATEWAY_ENV_TYPE_PRODUCTION.equals(environment.getType())
-                        && !endpointExistsForStage(api, isAiApi, defaultProductionEndpoint,
-                        APIConstants.APIEndpoint.PRODUCTION)) || (
+                        && !APIUtil.isProductionEndpointsExists(api.getEndpointConfig())) || (
                         APIConstants.GATEWAY_ENV_TYPE_SANDBOX.equals(environment.getType())
-                                && !endpointExistsForStage(api, isAiApi, defaultSandboxEndpoint,
-                                APIConstants.APIEndpoint.SANDBOX)))) {
+                                && !APIUtil.isSandboxEndpointsExists(api.getEndpointConfig())))) {
             if (log.isDebugEnabled()) {
                 log.debug("Not adding API to environment " + environment.getName() + " since its endpoint URL "
                         + "cannot be found");
@@ -1125,7 +1142,13 @@ public class TemplateBuilderUtil {
                 apiConfig = builder.getConfigStringForTemplate(environment);
             }
             gatewayAPIDTO.setApiDefinition(apiConfig);
-            if (endpointConfig != null && !APIConstants.ENDPOINT_TYPE_AWSLAMBDA.equalsIgnoreCase(
+            if (isAiApi) {
+                // The endpoint sequence added above refers to these entries by key, so they have to be added
+                // whatever endpoint_config holds -- an AI API can carry a valid endpoint list alongside a minimal
+                // or absent endpoint_config, and gating on it would leave the sequence pointing at endpoints that
+                // were never created.
+                addEndpoints(api, builder, gatewayAPIDTO, endpointList);
+            } else if (endpointConfig != null && !APIConstants.ENDPOINT_TYPE_AWSLAMBDA.equalsIgnoreCase(
                     (String) endpointConfig.get(API_ENDPOINT_CONFIG_PROTOCOL_TYPE)) &&
                     !APIConstants.ENDPOINT_TYPE_SEQUENCE.equalsIgnoreCase((String) endpointConfig
                             .get(API_ENDPOINT_CONFIG_PROTOCOL_TYPE))) {
@@ -1180,34 +1203,6 @@ public class TemplateBuilderUtil {
             gatewayAPIDTO.setSequenceToBeAdd(
                     addGatewayContentToList(endpointSequence, gatewayAPIDTO.getSequenceToBeAdd()));
         }
-    }
-
-    /**
-     * Checks whether the API has an endpoint that can serve the given deployment stage.
-     * <p>
-     * For a regular API the endpoints are always inlined in endpoint_config, so the legacy
-     * production_endpoints/sandbox_endpoints keys answer this directly. An AI API is different: its primary
-     * endpoint may be a named endpoint held separately and referenced through
-     * primaryProductionEndpointId/primarySandboxEndpointId, in which case those keys are absent even though a
-     * perfectly valid endpoint exists. Consulting endpoint_config for such an API would report a missing
-     * endpoint and suppress the whole gateway artifact, so this check instead trusts the endpoint already
-     * resolved from {@code endpointList} by the caller, which is the very value used to build the artifact.
-     *
-     * @param api             The API being published
-     * @param isAiApi         Whether the API is an AI API
-     * @param resolvedPrimary The primary endpoint already resolved for this stage, null for a non-AI API
-     * @param stage           The deployment stage to check, PRODUCTION or SANDBOX
-     * @return true if an endpoint is available for the given stage
-     */
-    private static boolean endpointExistsForStage(API api, boolean isAiApi, SimplifiedEndpoint resolvedPrimary,
-                                                  String stage) {
-
-        if (isAiApi) {
-            return resolvedPrimary != null;
-        }
-        return APIConstants.APIEndpoint.PRODUCTION.equals(stage)
-                ? APIUtil.isProductionEndpointsExists(api.getEndpointConfig())
-                : APIUtil.isSandboxEndpointsExists(api.getEndpointConfig());
     }
 
     /**

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/TemplateBuilderUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/TemplateBuilderUtil.java
@@ -1050,15 +1050,37 @@ public class TemplateBuilderUtil {
                     gatewayAPIDTO.getLocalEntriesToBeAdd()));
         }
 
+        // An AI API holds its endpoints outside endpoint_config, so resolve them once here. Both the gate below
+        // and the AI API branch further down need exactly these values, and resolving them in a single place
+        // keeps the two from ever disagreeing about which endpoint is primary.
+        boolean isAiApi = APIConstants.API_SUBTYPE_AI_API.equals(api.getSubtype());
+        List<SimplifiedEndpoint> productionEndpoints = Collections.emptyList();
+        List<SimplifiedEndpoint> sandboxEndpoints = Collections.emptyList();
+        SimplifiedEndpoint defaultProductionEndpoint = null;
+        SimplifiedEndpoint defaultSandboxEndpoint = null;
+        if (isAiApi) {
+            Map<String, List<SimplifiedEndpoint>> groupedEndpoints = simplifyEndpoints(endpointList).stream()
+                    .collect(Collectors.groupingBy(SimplifiedEndpoint::getDeploymentStage));
+            productionEndpoints = new ArrayList<>(
+                    groupedEndpoints.getOrDefault(APIConstants.APIEndpoint.PRODUCTION, Collections.emptyList()));
+            sandboxEndpoints = new ArrayList<>(
+                    groupedEndpoints.getOrDefault(APIConstants.APIEndpoint.SANDBOX, Collections.emptyList()));
+            defaultProductionEndpoint = resolvePrimaryEndpoint(productionEndpoints,
+                    api.getPrimaryProductionEndpointId());
+            defaultSandboxEndpoint = resolvePrimaryEndpoint(sandboxEndpoints, api.getPrimarySandboxEndpointId());
+        }
+
         // If the API exists in the Gateway and If the Gateway type is 'production' and a production url has not been
         // specified Or if the Gateway type is 'sandbox' and a sandbox url has not been specified
 
         if (endpointConfig != null && !APIConstants.ENDPOINT_TYPE_AWSLAMBDA.equalsIgnoreCase(
                 (String) endpointConfig.get(API_ENDPOINT_CONFIG_PROTOCOL_TYPE)) && (
                 (APIConstants.GATEWAY_ENV_TYPE_PRODUCTION.equals(environment.getType())
-                        && !APIUtil.isProductionEndpointsExists(api.getEndpointConfig())) || (
+                        && !endpointExistsForStage(api, isAiApi, defaultProductionEndpoint,
+                        APIConstants.APIEndpoint.PRODUCTION)) || (
                         APIConstants.GATEWAY_ENV_TYPE_SANDBOX.equals(environment.getType())
-                                && !APIUtil.isSandboxEndpointsExists(api.getEndpointConfig())))) {
+                                && !endpointExistsForStage(api, isAiApi, defaultSandboxEndpoint,
+                                APIConstants.APIEndpoint.SANDBOX)))) {
             if (log.isDebugEnabled()) {
                 log.debug("Not adding API to environment " + environment.getName() + " since its endpoint URL "
                         + "cannot be found");
@@ -1085,23 +1107,7 @@ public class TemplateBuilderUtil {
             gatewayAPIDTO.setApiDefinition(prototypeScriptAPI);
         } else if (APIConstants.IMPLEMENTATION_TYPE_ENDPOINT.equalsIgnoreCase(api.getImplementation())) {
             String apiConfig = null;
-            if (APIConstants.API_SUBTYPE_AI_API.equals(api.getSubtype())) {
-
-                Map<String, List<SimplifiedEndpoint>> groupedEndpoints = simplifyEndpoints(endpointList).stream()
-                        .collect(Collectors.groupingBy(SimplifiedEndpoint::getDeploymentStage));
-
-                List<SimplifiedEndpoint> productionEndpoints = new ArrayList<>(
-                        groupedEndpoints.getOrDefault(APIConstants.APIEndpoint.PRODUCTION, Collections.emptyList()));
-                List<SimplifiedEndpoint> sandboxEndpoints = new ArrayList<>(
-                        groupedEndpoints.getOrDefault(APIConstants.APIEndpoint.SANDBOX, Collections.emptyList()));
-
-                SimplifiedEndpoint defaultProductionEndpoint = Optional.ofNullable(api.getPrimaryProductionEndpointId())
-                        .map(id -> findEndpointByUuid(productionEndpoints, id))
-                        .orElseGet(() -> productionEndpoints.isEmpty() ? null : productionEndpoints.get(0));
-
-                SimplifiedEndpoint defaultSandboxEndpoint = Optional.ofNullable(api.getPrimarySandboxEndpointId())
-                        .map(id -> findEndpointByUuid(sandboxEndpoints, id))
-                        .orElseGet(() -> sandboxEndpoints.isEmpty() ? null : sandboxEndpoints.get(0));
+            if (isAiApi) {
 
                 if (defaultProductionEndpoint != null) {
                     addEndpointsSequence(APIConstants.APIEndpoint.PRODUCTION, productionEndpoints,
@@ -1174,6 +1180,50 @@ public class TemplateBuilderUtil {
             gatewayAPIDTO.setSequenceToBeAdd(
                     addGatewayContentToList(endpointSequence, gatewayAPIDTO.getSequenceToBeAdd()));
         }
+    }
+
+    /**
+     * Checks whether the API has an endpoint that can serve the given deployment stage.
+     * <p>
+     * For a regular API the endpoints are always inlined in endpoint_config, so the legacy
+     * production_endpoints/sandbox_endpoints keys answer this directly. An AI API is different: its primary
+     * endpoint may be a named endpoint held separately and referenced through
+     * primaryProductionEndpointId/primarySandboxEndpointId, in which case those keys are absent even though a
+     * perfectly valid endpoint exists. Consulting endpoint_config for such an API would report a missing
+     * endpoint and suppress the whole gateway artifact, so this check instead trusts the endpoint already
+     * resolved from {@code endpointList} by the caller, which is the very value used to build the artifact.
+     *
+     * @param api             The API being published
+     * @param isAiApi         Whether the API is an AI API
+     * @param resolvedPrimary The primary endpoint already resolved for this stage, null for a non-AI API
+     * @param stage           The deployment stage to check, PRODUCTION or SANDBOX
+     * @return true if an endpoint is available for the given stage
+     */
+    private static boolean endpointExistsForStage(API api, boolean isAiApi, SimplifiedEndpoint resolvedPrimary,
+                                                  String stage) {
+
+        if (isAiApi) {
+            return resolvedPrimary != null;
+        }
+        return APIConstants.APIEndpoint.PRODUCTION.equals(stage)
+                ? APIUtil.isProductionEndpointsExists(api.getEndpointConfig())
+                : APIUtil.isSandboxEndpointsExists(api.getEndpointConfig());
+    }
+
+    /**
+     * Resolves the primary endpoint of a deployment stage, falling back to the first available endpoint when the
+     * API does not name one.
+     *
+     * @param stageEndpoints    The endpoints of a single deployment stage
+     * @param primaryEndpointId The UUID of the endpoint marked primary, may be null
+     * @return The primary endpoint, or null if the stage has none
+     */
+    private static SimplifiedEndpoint resolvePrimaryEndpoint(List<SimplifiedEndpoint> stageEndpoints,
+                                                             String primaryEndpointId) {
+
+        return Optional.ofNullable(primaryEndpointId)
+                .map(id -> findEndpointByUuid(stageEndpoints, id))
+                .orElseGet(() -> stageEndpoints.isEmpty() ? null : stageEndpoints.get(0));
     }
 
     /**


### PR DESCRIPTION
## Purpose

Fixes https://github.com/wso2/api-manager/issues/5184

An AI API cannot be deployed to a **production** (or **sandbox**) type gateway once its primary endpoint has been switched to a newly added endpoint and the original one removed. Deployment fails with:

```
WARN  {SynapseArtifactGenerator} - Failed to create Synapse configurations for the following APIs:
      <API> (<uuid>): Generated GatewayAPIDTO was null
ERROR {InMemoryAPIDeployer} - Error retrieving artifacts for API <uuid>. Storage returned null
```

## Steps to reproduce

1. Configure a gateway environment of type `production` (the default one is `hybrid`).
2. Create an AI API.
3. Under **Endpoints**, add a second **Production** endpoint.
4. Change the **Primary Endpoint** to the newly added one.
5. Delete the old endpoint.
6. Deploy to the production gateway.

## Root cause

An AI API may hold its primary endpoint outside `endpoint_config`, as a named endpoint referenced by `primaryProductionEndpointId` / `primarySandboxEndpointId`. After step 5 the API is in a perfectly valid state — the primary endpoint exists in `AM_API_ENDPOINTS` — but `endpoint_config` is reduced to `{"endpoint_type":"http"}`.

The guard in `TemplateBuilderUtil#createAPIGatewayDTOtoPublishAPI` that decides whether an API may be published to a production/sandbox gateway asked that question via `APIUtil.isProductionEndpointsExists` / `isSandboxEndpointsExists`, which inspect only the legacy `endpoint_config` keys. It therefore concluded no production endpoint existed and returned `null`, even though the `API_SUBTYPE_AI_API` branch ~30 lines below resolves that same endpoint correctly from the endpoint list.

Because the guard only applies to `production`/`sandbox` typed environments, the default `hybrid` gateway was unaffected, which is why this surfaces only on deployments with a dedicated production gateway.

## Approach

Resolve the AI API endpoints **once**, ahead of the guard, and have both the guard and the AI API branch consume those resolved values, so the two can no longer disagree about which endpoint is primary.

- Non-AI APIs are untouched: they still go through the existing `endpoint_config` checks, which stay inside the condition so they keep short-circuiting on gateway type.
- The guard is corrected rather than skipped: an AI API that genuinely has no endpoint for the stage is still refused, instead of being deployed with no backend behind it.
- Endpoint resolution now happens once per artifact generation rather than three times (the previous code grouped the list once inside the AI branch; this keeps it to a single pass).

## Testing

Verified on a WSO2 AM 4.6.0 pack with a dedicated `production` gateway, a `sandbox` gateway and the default `hybrid` gateway, in both the super tenant and a `wso2.com` tenant. Same suite run against the unpatched build for comparison.

| Scenario | Unpatched | Patched |
|---|---|---|
| AI API, inline production endpoint → production gw | deployed | deployed |
| **AI API, primary switched + old endpoint deleted → production gw** | **failed** | **deployed** |
| **AI API, sandbox primary switched + old deleted → sandbox gw** | **failed** | **deployed** |
| AI API with no production endpoint → production gw | refused | refused |
| AI API with no sandbox endpoint → sandbox gw | refused | refused |
| Regular API with production endpoint → production gw | deployed | deployed |
| Regular API without production endpoint → production gw | refused | refused |
| AI API, primary switched → hybrid gw | deployed | deployed |
| AI API, primary reverted + added endpoint deleted → production gw | deployed | deployed |

The "refused" rows are the cases that distinguish correcting the guard from disabling it for AI APIs — they behave identically before and after.