### PR TITLE
Stop Info Severity Rule Violations from Failing Governance Compliance

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.governance.impl/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.governance.impl/pom.xml
@@ -88,6 +88,16 @@
             <groupId>org.wso2.carbon.apimgt</groupId>
             <artifactId>org.wso2.carbon.apimgt.common.jms</artifactId>
         </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/components/apimgt/org.wso2.carbon.apimgt.governance.impl/src/main/java/org/wso2/carbon/apimgt/governance/impl/dao/constants/SQLConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.governance.impl/src/main/java/org/wso2/carbon/apimgt/governance/impl/dao/constants/SQLConstants.java
@@ -18,6 +18,10 @@
 
 package org.wso2.carbon.apimgt.governance.impl.dao.constants;
 
+import org.wso2.carbon.apimgt.governance.api.model.RuleSeverity;
+
+import java.util.Collections;
+
 /**
  * This class represents the SQL Constants
  */
@@ -358,10 +362,14 @@ public class SQLConstants {
      * tell a blocking violation apart from an informational one. Severity is resolved here instead, so that a change
      * to the configured severities applies to already stored results without a re-evaluation.
      */
+    private static final String COMPLIANCE_AFFECTING_SEVERITY_PLACEHOLDERS =
+            String.join(", ", Collections.nCopies(RuleSeverity.values().length, "?"));
+
     private static final String COMPLIANCE_AFFECTING_VIOLATION_EXISTS = "EXISTS (SELECT 1 " +
             "FROM GOV_RULE_VIOLATION GV " +
             "JOIN GOV_RULESET_RULE GRULE ON GV.RULESET_ID = GRULE.RULESET_ID AND GV.RULE_NAME = GRULE.RULE_NAME " +
-            "WHERE GV.RULESET_RUN_ID = GRR.RULESET_RUN_ID AND GRULE.SEVERITY IN (?, ?, ?))";
+            "WHERE GV.RULESET_RUN_ID = GRR.RULESET_RUN_ID AND GRULE.SEVERITY IN ("
+            + COMPLIANCE_AFFECTING_SEVERITY_PLACEHOLDERS + "))";
 
     public static final String GET_FAILED_RULESET_RUNS = "SELECT DISTINCT GRR.RULESET_ID " +
             "FROM GOV_RULESET_RUN GRR " +

--- a/components/apimgt/org.wso2.carbon.apimgt.governance.impl/src/main/java/org/wso2/carbon/apimgt/governance/impl/dao/constants/SQLConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.governance.impl/src/main/java/org/wso2/carbon/apimgt/governance/impl/dao/constants/SQLConstants.java
@@ -352,14 +352,28 @@ public class SQLConstants {
             "JOIN GOV_ARTIFACT GA ON GRR.ARTIFACT_KEY = GA.ARTIFACT_KEY " +
             "WHERE GA.ARTIFACT_REF_ID = ? AND GA.ARTIFACT_TYPE = ? AND GA.ORGANIZATION = ? AND GRR.RULESET_ID = ?";
 
-    public static final String GET_FAILED_RULESET_RUNS = "SELECT DISTINCT RULESET_ID FROM GOV_RULESET_RUN GRR " +
-            "JOIN GOV_ARTIFACT GA ON GRR.ARTIFACT_KEY = GA.ARTIFACT_KEY " +
-            "WHERE GA.ORGANIZATION = ? AND GRR.RESULT = 0";
+    /**
+     * Matches a ruleset run that holds at least one violation of a compliance affecting severity. GOV_RULESET_RUN
+     * carries a RESULT flag, but that flag only records whether the run was completely clean and therefore cannot
+     * tell a blocking violation apart from an informational one. Severity is resolved here instead, so that a change
+     * to the configured severities applies to already stored results without a re-evaluation.
+     */
+    private static final String COMPLIANCE_AFFECTING_VIOLATION_EXISTS = "EXISTS (SELECT 1 " +
+            "FROM GOV_RULE_VIOLATION GV " +
+            "JOIN GOV_RULESET_RULE GRULE ON GV.RULESET_ID = GRULE.RULESET_ID AND GV.RULE_NAME = GRULE.RULE_NAME " +
+            "WHERE GV.RULESET_RUN_ID = GRR.RULESET_RUN_ID AND GRULE.SEVERITY IN (?, ?, ?))";
 
-    public static final String GET_FAILED_RULESET_RUNS_FOR_ARTIFACT = "SELECT DISTINCT RULESET_ID " +
+    public static final String GET_FAILED_RULESET_RUNS = "SELECT DISTINCT GRR.RULESET_ID " +
             "FROM GOV_RULESET_RUN GRR " +
             "JOIN GOV_ARTIFACT GA ON GRR.ARTIFACT_KEY = GA.ARTIFACT_KEY " +
-            "WHERE GA.ARTIFACT_REF_ID = ? AND GA.ARTIFACT_TYPE = ? AND GA.ORGANIZATION = ? AND GRR.RESULT = 0";
+            "WHERE GA.ORGANIZATION = ? AND " + COMPLIANCE_AFFECTING_VIOLATION_EXISTS;
+
+    public static final String GET_FAILED_RULESET_RUNS_FOR_ARTIFACT = "SELECT DISTINCT GRR.RULESET_ID " +
+            "FROM GOV_RULESET_RUN GRR " +
+            "JOIN GOV_ARTIFACT GA ON GRR.ARTIFACT_KEY = GA.ARTIFACT_KEY " +
+            "WHERE GA.ARTIFACT_REF_ID = ? AND GA.ARTIFACT_TYPE = ? AND GA.ORGANIZATION = ? AND "
+            + COMPLIANCE_AFFECTING_VIOLATION_EXISTS;
+
     public static final String DELETE_RULESET_RUNS_FOR_ARTIFACT = "DELETE FROM GOV_RULESET_RUN " +
             "WHERE ARTIFACT_KEY IN (SELECT ARTIFACT_KEY FROM GOV_ARTIFACT WHERE ARTIFACT_REF_ID = ? " +
             "AND ARTIFACT_TYPE = ? AND ORGANIZATION = ?)";
@@ -414,8 +428,9 @@ public class SQLConstants {
             "FROM GOV_ARTIFACT GA " +
             "JOIN GOV_POLICY_RUN GPR ON GA.ARTIFACT_KEY = GPR.ARTIFACT_KEY " +
             "JOIN GOV_POLICY_RULESET GPRR ON GPR.POLICY_ID = GPRR.POLICY_ID " +
-            "JOIN GOV_RULESET_RUN GRR ON GA.ARTIFACT_KEY = GRR.ARTIFACT_KEY AND GRR.RULESET_ID = GPRR.RULESET_ID " +
-            "WHERE GA.ARTIFACT_TYPE = ? AND GA.ORGANIZATION = ? AND GRR.RESULT = 0";
+            "JOIN GOV_RULESET_RUN GRR ON GA.ARTIFACT_KEY = GRR.ARTIFACT_KEY " +
+            "AND GRR.RULESET_ID = GPRR.RULESET_ID " +
+            "WHERE GA.ARTIFACT_TYPE = ? AND GA.ORGANIZATION = ? AND " + COMPLIANCE_AFFECTING_VIOLATION_EXISTS;
 
     public static final String GET_ARITFCATS_FOR_POLICY_RUN = "SELECT DISTINCT GA.ARTIFACT_REF_ID, GA.ARTIFACT_TYPE " +
             "FROM GOV_ARTIFACT GA " +

--- a/components/apimgt/org.wso2.carbon.apimgt.governance.impl/src/main/java/org/wso2/carbon/apimgt/governance/impl/dao/impl/ComplianceMgtDAOImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.governance.impl/src/main/java/org/wso2/carbon/apimgt/governance/impl/dao/impl/ComplianceMgtDAOImpl.java
@@ -54,6 +54,9 @@ public class ComplianceMgtDAOImpl implements ComplianceMgtDAO {
     private static final Log log = LogFactory.getLog(ComplianceMgtDAOImpl.class);
     private static final Lock resultWrtiteDelLock = new ReentrantLock();
 
+    /** Number of severity bind parameters declared by the compliance affecting violation predicate */
+    private static final int SEVERITY_BIND_PARAM_COUNT = RuleSeverity.values().length;
+
     private ComplianceMgtDAOImpl() {
 
     }
@@ -921,6 +924,7 @@ public class ComplianceMgtDAOImpl implements ComplianceMgtDAO {
              PreparedStatement prepStmnt = connection.prepareStatement(sqlQuery)) {
             prepStmnt.setString(1, String.valueOf(artifactType));
             prepStmnt.setString(2, organization);
+            setComplianceAffectingSeverities(prepStmnt, 3);
             try (ResultSet resultSet = prepStmnt.executeQuery()) {
                 while (resultSet.next()) {
                     artifactRefIds.add(resultSet.getString("ARTIFACT_REF_ID"));
@@ -973,6 +977,7 @@ public class ComplianceMgtDAOImpl implements ComplianceMgtDAO {
         try (Connection connection = APIMGovernanceDBUtil.getConnection();
              PreparedStatement prepStmnt = connection.prepareStatement(sqlQuery)) {
             prepStmnt.setString(1, organization);
+            setComplianceAffectingSeverities(prepStmnt, 2);
             try (ResultSet resultSet = prepStmnt.executeQuery()) {
                 while (resultSet.next()) {
                     rulesetIds.add(resultSet.getString("RULESET_ID"));
@@ -1004,6 +1009,7 @@ public class ComplianceMgtDAOImpl implements ComplianceMgtDAO {
             prepStmnt.setString(1, artifactRefId);
             prepStmnt.setString(2, String.valueOf(artifactType));
             prepStmnt.setString(3, organization);
+            setComplianceAffectingSeverities(prepStmnt, 4);
             try (ResultSet resultSet = prepStmnt.executeQuery()) {
                 while (resultSet.next()) {
                     rulesetIds.add(resultSet.getString("RULESET_ID"));
@@ -1156,6 +1162,26 @@ public class ComplianceMgtDAOImpl implements ComplianceMgtDAO {
                     .ERROR_WHILE_DELETING_GOVERNANCE_DATA, e, artifactRefId);
         } finally {
             resultWrtiteDelLock.unlock();
+        }
+    }
+
+    /**
+     * Bind the compliance affecting severities of a query that filters violations by severity.
+     * <p>
+     * The predicate always declares one bind parameter per severity {@link RuleSeverity} defines, so that the queries
+     * stay constant strings. When fewer severities are configured the last one is repeated, which does not change the
+     * outcome of the IN check. The configured set is never empty, so there is always at least one severity to repeat.
+     *
+     * @param prepStmnt  Prepared statement to bind the severities to
+     * @param startIndex Index of the first severity bind parameter
+     * @throws SQLException If an error occurs while setting the severities
+     */
+    private void setComplianceAffectingSeverities(PreparedStatement prepStmnt, int startIndex) throws SQLException {
+
+        List<RuleSeverity> severities = APIMGovernanceUtil.getComplianceAffectingSeverityList();
+        for (int i = 0; i < SEVERITY_BIND_PARAM_COUNT; i++) {
+            RuleSeverity severity = severities.get(Math.min(i, severities.size() - 1));
+            prepStmnt.setString(startIndex + i, String.valueOf(severity));
         }
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.governance.impl/src/main/java/org/wso2/carbon/apimgt/governance/impl/util/APIMGovernanceUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.governance.impl/src/main/java/org/wso2/carbon/apimgt/governance/impl/util/APIMGovernanceUtil.java
@@ -743,6 +743,9 @@ public class APIMGovernanceUtil {
         if (severities.isEmpty()) {
             log.warn("No valid compliance affecting rule severity is configured. Treating every severity as "
                     + "compliance affecting");
+            // Cache the fallback too, otherwise the same invalid value is re-parsed and re-logged on every call
+            resolvedComplianceAffectingSeverities = ALL_SEVERITIES;
+            resolvedSeverityConfig = configuredSeverities;
             return ALL_SEVERITIES;
         }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.governance.impl/src/main/java/org/wso2/carbon/apimgt/governance/impl/util/APIMGovernanceUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.governance.impl/src/main/java/org/wso2/carbon/apimgt/governance/impl/util/APIMGovernanceUtil.java
@@ -21,6 +21,7 @@ package org.wso2.carbon.apimgt.governance.impl.util;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.apimgt.api.model.OASParserOptions;
@@ -35,7 +36,9 @@ import org.wso2.carbon.apimgt.governance.api.model.ArtifactType;
 import org.wso2.carbon.apimgt.governance.api.model.DefaultRuleset;
 import org.wso2.carbon.apimgt.governance.api.model.ExtendedArtifactType;
 import org.wso2.carbon.apimgt.governance.api.model.RuleCategory;
+import org.wso2.carbon.apimgt.governance.api.model.RuleSeverity;
 import org.wso2.carbon.apimgt.governance.api.model.RuleType;
+import org.wso2.carbon.apimgt.governance.api.model.RuleViolation;
 import org.wso2.carbon.apimgt.governance.api.model.Ruleset;
 import org.wso2.carbon.apimgt.governance.api.model.RulesetContent;
 import org.wso2.carbon.apimgt.governance.api.model.RulesetInfo;
@@ -47,6 +50,8 @@ import org.wso2.carbon.apimgt.governance.impl.PolicyManager;
 import org.wso2.carbon.apimgt.governance.impl.RulesetManager;
 import org.wso2.carbon.apimgt.governance.impl.internal.ServiceReferenceHolder;
 import org.wso2.carbon.apimgt.impl.APIMDependencyConfigurationService;
+import org.wso2.carbon.apimgt.impl.APIManagerConfigurationService;
+import org.wso2.carbon.apimgt.impl.dto.APIMGovernanceConfigDTO;
 import org.wso2.carbon.utils.CarbonUtils;
 
 import java.io.File;
@@ -57,6 +62,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -70,6 +76,12 @@ import java.util.stream.Collectors;
  */
 public class APIMGovernanceUtil {
     private static final Log log = LogFactory.getLog(APIMGovernanceUtil.class);
+
+    private static final Set<RuleSeverity> ALL_SEVERITIES =
+            Collections.unmodifiableSet(EnumSet.allOf(RuleSeverity.class));
+
+    private static volatile String resolvedSeverityConfig;
+    private static volatile Set<RuleSeverity> resolvedComplianceAffectingSeverities;
 
     /**
      * Generates a UUID
@@ -678,6 +690,109 @@ public class APIMGovernanceUtil {
             governanceOptions.setYamlCodePointLimit(parserOptions.getYamlCodePointLimit());
         }
         return governanceOptions;
+    }
+
+    /**
+     * Resolve the set of rule severities that affect compliance results.
+     * <p>
+     * Violations of a severity outside this set are still evaluated, persisted and returned to the user, but they do
+     * not mark a ruleset as failed, a policy as violated or an artifact as non-compliant. When the configuration is
+     * absent, blank, or contains no recognizable severity, every severity affects compliance. That keeps the
+     * behaviour of deployments which have not opted in unchanged.
+     *
+     * @return Immutable, never empty set of severities that affect compliance
+     */
+    private static Set<RuleSeverity> resolveComplianceAffectingSeverities() {
+
+        String configuredSeverities = null;
+        APIManagerConfigurationService configurationService = ServiceReferenceHolder.getInstance()
+                .getAPIMConfigurationService();
+        if (configurationService != null && configurationService.getAPIManagerConfiguration() != null) {
+            APIMGovernanceConfigDTO governanceConfig = configurationService.getAPIManagerConfiguration()
+                    .getAPIMGovernanceConfigurationDto();
+            if (governanceConfig != null) {
+                configuredSeverities = governanceConfig.getComplianceAffectingSeverities();
+            }
+        }
+
+        if (StringUtils.isBlank(configuredSeverities)) {
+            return ALL_SEVERITIES;
+        }
+
+        // The configuration is loaded once at server startup, so caching against the raw value is sufficient and
+        // avoids re-parsing it for every artifact while listing compliance results.
+        if (configuredSeverities.equals(resolvedSeverityConfig) && resolvedComplianceAffectingSeverities != null) {
+            return resolvedComplianceAffectingSeverities;
+        }
+
+        Set<RuleSeverity> severities = EnumSet.noneOf(RuleSeverity.class);
+        for (String severityToken : configuredSeverities.split(",")) {
+            String trimmedSeverity = severityToken.trim();
+            if (StringUtils.isEmpty(trimmedSeverity)) {
+                continue;
+            }
+            RuleSeverity severity = RuleSeverity.fromString(trimmedSeverity);
+            if (severity == null) {
+                log.warn("Ignoring unknown rule severity '" + trimmedSeverity
+                        + "' configured as a compliance affecting severity");
+                continue;
+            }
+            severities.add(severity);
+        }
+
+        if (severities.isEmpty()) {
+            log.warn("No valid compliance affecting rule severity is configured. Treating every severity as "
+                    + "compliance affecting");
+            return ALL_SEVERITIES;
+        }
+
+        Set<RuleSeverity> complianceAffectingSeverities = Collections.unmodifiableSet(severities);
+        resolvedComplianceAffectingSeverities = complianceAffectingSeverities;
+        resolvedSeverityConfig = configuredSeverities;
+        return complianceAffectingSeverities;
+    }
+
+    /**
+     * Get the rule severities that affect compliance results, as a list whose order is stable within a call so that
+     * it can be used to bind the parameters of a severity filtered query
+     *
+     * @return Mutable copy of the compliance affecting severities, never empty
+     */
+    public static List<RuleSeverity> getComplianceAffectingSeverityList() {
+
+        return new ArrayList<>(resolveComplianceAffectingSeverities());
+    }
+
+    /**
+     * Check whether a violation of the given severity should affect compliance results
+     *
+     * @param severity Rule severity, may be null when the severity of a violation could not be resolved
+     * @return True if a violation of this severity should mark a ruleset as failed
+     */
+    public static boolean isComplianceAffectingSeverity(RuleSeverity severity) {
+
+        // An unresolved severity is treated as compliance affecting so that a malformed severity in a ruleset can
+        // never silently stop a rule from being enforced.
+        return severity == null || resolveComplianceAffectingSeverities().contains(severity);
+    }
+
+    /**
+     * Filter out the rule violations that should not affect compliance results.
+     * <p>
+     * The given list is never modified. Callers keep using the original list for anything that is shown to the user
+     * and use the returned list only to decide whether a ruleset passed or failed.
+     *
+     * @param ruleViolations List of rule violations
+     * @return List holding only the violations that affect compliance
+     */
+    public static List<RuleViolation> filterComplianceAffectingViolations(List<RuleViolation> ruleViolations) {
+
+        if (ruleViolations == null || ruleViolations.isEmpty()) {
+            return Collections.emptyList();
+        }
+        return ruleViolations.stream()
+                .filter(ruleViolation -> isComplianceAffectingSeverity(ruleViolation.getSeverity()))
+                .collect(Collectors.toList());
     }
 
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.governance.impl/src/test/java/org/wso2/carbon/apimgt/governance/impl/dao/constants/ComplianceSQLConstantsTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.governance.impl/src/test/java/org/wso2/carbon/apimgt/governance/impl/dao/constants/ComplianceSQLConstantsTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.apimgt.governance.impl.dao.constants;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.wso2.carbon.apimgt.governance.api.model.RuleSeverity;
+
+/**
+ * Guards the contract between the compliance queries and the bind indexes used by ComplianceMgtDAOImpl.
+ * <p>
+ * The severity placeholders are bound last, one per severity {@link RuleSeverity} defines. Adding a condition to any
+ * of these queries without moving the severity bind index would bind the severities over the wrong parameters, which
+ * these tests are meant to catch at build time.
+ */
+public class ComplianceSQLConstantsTest {
+
+    private static final int SEVERITY_PARAM_COUNT = RuleSeverity.values().length;
+
+    /**
+     * Count the bind parameters of a query
+     *
+     * @param query SQL query
+     * @return Number of bind parameters
+     */
+    private int countBindParams(String query) {
+
+        int count = 0;
+        for (char character : query.toCharArray()) {
+            if (character == '?') {
+                count++;
+            }
+        }
+        return count;
+    }
+
+    /**
+     * Assert that the severities are bound over the trailing parameters of the query
+     *
+     * @param query              SQL query
+     * @param severityStartIndex Index the DAO starts binding severities at
+     */
+    private void assertSeveritiesAreBoundLast(String query, int severityStartIndex) {
+
+        Assert.assertEquals("The severity bind index must line up with the trailing placeholders of the query",
+                countBindParams(query), severityStartIndex + SEVERITY_PARAM_COUNT - 1);
+    }
+
+    @Test
+    public void testFailedRulesetRunsBindsOrganizationThenSeverities() {
+
+        // ComplianceMgtDAOImpl.getViolatedRulesets binds the organization at 1 and the severities from 2
+        Assert.assertEquals(1 + SEVERITY_PARAM_COUNT,
+                countBindParams(SQLConstants.GET_FAILED_RULESET_RUNS));
+        assertSeveritiesAreBoundLast(SQLConstants.GET_FAILED_RULESET_RUNS, 2);
+    }
+
+    @Test
+    public void testFailedRulesetRunsForArtifactBindsArtifactThenSeverities() {
+
+        // ComplianceMgtDAOImpl.getViolatedRulesetsForArtifact binds three parameters before the severities
+        Assert.assertEquals(3 + SEVERITY_PARAM_COUNT,
+                countBindParams(SQLConstants.GET_FAILED_RULESET_RUNS_FOR_ARTIFACT));
+        assertSeveritiesAreBoundLast(SQLConstants.GET_FAILED_RULESET_RUNS_FOR_ARTIFACT, 4);
+    }
+
+    @Test
+    public void testNonCompliantArtifactsBindsArtifactTypeThenSeverities() {
+
+        // ComplianceMgtDAOImpl.getNonCompliantArtifacts binds two parameters before the severities
+        Assert.assertEquals(2 + SEVERITY_PARAM_COUNT,
+                countBindParams(SQLConstants.GET_NON_COMPLIANT_ARTIFACTS));
+        assertSeveritiesAreBoundLast(SQLConstants.GET_NON_COMPLIANT_ARTIFACTS, 3);
+    }
+
+    @Test
+    public void testComplianceQueriesResolveSeverityInsteadOfTheRulesetRunResultFlag() {
+
+        // GOV_RULESET_RUN.RESULT only records whether a run was completely clean, so it cannot tell an informational
+        // violation apart from a blocking one. Reverting to it would reintroduce the defect these queries fix.
+        for (String query : new String[]{
+                SQLConstants.GET_FAILED_RULESET_RUNS,
+                SQLConstants.GET_FAILED_RULESET_RUNS_FOR_ARTIFACT,
+                SQLConstants.GET_NON_COMPLIANT_ARTIFACTS}) {
+            Assert.assertFalse("Compliance must not be decided by the ruleset run result flag",
+                    query.contains("GRR.RESULT"));
+            Assert.assertTrue("Compliance must be filtered by rule severity",
+                    query.contains("GRULE.SEVERITY IN"));
+            Assert.assertTrue("The severity filter must be correlated with the ruleset run being evaluated",
+                    query.contains("GV.RULESET_RUN_ID = GRR.RULESET_RUN_ID"));
+        }
+    }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.governance.impl/src/test/java/org/wso2/carbon/apimgt/governance/impl/util/ComplianceAffectingSeverityTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.governance.impl/src/test/java/org/wso2/carbon/apimgt/governance/impl/util/ComplianceAffectingSeverityTest.java
@@ -29,6 +29,7 @@ import org.wso2.carbon.apimgt.impl.APIManagerConfiguration;
 import org.wso2.carbon.apimgt.impl.APIManagerConfigurationService;
 import org.wso2.carbon.apimgt.impl.dto.APIMGovernanceConfigDTO;
 
+import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -82,9 +83,36 @@ public class ComplianceAffectingSeverityTest {
     }
 
     @After
-    public void resetConfiguration() {
+    public void resetConfiguration() throws Exception {
 
         ServiceReferenceHolder.getInstance().setAPIMConfigurationService(null);
+        setCachedConfig(null);
+    }
+
+    /**
+     * Overwrite the cached raw configuration value so each test resolves the configuration from scratch
+     *
+     * @param value Raw configuration value to seed the cache with, may be null to clear it
+     * @throws Exception If the field cannot be accessed
+     */
+    private void setCachedConfig(String value) throws Exception {
+
+        Field cachedConfig = APIMGovernanceUtil.class.getDeclaredField("resolvedSeverityConfig");
+        cachedConfig.setAccessible(true);
+        cachedConfig.set(null, value);
+    }
+
+    /**
+     * Read the cached raw configuration value
+     *
+     * @return Cached configuration value, null when nothing has been cached
+     * @throws Exception If the field cannot be accessed
+     */
+    private String getCachedConfig() throws Exception {
+
+        Field cachedConfig = APIMGovernanceUtil.class.getDeclaredField("resolvedSeverityConfig");
+        cachedConfig.setAccessible(true);
+        return (String) cachedConfig.get(null);
     }
 
     // Configuration resolution
@@ -274,5 +302,30 @@ public class ComplianceAffectingSeverityTest {
                 Collections.singletonList(violation("malformed-severity-rule", null));
 
         Assert.assertEquals(1, APIMGovernanceUtil.filterComplianceAffectingViolations(ruleViolations).size());
+    }
+
+    @Test
+    public void testFallbackForAnEntirelyInvalidConfigurationIsCached() throws Exception {
+
+        configureSeverities("NOPE,ALSO_NOPE");
+        Assert.assertEquals(ALL_SEVERITIES,
+                EnumSet.copyOf(APIMGovernanceUtil.getComplianceAffectingSeverityList()));
+
+        Assert.assertEquals("The fallback must be cached, otherwise the invalid value is re-parsed and the warning "
+                        + "re-logged on every call",
+                "NOPE,ALSO_NOPE", getCachedConfig());
+    }
+
+    @Test
+    public void testCacheIsInvalidatedWhenTheConfigurationChanges() throws Exception {
+
+        configureSeverities("ERROR,WARN");
+        Assert.assertEquals(EnumSet.of(RuleSeverity.ERROR, RuleSeverity.WARN),
+                EnumSet.copyOf(APIMGovernanceUtil.getComplianceAffectingSeverityList()));
+
+        configureSeverities("ERROR");
+        Assert.assertEquals("A changed configuration must not keep serving the previously cached value",
+                EnumSet.of(RuleSeverity.ERROR),
+                EnumSet.copyOf(APIMGovernanceUtil.getComplianceAffectingSeverityList()));
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.governance.impl/src/test/java/org/wso2/carbon/apimgt/governance/impl/util/ComplianceAffectingSeverityTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.governance.impl/src/test/java/org/wso2/carbon/apimgt/governance/impl/util/ComplianceAffectingSeverityTest.java
@@ -1,0 +1,278 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.apimgt.governance.impl.util;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.wso2.carbon.apimgt.governance.api.model.RuleSeverity;
+import org.wso2.carbon.apimgt.governance.api.model.RuleViolation;
+import org.wso2.carbon.apimgt.governance.impl.internal.ServiceReferenceHolder;
+import org.wso2.carbon.apimgt.impl.APIManagerConfiguration;
+import org.wso2.carbon.apimgt.impl.APIManagerConfigurationService;
+import org.wso2.carbon.apimgt.impl.dto.APIMGovernanceConfigDTO;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Tests the resolution of compliance affecting rule severities and the filtering of rule violations based on it.
+ * <p>
+ * Rules of a severity that does not affect compliance are still evaluated and reported, but they must not fail a
+ * ruleset, violate a policy or make an artifact non-compliant.
+ */
+public class ComplianceAffectingSeverityTest {
+
+    private static final Set<RuleSeverity> ALL_SEVERITIES = EnumSet.allOf(RuleSeverity.class);
+
+    /**
+     * Point the governance component at a configuration holding the given compliance affecting severities
+     *
+     * @param configuredSeverities Value as it would be read from api-manager.xml, may be null
+     */
+    private void configureSeverities(String configuredSeverities) {
+
+        APIMGovernanceConfigDTO governanceConfig = new APIMGovernanceConfigDTO();
+        governanceConfig.setComplianceAffectingSeverities(configuredSeverities);
+
+        APIManagerConfiguration configuration = Mockito.mock(APIManagerConfiguration.class);
+        Mockito.when(configuration.getAPIMGovernanceConfigurationDto()).thenReturn(governanceConfig);
+
+        APIManagerConfigurationService configurationService = Mockito.mock(APIManagerConfigurationService.class);
+        Mockito.when(configurationService.getAPIManagerConfiguration()).thenReturn(configuration);
+
+        ServiceReferenceHolder.getInstance().setAPIMConfigurationService(configurationService);
+    }
+
+    /**
+     * Build a rule violation carrying the given severity
+     *
+     * @param ruleName Name of the violated rule
+     * @param severity Severity of the violated rule, may be null
+     * @return RuleViolation
+     */
+    private RuleViolation violation(String ruleName, RuleSeverity severity) {
+
+        RuleViolation ruleViolation = new RuleViolation();
+        ruleViolation.setRuleName(ruleName);
+        ruleViolation.setRulesetId("ruleset-1");
+        ruleViolation.setSeverity(severity);
+        return ruleViolation;
+    }
+
+    @After
+    public void resetConfiguration() {
+
+        ServiceReferenceHolder.getInstance().setAPIMConfigurationService(null);
+    }
+
+    // Configuration resolution
+
+    @Test
+    public void testEverySeverityAffectsComplianceWhenNotConfigured() {
+
+        configureSeverities(null);
+        Assert.assertEquals("An unconfigured deployment must keep its existing behaviour",
+                ALL_SEVERITIES, EnumSet.copyOf(APIMGovernanceUtil.getComplianceAffectingSeverityList()));
+    }
+
+    @Test
+    public void testEverySeverityAffectsComplianceWhenConfigurationIsBlank() {
+
+        configureSeverities("   ");
+        Assert.assertEquals(ALL_SEVERITIES,
+                EnumSet.copyOf(APIMGovernanceUtil.getComplianceAffectingSeverityList()));
+    }
+
+    @Test
+    public void testEverySeverityAffectsComplianceWhenConfigurationServiceIsUnavailable() {
+
+        ServiceReferenceHolder.getInstance().setAPIMConfigurationService(null);
+        Assert.assertEquals(ALL_SEVERITIES,
+                EnumSet.copyOf(APIMGovernanceUtil.getComplianceAffectingSeverityList()));
+    }
+
+    @Test
+    public void testConfiguredSeveritiesAreResolved() {
+
+        configureSeverities("ERROR,WARN");
+        Assert.assertEquals(EnumSet.of(RuleSeverity.ERROR, RuleSeverity.WARN),
+                EnumSet.copyOf(APIMGovernanceUtil.getComplianceAffectingSeverityList()));
+    }
+
+    @Test
+    public void testConfiguredSeveritiesAreCaseInsensitiveAndTrimmed() {
+
+        configureSeverities(" error , Warn ");
+        Assert.assertEquals(EnumSet.of(RuleSeverity.ERROR, RuleSeverity.WARN),
+                EnumSet.copyOf(APIMGovernanceUtil.getComplianceAffectingSeverityList()));
+    }
+
+    @Test
+    public void testUnknownSeverityTokensAreIgnored() {
+
+        configureSeverities("ERROR,BLOCKER");
+        Assert.assertEquals("An unknown token must be skipped without discarding the valid ones",
+                EnumSet.of(RuleSeverity.ERROR),
+                EnumSet.copyOf(APIMGovernanceUtil.getComplianceAffectingSeverityList()));
+    }
+
+    @Test
+    public void testEverySeverityAffectsComplianceWhenNoTokenIsValid() {
+
+        configureSeverities("BLOCKER,ERR0R");
+        Assert.assertEquals("Falling back to every severity keeps governance strict rather than silently lenient",
+                ALL_SEVERITIES, EnumSet.copyOf(APIMGovernanceUtil.getComplianceAffectingSeverityList()));
+    }
+
+    @Test
+    public void testEmptyTokensAreIgnored() {
+
+        configureSeverities("ERROR,,WARN,");
+        Assert.assertEquals(EnumSet.of(RuleSeverity.ERROR, RuleSeverity.WARN),
+                EnumSet.copyOf(APIMGovernanceUtil.getComplianceAffectingSeverityList()));
+    }
+
+    @Test
+    public void testSeverityListIsNeverEmpty() {
+
+        for (String configuredSeverities : new String[]{null, "", "   ", ",", "UNKNOWN"}) {
+            configureSeverities(configuredSeverities);
+            Assert.assertFalse("A query filtered by severity always needs at least one severity to bind",
+                    APIMGovernanceUtil.getComplianceAffectingSeverityList().isEmpty());
+        }
+    }
+
+    @Test
+    public void testSeverityListIsADefensiveCopy() {
+
+        configureSeverities("ERROR,WARN");
+        List<RuleSeverity> severities = APIMGovernanceUtil.getComplianceAffectingSeverityList();
+        severities.clear();
+        Assert.assertEquals("Mutating the returned list must not affect the cached configuration",
+                EnumSet.of(RuleSeverity.ERROR, RuleSeverity.WARN),
+                EnumSet.copyOf(APIMGovernanceUtil.getComplianceAffectingSeverityList()));
+    }
+
+    // Severity checks
+
+    @Test
+    public void testOnlyConfiguredSeveritiesAffectCompliance() {
+
+        configureSeverities("ERROR,WARN");
+        Assert.assertTrue(APIMGovernanceUtil.isComplianceAffectingSeverity(RuleSeverity.ERROR));
+        Assert.assertTrue(APIMGovernanceUtil.isComplianceAffectingSeverity(RuleSeverity.WARN));
+        Assert.assertFalse(APIMGovernanceUtil.isComplianceAffectingSeverity(RuleSeverity.INFO));
+    }
+
+    @Test
+    public void testUnresolvedSeverityAffectsCompliance() {
+
+        configureSeverities("ERROR");
+        Assert.assertTrue("A violation whose severity could not be resolved must not silently stop being enforced",
+                APIMGovernanceUtil.isComplianceAffectingSeverity(null));
+    }
+
+    // Violation filtering
+
+    @Test
+    public void testInfoViolationsAloneDoNotAffectCompliance() {
+
+        configureSeverities("ERROR,WARN");
+        List<RuleViolation> ruleViolations = Arrays.asList(
+                violation("api-description-check", RuleSeverity.INFO),
+                violation("api-contact-check", RuleSeverity.INFO));
+
+        Assert.assertTrue("A ruleset failing only info level rules must pass",
+                APIMGovernanceUtil.filterComplianceAffectingViolations(ruleViolations).isEmpty());
+    }
+
+    @Test
+    public void testErrorViolationStillAffectsComplianceAlongsideInfoViolations() {
+
+        configureSeverities("ERROR,WARN");
+        List<RuleViolation> ruleViolations = Arrays.asList(
+                violation("api-version-prefix", RuleSeverity.ERROR),
+                violation("api-description-check", RuleSeverity.INFO));
+
+        List<RuleViolation> complianceAffecting =
+                APIMGovernanceUtil.filterComplianceAffectingViolations(ruleViolations);
+
+        Assert.assertEquals(1, complianceAffecting.size());
+        Assert.assertEquals("api-version-prefix", complianceAffecting.get(0).getRuleName());
+    }
+
+    @Test
+    public void testWarnViolationAffectsCompliance() {
+
+        configureSeverities("ERROR,WARN");
+        List<RuleViolation> ruleViolations =
+                Collections.singletonList(violation("api-description-length", RuleSeverity.WARN));
+
+        Assert.assertEquals(1, APIMGovernanceUtil.filterComplianceAffectingViolations(ruleViolations).size());
+    }
+
+    @Test
+    public void testInfoViolationsAffectComplianceWhenNotConfigured() {
+
+        configureSeverities(null);
+        List<RuleViolation> ruleViolations =
+                Collections.singletonList(violation("api-description-check", RuleSeverity.INFO));
+
+        Assert.assertEquals("Without the configuration an info violation must keep failing the ruleset",
+                1, APIMGovernanceUtil.filterComplianceAffectingViolations(ruleViolations).size());
+    }
+
+    @Test
+    public void testFilteringDoesNotModifyTheGivenViolations() {
+
+        configureSeverities("ERROR");
+        List<RuleViolation> ruleViolations = new ArrayList<>(Arrays.asList(
+                violation("api-version-prefix", RuleSeverity.ERROR),
+                violation("api-description-check", RuleSeverity.INFO)));
+
+        APIMGovernanceUtil.filterComplianceAffectingViolations(ruleViolations);
+
+        Assert.assertEquals("Every violation must still be reported to the user", 2, ruleViolations.size());
+    }
+
+    @Test
+    public void testFilteringHandlesEmptyAndNullViolations() {
+
+        configureSeverities("ERROR,WARN");
+        Assert.assertTrue(APIMGovernanceUtil.filterComplianceAffectingViolations(null).isEmpty());
+        Assert.assertTrue(APIMGovernanceUtil
+                .filterComplianceAffectingViolations(Collections.emptyList()).isEmpty());
+    }
+
+    @Test
+    public void testViolationWithUnresolvedSeverityIsKept() {
+
+        configureSeverities("ERROR");
+        List<RuleViolation> ruleViolations =
+                Collections.singletonList(violation("malformed-severity-rule", null));
+
+        Assert.assertEquals(1, APIMGovernanceUtil.filterComplianceAffectingViolations(ruleViolations).size());
+    }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.governance.rest.api/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.governance.rest.api/pom.xml
@@ -105,6 +105,26 @@
             <artifactId>org.wso2.carbon.apimgt.spec.parser</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-module-junit4</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-api-mockito2</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>
@@ -155,6 +175,16 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <!-- PowerMock needs deep reflection into java.base, which is not open by default from JDK 17 -->
+                    <argLine>
+                        --add-opens java.base/java.lang=ALL-UNNAMED
+                        --add-opens java.base/java.lang.reflect=ALL-UNNAMED
+                        --add-opens java.base/java.io=ALL-UNNAMED
+                        --add-opens java.base/java.util=ALL-UNNAMED
+                        --add-opens=java.base/jdk.internal.loader=ALL-UNNAMED
+                    </argLine>
+                </configuration>
                 <dependencies>
                     <dependency>
                         <groupId>org.apache.maven.surefire</groupId>

--- a/components/apimgt/org.wso2.carbon.apimgt.governance.rest.api/src/main/java/org/wso2/carbon/apimgt/governance/rest/api/util/ComplianceAPIUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.governance.rest.api/src/main/java/org/wso2/carbon/apimgt/governance/rest/api/util/ComplianceAPIUtil.java
@@ -160,9 +160,6 @@ public class ComplianceAPIUtil {
         } else if (policyAdherenceDetails.stream().anyMatch(dto -> dto.getStatus()
                 == PolicyAdherenceWithRulesetsDTO.StatusEnum.VIOLATED)) {
             status = ArtifactComplianceDetailsDTO.StatusEnum.NON_COMPLIANT;
-        } else if (policyAdherenceDetails.stream().anyMatch(dto -> dto.getStatus()
-                == PolicyAdherenceWithRulesetsDTO.StatusEnum.VIOLATED)) {
-            status = ArtifactComplianceDetailsDTO.StatusEnum.NON_COMPLIANT;
         } else {
             status = ArtifactComplianceDetailsDTO.StatusEnum.COMPLIANT;
         }
@@ -289,7 +286,8 @@ public class ComplianceAPIUtil {
                 ruleset.getId(), organization);
 
 
-        rulesetDTO.setStatus(ruleViolations.isEmpty() ?
+        // Violations of a non compliance affecting severity are still reported, but they do not fail the ruleset
+        rulesetDTO.setStatus(APIMGovernanceUtil.filterComplianceAffectingViolations(ruleViolations).isEmpty() ?
                 RulesetValidationResultWithoutRulesDTO.StatusEnum.PASSED :
                 RulesetValidationResultWithoutRulesDTO.StatusEnum.FAILED);
 
@@ -434,6 +432,12 @@ public class ComplianceAPIUtil {
 
             ruleViolationCounts.add(violationCountDTO);
 
+            // Violations of a non compliance affecting severity are still counted above, but they do not make the
+            // ruleset, and in turn the policy and the artifact, non-compliant
+            if (!APIMGovernanceUtil.isComplianceAffectingSeverity(severity)) {
+                continue;
+            }
+
             // Track the IDs of violated rulesets
             for (RuleViolation ruleViolation : ruleViolations) {
                 violatedRulesets.add(ruleViolation.getRulesetId());
@@ -574,11 +578,14 @@ public class ComplianceAPIUtil {
             }
         }
 
+        // Every violation is reported to the user, including the ones of a non compliance affecting severity, but
+        // only the compliance affecting ones decide whether the ruleset passed
         rulesetValidationResultDTO.setViolatedRules(violatedRules);
         rulesetValidationResultDTO.setFollowedRules(followedRules);
-        rulesetValidationResultDTO.setStatus(violatedRules.isEmpty() ?
-                RulesetValidationResultDTO.StatusEnum.PASSED :
-                RulesetValidationResultDTO.StatusEnum.FAILED);
+        rulesetValidationResultDTO.setStatus(
+                APIMGovernanceUtil.filterComplianceAffectingViolations(ruleViolations).isEmpty() ?
+                        RulesetValidationResultDTO.StatusEnum.PASSED :
+                        RulesetValidationResultDTO.StatusEnum.FAILED);
 
         return rulesetValidationResultDTO;
     }

--- a/components/apimgt/org.wso2.carbon.apimgt.governance.rest.api/src/test/java/org/wso2/carbon/apimgt/governance/rest/api/util/ComplianceAPIUtilSeverityTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.governance.rest.api/src/test/java/org/wso2/carbon/apimgt/governance/rest/api/util/ComplianceAPIUtilSeverityTest.java
@@ -1,0 +1,213 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.apimgt.governance.rest.api.util;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.powermock.reflect.Whitebox;
+import org.wso2.carbon.apimgt.governance.api.model.ArtifactType;
+import org.wso2.carbon.apimgt.governance.api.model.RuleSeverity;
+import org.wso2.carbon.apimgt.governance.api.model.RuleType;
+import org.wso2.carbon.apimgt.governance.api.model.RuleViolation;
+import org.wso2.carbon.apimgt.governance.api.model.RulesetInfo;
+import org.wso2.carbon.apimgt.governance.impl.ComplianceManager;
+import org.wso2.carbon.apimgt.governance.impl.internal.ServiceReferenceHolder;
+import org.wso2.carbon.apimgt.governance.rest.api.dto.RulesetValidationResultWithoutRulesDTO;
+import org.wso2.carbon.apimgt.impl.APIManagerConfiguration;
+import org.wso2.carbon.apimgt.impl.APIManagerConfigurationService;
+import org.wso2.carbon.apimgt.impl.dto.APIMGovernanceConfigDTO;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Tests that the ruleset status reported to the portals is decided only by the violations whose severity affects
+ * compliance, while every violation stays visible to the user.
+ */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({ComplianceAPIUtil.class})
+public class ComplianceAPIUtilSeverityTest {
+
+    private static final String ARTIFACT_REF_ID = "d090cf7c-d1ab-491c-9357-b55a47e49ef2";
+    private static final String RULESET_ID = "7ca1bcae-6feb-4c4b-9252-78e034b8b89e";
+    private static final String ORGANIZATION = "carbon.super";
+
+    private ComplianceManager complianceManager;
+
+    @Before
+    public void setUp() throws Exception {
+
+        complianceManager = Mockito.mock(ComplianceManager.class);
+        PowerMockito.whenNew(ComplianceManager.class).withNoArguments().thenReturn(complianceManager);
+    }
+
+    @After
+    public void resetConfiguration() {
+
+        ServiceReferenceHolder.getInstance().setAPIMConfigurationService(null);
+    }
+
+    /**
+     * Point the governance component at a configuration holding the given compliance affecting severities
+     *
+     * @param configuredSeverities Value as it would be read from api-manager.xml, may be null
+     */
+    private void configureSeverities(String configuredSeverities) {
+
+        APIMGovernanceConfigDTO governanceConfig = new APIMGovernanceConfigDTO();
+        governanceConfig.setComplianceAffectingSeverities(configuredSeverities);
+
+        APIManagerConfiguration configuration = Mockito.mock(APIManagerConfiguration.class);
+        Mockito.when(configuration.getAPIMGovernanceConfigurationDto()).thenReturn(governanceConfig);
+
+        APIManagerConfigurationService configurationService = Mockito.mock(APIManagerConfigurationService.class);
+        Mockito.when(configurationService.getAPIManagerConfiguration()).thenReturn(configuration);
+
+        ServiceReferenceHolder.getInstance().setAPIMConfigurationService(configurationService);
+    }
+
+    /**
+     * Build a rule violation carrying the given severity
+     *
+     * @param ruleName Name of the violated rule
+     * @param severity Severity of the violated rule
+     * @return RuleViolation
+     */
+    private RuleViolation violation(String ruleName, RuleSeverity severity) {
+
+        RuleViolation ruleViolation = new RuleViolation();
+        ruleViolation.setRuleName(ruleName);
+        ruleViolation.setRulesetId(RULESET_ID);
+        ruleViolation.setSeverity(severity);
+        return ruleViolation;
+    }
+
+    /**
+     * Invoke the ruleset validation mapping with the given violations already recorded against the ruleset
+     *
+     * @param ruleViolations Violations the compliance manager should report
+     * @return RulesetValidationResultWithoutRulesDTO as returned to the portals
+     * @throws Exception If the mapping fails
+     */
+    private RulesetValidationResultWithoutRulesDTO evaluateRuleset(List<RuleViolation> ruleViolations)
+            throws Exception {
+
+        Mockito.when(complianceManager.getRuleViolations(ArgumentMatchers.anyString(),
+                        ArgumentMatchers.any(ArtifactType.class), ArgumentMatchers.anyString(),
+                        ArgumentMatchers.anyString()))
+                .thenReturn(ruleViolations);
+
+        RulesetInfo rulesetInfo = new RulesetInfo();
+        rulesetInfo.setId(RULESET_ID);
+        rulesetInfo.setName("Severity_Test_Ruleset");
+        rulesetInfo.setRuleType(RuleType.API_DEFINITION);
+
+        return Whitebox.invokeMethod(ComplianceAPIUtil.class, "getRulesetValidationResultsDTO",
+                rulesetInfo, ARTIFACT_REF_ID, ArtifactType.API, ORGANIZATION, true);
+    }
+
+    @Test
+    public void testRulesetPassesWhenOnlyInfoRulesAreViolated() throws Exception {
+
+        configureSeverities("ERROR,WARN");
+        RulesetValidationResultWithoutRulesDTO result = evaluateRuleset(Arrays.asList(
+                violation("api-description-check", RuleSeverity.INFO),
+                violation("api-contact-check", RuleSeverity.INFO)));
+
+        Assert.assertEquals(RulesetValidationResultWithoutRulesDTO.StatusEnum.PASSED, result.getStatus());
+    }
+
+    @Test
+    public void testRulesetFailsWhenAnErrorRuleIsViolatedAlongsideInfoRules() throws Exception {
+
+        configureSeverities("ERROR,WARN");
+        RulesetValidationResultWithoutRulesDTO result = evaluateRuleset(Arrays.asList(
+                violation("api-version-prefix", RuleSeverity.ERROR),
+                violation("api-description-check", RuleSeverity.INFO)));
+
+        Assert.assertEquals(RulesetValidationResultWithoutRulesDTO.StatusEnum.FAILED, result.getStatus());
+    }
+
+    @Test
+    public void testRulesetFailsWhenAWarnRuleIsViolated() throws Exception {
+
+        configureSeverities("ERROR,WARN");
+        RulesetValidationResultWithoutRulesDTO result = evaluateRuleset(
+                Collections.singletonList(violation("api-description-length", RuleSeverity.WARN)));
+
+        Assert.assertEquals(RulesetValidationResultWithoutRulesDTO.StatusEnum.FAILED, result.getStatus());
+    }
+
+    @Test
+    public void testRulesetFailsOnInfoViolationWhenSeveritiesAreNotConfigured() throws Exception {
+
+        configureSeverities(null);
+        RulesetValidationResultWithoutRulesDTO result = evaluateRuleset(
+                Collections.singletonList(violation("api-description-check", RuleSeverity.INFO)));
+
+        Assert.assertEquals("An unconfigured deployment must keep failing on info violations",
+                RulesetValidationResultWithoutRulesDTO.StatusEnum.FAILED, result.getStatus());
+    }
+
+    @Test
+    public void testRulesetPassesWhenNothingIsViolated() throws Exception {
+
+        configureSeverities("ERROR,WARN");
+        RulesetValidationResultWithoutRulesDTO result = evaluateRuleset(Collections.emptyList());
+
+        Assert.assertEquals(RulesetValidationResultWithoutRulesDTO.StatusEnum.PASSED, result.getStatus());
+    }
+
+    @Test
+    public void testRulesetFailsWhenAViolationSeverityCannotBeResolved() throws Exception {
+
+        configureSeverities("ERROR");
+        RulesetValidationResultWithoutRulesDTO result = evaluateRuleset(
+                Collections.singletonList(violation("malformed-severity-rule", null)));
+
+        Assert.assertEquals("A violation of an unresolved severity must still fail the ruleset",
+                RulesetValidationResultWithoutRulesDTO.StatusEnum.FAILED, result.getStatus());
+    }
+
+    @Test
+    public void testRulesetIsUnappliedWhenItWasNotEvaluated() throws Exception {
+
+        configureSeverities("ERROR,WARN");
+        RulesetInfo rulesetInfo = new RulesetInfo();
+        rulesetInfo.setId(RULESET_ID);
+        rulesetInfo.setName("Severity_Test_Ruleset");
+        rulesetInfo.setRuleType(RuleType.API_DEFINITION);
+
+        RulesetValidationResultWithoutRulesDTO result = Whitebox.invokeMethod(ComplianceAPIUtil.class,
+                "getRulesetValidationResultsDTO", rulesetInfo, ARTIFACT_REF_ID, ArtifactType.API, ORGANIZATION,
+                false);
+
+        Assert.assertEquals("Severity filtering must not disturb the unapplied state",
+                RulesetValidationResultWithoutRulesDTO.StatusEnum.UNAPPLIED, result.getStatus());
+    }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -3832,6 +3832,7 @@ public final class APIConstants {
         public static final String SCHEDULER_QUEUE_SIZE = "QueueSize";
         public static final String SCHEDULER_TASK_CHECK_INTERVAL = "TaskCheckIntervalMinutes";
         public static final String SCHEDULER_TASK_CLEANUP_INTERVAL = "TaskCleanupIntervalMinutes";
+        public static final String COMPLIANCE_AFFECTING_SEVERITIES = "ComplianceAffectingSeverities";
     }
 
     public static class MCP {

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIManagerConfiguration.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIManagerConfiguration.java
@@ -3434,6 +3434,12 @@ public class APIManagerConfiguration {
             apimGovConfigurationDto.setDataSourceName(dataSourceName);
         }
 
+        OMElement complianceAffectingSeverities = omElement
+                .getFirstChildWithName(new QName(APIConstants.APIMGovernance.COMPLIANCE_AFFECTING_SEVERITIES));
+        if (complianceAffectingSeverities != null) {
+            apimGovConfigurationDto.setComplianceAffectingSeverities(complianceAffectingSeverities.getText());
+        }
+
         OMElement schedulerConfig = omElement
                 .getFirstChildWithName(new QName(APIConstants.APIMGovernance.SCHEDULER_CONFIG));
 

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dto/APIMGovernanceConfigDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dto/APIMGovernanceConfigDTO.java
@@ -29,6 +29,13 @@ public class APIMGovernanceConfigDTO {
     private int schedulerTaskCheckInterval;
     private int schedulerTaskCleanupInterval;
 
+    /**
+     * Comma separated list of rule severities that make a ruleset/policy/artifact non-compliant.
+     * Kept as a raw string here so that this module does not depend on the governance component. An empty or null
+     * value means "not configured", in which case every severity affects compliance (the historical behaviour).
+     */
+    private String complianceAffectingSeverities;
+
     public String getDataSourceName() {
         return dataSourceName;
     }
@@ -67,5 +74,13 @@ public class APIMGovernanceConfigDTO {
 
     public void setSchedulerTaskCleanupInterval(int schedulerTaskCleanupInterval) {
         this.schedulerTaskCleanupInterval = schedulerTaskCleanupInterval;
+    }
+
+    public String getComplianceAffectingSeverities() {
+        return complianceAffectingSeverities;
+    }
+
+    public void setComplianceAffectingSeverities(String complianceAffectingSeverities) {
+        this.complianceAffectingSeverities = complianceAffectingSeverities;
     }
 }

--- a/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/templates/repository/conf/api-manager.xml.j2
+++ b/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/templates/repository/conf/api-manager.xml.j2
@@ -784,6 +784,10 @@
     <!-- This property is to configure the API Manager Governance capabilities -->
     <APIMGovernance>
         <DataSource>{{apim.governance.datasource.name}}</DataSource>
+        <!-- Rule severities that make a ruleset fail, and in turn the policy violated and the artifact
+             non-compliant. Violations of any other severity are still evaluated, stored and shown to the user,
+             but they do not affect the compliance status. Accepts ERROR, WARN and INFO. -->
+        <ComplianceAffectingSeverities>{{apim.governance.compliance_affecting_severities.toList()|join(',')}}</ComplianceAffectingSeverities>
         <SchedulerConfigurations>
             <ThreadPoolSize>{{apim.governance.scheduler.thread_pool_size}}</ThreadPoolSize>
             <QueueSize>{{apim.governance.scheduler.queue_size}}</QueueSize>


### PR DESCRIPTION
## Purpose

Fixes governance compliance treating all rule severities identically, so that a failing info rule marks the ruleset FAILED, the policy VIOLATED and the API NON-COMPLIANT even when every error and warn rule passes.

Related: https://github.com/wso2/product-apim/pull/14292
Resolves: https://github.com/wso2/api-manager/issues/5185

## Root cause

Severity is persisted but never consulted when a status is computed.

At write time a single boolean is stored per ruleset run - "were there zero violations?". Severity is discarded at that point. Every status above simply repeats that answer: ruleset → policy → artifact.

Severity was used in only two places: rendering the per-severity violation counts, and the blocking decision.

## Approach

Introduce a configurable set of compliance-affecting severities and consult it wherever a status is decided. Severity is resolved at read time, not write time.

[apim.governance]
compliance_affecting_severities = ["ERROR", "WARN"]

Default is all three severities, so deployments that don't opt in are unaffected.

Violations outside the set are still evaluated, persisted, returned and counted in the badges - they simply stop flipping a status. A ruleset can now report PASSED while listing an info finding.