### PR TITLE
Add coverage for throttle expiry checks

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/test/java/org/wso2/carbon/apimgt/gateway/throttling/ThrottleDataHolderTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/test/java/org/wso2/carbon/apimgt/gateway/throttling/ThrottleDataHolderTest.java
@@ -1,17 +1,17 @@
 /*
-* Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*  Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
 *
-* WSO2 Inc. licenses this file to you under the Apache License,
-* Version 2.0 (the "License"); you may not use this file except
-* in compliance with the License.
-* You may obtain a copy of the License at
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
 *
-* http://www.apache.org/licenses/LICENSE-2.0
+*    http://www.apache.org/licenses/LICENSE-2.0
 *
 * Unless required by applicable law or agreed to in writing,
 * software distributed under the License is distributed on an
 * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-* KIND, either express or implied. See the License for the
+* KIND, either express or implied.  See the License for the
 * specific language governing permissions and limitations
 * under the License.
 */
@@ -24,131 +24,134 @@ import org.junit.Test;
 import java.util.HashMap;
 import java.util.Map;
 
+
 public class ThrottleDataHolderTest {
 
- @Test
- public void addThrottleDataFromMap() throws Exception {
- Map<String,Long> map = new HashMap<>();
- map.put("/api/1.0.0",System.currentTimeMillis());
- ThrottleDataHolder throttleDataHolder = ThrottleDataHolder.getInstance();
- throttleDataHolder.addThrottleDataFromMap(map);
- throttleDataHolder.removeThrottleData("/api/1.0.0");
- }
+    @Test
+    public void addThrottleDataFromMap() throws Exception {
+        Map<String,Long> map = new HashMap<>();
+        map.put("/api/1.0.0",System.currentTimeMillis());
+        ThrottleDataHolder throttleDataHolder = ThrottleDataHolder.getInstance();
+        throttleDataHolder.addThrottleDataFromMap(map);
+        throttleDataHolder.removeThrottleData("/api/1.0.0");
+    }
 
- @Test
- public void removeThrottledAPIKey() throws Exception {
- ThrottleDataHolder throttleDataHolder = ThrottleDataHolder.getInstance();
- throttleDataHolder.addThrottledAPIKey("/api/1.0.0",System.currentTimeMillis());
- throttleDataHolder.removeThrottledAPIKey("/api/1.0.0");
- }
 
- @Test
- public void addBlockingCondition() throws Exception {
- ThrottleDataHolder throttleDataHolder = ThrottleDataHolder.getInstance();
- throttleDataHolder.addAPIBlockingCondition("/api1/1.0.0","enabled");
- throttleDataHolder.removeAPIBlockingCondition("/api1/1.0.0");
- throttleDataHolder.addApplicationBlockingCondition("admin:DefaultApplication","enabled");
- throttleDataHolder.removeApplicationBlockingCondition("admin:DefaultApplication");
- throttleDataHolder.addUserBlockingCondition("user1","enabled");
- throttleDataHolder.removeUserBlockingCondition("user1");
- throttleDataHolder.setKeyTemplatesPresent(true);
- }
+    @Test
+    public void removeThrottledAPIKey() throws Exception {
+        ThrottleDataHolder throttleDataHolder = ThrottleDataHolder.getInstance();
+        throttleDataHolder.addThrottledAPIKey("/api/1.0.0",System.currentTimeMillis());
+        throttleDataHolder.removeThrottledAPIKey("/api/1.0.0");
+    }
 
- @Test
- public void addApplicationBlockingCondition() throws Exception {
- }
 
- @Test
- public void addUserBlockingCondition() throws Exception {
- }
+    @Test
+    public void addBlockingCondition() throws Exception {
+        ThrottleDataHolder throttleDataHolder = ThrottleDataHolder.getInstance();
+        throttleDataHolder.addAPIBlockingCondition("/api1/1.0.0","enabled");
+        throttleDataHolder.removeAPIBlockingCondition("/api1/1.0.0");
+        throttleDataHolder.addApplicationBlockingCondition("admin:DefaultApplication","enabled");
+        throttleDataHolder.removeApplicationBlockingCondition("admin:DefaultApplication");
+        throttleDataHolder.addUserBlockingCondition("user1","enabled");
+        throttleDataHolder.removeUserBlockingCondition("user1");
+        throttleDataHolder.setKeyTemplatesPresent(true);
+    }
 
- @Test
- public void addIplockingCondition() throws Exception {
- }
+    @Test
+    public void addApplicationBlockingCondition() throws Exception {
+    }
 
- @Test
- public void addUserBlockingConditionsFromMap() throws Exception {
- }
+    @Test
+    public void addUserBlockingCondition() throws Exception {
+    }
 
- @Test
- public void addIplockingConditionsFromMap() throws Exception {
- }
+    @Test
+    public void addIplockingCondition() throws Exception {
+    }
 
- @Test
- public void addAPIBlockingConditionsFromMap() throws Exception {
- }
+    @Test
+    public void addUserBlockingConditionsFromMap() throws Exception {
+    }
 
- @Test
- public void addApplicationBlockingConditionsFromMap() throws Exception {
- }
+    @Test
+    public void addIplockingConditionsFromMap() throws Exception {
+    }
 
- @Test
- public void removeAPIBlockingCondition() throws Exception {
- }
+    @Test
+    public void addAPIBlockingConditionsFromMap() throws Exception {
+    }
 
- @Test
- public void removeApplicationBlockingCondition() throws Exception {
- }
+    @Test
+    public void addApplicationBlockingConditionsFromMap() throws Exception {
+    }
 
- @Test
- public void removeUserBlockingCondition() throws Exception {
- }
+    @Test
+    public void removeAPIBlockingCondition() throws Exception {
+    }
 
- @Test
- public void removeIpBlockingCondition() throws Exception {
- }
+    @Test
+    public void removeApplicationBlockingCondition() throws Exception {
+    }
 
- @Test
- public void addKeyTemplate() throws Exception {
- }
+    @Test
+    public void removeUserBlockingCondition() throws Exception {
+    }
 
- @Test
- public void addKeyTemplateFromMap() throws Exception {
- }
+    @Test
+    public void removeIpBlockingCondition() throws Exception {
+    }
 
- @Test
- public void removeKeyTemplate() throws Exception {
- }
+    @Test
+    public void addKeyTemplate() throws Exception {
+    }
 
- @Test
- public void getKeyTemplateMap() throws Exception {
- }
+    @Test
+    public void addKeyTemplateFromMap() throws Exception {
+    }
 
- @Test
- public void isThrottled() throws Exception {
-     ThrottleDataHolder throttleDataHolder = ThrottleDataHolder.getInstance();
-     String activeKey = "test-active-throttle-key";
-     String expiredKey = "test-expired-throttle-key";
-     try {
-         throttleDataHolder.addThrottleData(activeKey, System.currentTimeMillis() + 10_000);
-         throttleDataHolder.addThrottleData(expiredKey, System.currentTimeMillis() - 1_000);
+    @Test
+    public void removeKeyTemplate() throws Exception {
+    }
 
-         Assert.assertTrue(throttleDataHolder.isThrottled(activeKey));
-         Assert.assertFalse(throttleDataHolder.isThrottled(expiredKey));
-     } finally {
-         throttleDataHolder.removeThrottleData(activeKey);
-         throttleDataHolder.removeThrottleData(expiredKey);
-     }
- }
+    @Test
+    public void getKeyTemplateMap() throws Exception {
+    }
 
- @Test
- public void getThrottleNextAccessTimestamp() throws Exception {
- }
+    @Test
+    public void isThrottled() throws Exception {
+        ThrottleDataHolder throttleDataHolder = ThrottleDataHolder.getInstance();
+        String activeKey = "test-active-throttle-key";
+        String expiredKey = "test-expired-throttle-key";
+        try {
+            throttleDataHolder.addThrottleData(activeKey, System.currentTimeMillis() + 10_000);
+            throttleDataHolder.addThrottleData(expiredKey, System.currentTimeMillis() - 1_000);
 
- @Test
- public void isBlockingConditionsPresent() throws Exception {
- }
+            Assert.assertTrue(throttleDataHolder.isThrottled(activeKey));
+            Assert.assertFalse(throttleDataHolder.isThrottled(expiredKey));
+        } finally {
+            throttleDataHolder.removeThrottleData(activeKey);
+            throttleDataHolder.removeThrottleData(expiredKey);
+        }
+    }
 
- @Test
- public void setBlockingConditionsPresent() throws Exception {
- }
+    @Test
+    public void getThrottleNextAccessTimestamp() throws Exception {
+    }
 
- @Test
- public void isKeyTemplatesPresent() throws Exception {
- }
+    @Test
+    public void isBlockingConditionsPresent() throws Exception {
+    }
 
- @Test
- public void setKeyTemplatesPresent() throws Exception {
- }
+    @Test
+    public void setBlockingConditionsPresent() throws Exception {
+    }
+
+    @Test
+    public void isKeyTemplatesPresent() throws Exception {
+    }
+
+    @Test
+    public void setKeyTemplatesPresent() throws Exception {
+    }
 
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/test/java/org/wso2/carbon/apimgt/gateway/throttling/ThrottleDataHolderTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/test/java/org/wso2/carbon/apimgt/gateway/throttling/ThrottleDataHolderTest.java
@@ -1,143 +1,154 @@
 /*
-*  Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+* Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
 *
-*  WSO2 Inc. licenses this file to you under the Apache License,
-*  Version 2.0 (the "License"); you may not use this file except
-*  in compliance with the License.
-*  You may obtain a copy of the License at
+* WSO2 Inc. licenses this file to you under the Apache License,
+* Version 2.0 (the "License"); you may not use this file except
+* in compliance with the License.
+* You may obtain a copy of the License at
 *
-*    http://www.apache.org/licenses/LICENSE-2.0
+* http://www.apache.org/licenses/LICENSE-2.0
 *
 * Unless required by applicable law or agreed to in writing,
 * software distributed under the License is distributed on an
 * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-* KIND, either express or implied.  See the License for the
+* KIND, either express or implied. See the License for the
 * specific language governing permissions and limitations
 * under the License.
 */
 
 package org.wso2.carbon.apimgt.gateway.throttling;
 
+import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.HashMap;
 import java.util.Map;
 
-
 public class ThrottleDataHolderTest {
 
-    @Test
-    public void addThrottleDataFromMap() throws Exception {
-        Map<String,Long> map = new HashMap<>();
-        map.put("/api/1.0.0",System.currentTimeMillis());
-        ThrottleDataHolder throttleDataHolder = ThrottleDataHolder.getInstance();
-        throttleDataHolder.addThrottleDataFromMap(map);
-        throttleDataHolder.removeThrottleData("/api/1.0.0");
-    }
+ @Test
+ public void addThrottleDataFromMap() throws Exception {
+ Map<String,Long> map = new HashMap<>();
+ map.put("/api/1.0.0",System.currentTimeMillis());
+ ThrottleDataHolder throttleDataHolder = ThrottleDataHolder.getInstance();
+ throttleDataHolder.addThrottleDataFromMap(map);
+ throttleDataHolder.removeThrottleData("/api/1.0.0");
+ }
 
+ @Test
+ public void removeThrottledAPIKey() throws Exception {
+ ThrottleDataHolder throttleDataHolder = ThrottleDataHolder.getInstance();
+ throttleDataHolder.addThrottledAPIKey("/api/1.0.0",System.currentTimeMillis());
+ throttleDataHolder.removeThrottledAPIKey("/api/1.0.0");
+ }
 
-    @Test
-    public void removeThrottledAPIKey() throws Exception {
-        ThrottleDataHolder throttleDataHolder = ThrottleDataHolder.getInstance();
-        throttleDataHolder.addThrottledAPIKey("/api/1.0.0",System.currentTimeMillis());
-        throttleDataHolder.removeThrottledAPIKey("/api/1.0.0");
-    }
+ @Test
+ public void addBlockingCondition() throws Exception {
+ ThrottleDataHolder throttleDataHolder = ThrottleDataHolder.getInstance();
+ throttleDataHolder.addAPIBlockingCondition("/api1/1.0.0","enabled");
+ throttleDataHolder.removeAPIBlockingCondition("/api1/1.0.0");
+ throttleDataHolder.addApplicationBlockingCondition("admin:DefaultApplication","enabled");
+ throttleDataHolder.removeApplicationBlockingCondition("admin:DefaultApplication");
+ throttleDataHolder.addUserBlockingCondition("user1","enabled");
+ throttleDataHolder.removeUserBlockingCondition("user1");
+ throttleDataHolder.setKeyTemplatesPresent(true);
+ }
 
+ @Test
+ public void addApplicationBlockingCondition() throws Exception {
+ }
 
-    @Test
-    public void addBlockingCondition() throws Exception {
-        ThrottleDataHolder throttleDataHolder = ThrottleDataHolder.getInstance();
-        throttleDataHolder.addAPIBlockingCondition("/api1/1.0.0","enabled");
-        throttleDataHolder.removeAPIBlockingCondition("/api1/1.0.0");
-        throttleDataHolder.addApplicationBlockingCondition("admin:DefaultApplication","enabled");
-        throttleDataHolder.removeApplicationBlockingCondition("admin:DefaultApplication");
-        throttleDataHolder.addUserBlockingCondition("user1","enabled");
-        throttleDataHolder.removeUserBlockingCondition("user1");
-        throttleDataHolder.setKeyTemplatesPresent(true);
-    }
+ @Test
+ public void addUserBlockingCondition() throws Exception {
+ }
 
-    @Test
-    public void addApplicationBlockingCondition() throws Exception {
-    }
+ @Test
+ public void addIplockingCondition() throws Exception {
+ }
 
-    @Test
-    public void addUserBlockingCondition() throws Exception {
-    }
+ @Test
+ public void addUserBlockingConditionsFromMap() throws Exception {
+ }
 
-    @Test
-    public void addIplockingCondition() throws Exception {
-    }
+ @Test
+ public void addIplockingConditionsFromMap() throws Exception {
+ }
 
-    @Test
-    public void addUserBlockingConditionsFromMap() throws Exception {
-    }
+ @Test
+ public void addAPIBlockingConditionsFromMap() throws Exception {
+ }
 
-    @Test
-    public void addIplockingConditionsFromMap() throws Exception {
-    }
+ @Test
+ public void addApplicationBlockingConditionsFromMap() throws Exception {
+ }
 
-    @Test
-    public void addAPIBlockingConditionsFromMap() throws Exception {
-    }
+ @Test
+ public void removeAPIBlockingCondition() throws Exception {
+ }
 
-    @Test
-    public void addApplicationBlockingConditionsFromMap() throws Exception {
-    }
+ @Test
+ public void removeApplicationBlockingCondition() throws Exception {
+ }
 
-    @Test
-    public void removeAPIBlockingCondition() throws Exception {
-    }
+ @Test
+ public void removeUserBlockingCondition() throws Exception {
+ }
 
-    @Test
-    public void removeApplicationBlockingCondition() throws Exception {
-    }
+ @Test
+ public void removeIpBlockingCondition() throws Exception {
+ }
 
-    @Test
-    public void removeUserBlockingCondition() throws Exception {
-    }
+ @Test
+ public void addKeyTemplate() throws Exception {
+ }
 
-    @Test
-    public void removeIpBlockingCondition() throws Exception {
-    }
+ @Test
+ public void addKeyTemplateFromMap() throws Exception {
+ }
 
-    @Test
-    public void addKeyTemplate() throws Exception {
-    }
+ @Test
+ public void removeKeyTemplate() throws Exception {
+ }
 
-    @Test
-    public void addKeyTemplateFromMap() throws Exception {
-    }
+ @Test
+ public void getKeyTemplateMap() throws Exception {
+ }
 
-    @Test
-    public void removeKeyTemplate() throws Exception {
-    }
+ @Test
+ public void isThrottled() throws Exception {
+     ThrottleDataHolder throttleDataHolder = ThrottleDataHolder.getInstance();
+     String activeKey = "test-active-throttle-key";
+     String expiredKey = "test-expired-throttle-key";
+     try {
+         throttleDataHolder.addThrottleData(activeKey, System.currentTimeMillis() + 10_000);
+         throttleDataHolder.addThrottleData(expiredKey, System.currentTimeMillis() - 1_000);
 
-    @Test
-    public void getKeyTemplateMap() throws Exception {
-    }
+         Assert.assertTrue(throttleDataHolder.isThrottled(activeKey));
+         Assert.assertFalse(throttleDataHolder.isThrottled(expiredKey));
+     } finally {
+         throttleDataHolder.removeThrottleData(activeKey);
+         throttleDataHolder.removeThrottleData(expiredKey);
+     }
+ }
 
-    @Test
-    public void isThrottled() throws Exception {
-    }
+ @Test
+ public void getThrottleNextAccessTimestamp() throws Exception {
+ }
 
-    @Test
-    public void getThrottleNextAccessTimestamp() throws Exception {
-    }
+ @Test
+ public void isBlockingConditionsPresent() throws Exception {
+ }
 
-    @Test
-    public void isBlockingConditionsPresent() throws Exception {
-    }
+ @Test
+ public void setBlockingConditionsPresent() throws Exception {
+ }
 
-    @Test
-    public void setBlockingConditionsPresent() throws Exception {
-    }
+ @Test
+ public void isKeyTemplatesPresent() throws Exception {
+ }
 
-    @Test
-    public void isKeyTemplatesPresent() throws Exception {
-    }
-
-    @Test
-    public void setKeyTemplatesPresent() throws Exception {
-    }
+ @Test
+ public void setKeyTemplatesPresent() throws Exception {
+ }
 
 }


### PR DESCRIPTION
## Purpose

Fill the missing `isThrottled()` test in `ThrottleDataHolderTest`. The production method has separate behavior for active and expired throttle entries, but the existing test method was an empty stub.

## Approach

The test adds one future timestamp and one expired timestamp to the singleton `ThrottleDataHolder`, then asserts that the active entry returns `true` and the expired entry returns `false`. Both test keys are removed in a `finally` block to prevent state leakage between tests.

## Testing

- `git diff --check` passed.
- The targeted Maven test command was attempted, but local dependency resolution was blocked before compilation by a Cloudflare challenge returned from WSO2 Nexus for the required `carbon-parent` artifact. No test failure was observed; upstream CI should provide the authoritative build and test result.

## Scope

Test-only change. No production code, dependencies, configuration, or security-sensitive behavior were modified.