### PR TITLE
Add case sensitivity check for resources when updating an API

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
@@ -6275,9 +6275,11 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
                     String updatedVerb = updatedUriTemplate.getHTTPVerb();
                     String updatedPath = updatedUriTemplate.getUriTemplate();
 
-                    //Check if existing reused resource is among updated resources
+                    //Check if existing reused resource is among updated resources.
+                    //Resource paths are case-sensitive, hence a change which only alters the letter case of the
+                    //path removes the existing resource. The HTTP verb, however, is case-insensitive.
                     if (existingVerb.equalsIgnoreCase(updatedVerb) &&
-                            existingPath.equalsIgnoreCase(updatedPath)) {
+                            existingPath.equals(updatedPath)) {
                         isReusedResourceRemoved = false;
                         break;
                     }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/APIProviderImplTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/APIProviderImplTest.java
@@ -2013,4 +2013,129 @@ public class APIProviderImplTest {
         policy.setParameters(params);
         return policy;
     }
+
+    @Test
+    public void testGetRemovedProductResourcesWhenResourceIsUnchanged() throws APIManagementException {
+
+        APIProviderImplWrapper apiProvider = new APIProviderImplWrapper(apimgtDAO, scopesDAO);
+        API existingAPI = createAPIWithResources(true, "GET:/hello", "POST:/hello");
+
+        List<APIResource> removedResources = apiProvider
+                .getRemovedProductResources(createURITemplates("GET:/hello", "POST:/hello"), existingAPI);
+
+        Assert.assertTrue("An unchanged product used resource was reported as removed: " + removedResources,
+                removedResources.isEmpty());
+    }
+
+    /**
+     * Resource paths of an API are case-sensitive, therefore changing only the letter case of a resource path
+     * removes the original resource. This has to be reported when the resource is used by one or more API Products,
+     * otherwise the product to resource mapping of the API Product is left dangling.
+     */
+    @Test
+    public void testGetRemovedProductResourcesWhenResourcePathLetterCaseChanged() throws APIManagementException {
+
+        APIProviderImplWrapper apiProvider = new APIProviderImplWrapper(apimgtDAO, scopesDAO);
+        API existingAPI = createAPIWithResources(true, "GET:/hello");
+
+        List<APIResource> removedResources = apiProvider
+                .getRemovedProductResources(createURITemplates("GET:/Hello"), existingAPI);
+
+        Assert.assertEquals("A letter case only change of a product used resource path was not detected as a "
+                + "removed resource", 1, removedResources.size());
+        Assert.assertEquals(new APIResource("GET", "/hello"), removedResources.get(0));
+    }
+
+    /**
+     * Path parameter names are part of the URL template stored against the API Product, hence a letter case change
+     * of a path parameter has to be treated the same way as any other resource path change.
+     */
+    @Test
+    public void testGetRemovedProductResourcesWhenPathParameterLetterCaseChanged() throws APIManagementException {
+
+        APIProviderImplWrapper apiProvider = new APIProviderImplWrapper(apimgtDAO, scopesDAO);
+        API existingAPI = createAPIWithResources(true, "GET:/pizza/{orderId}");
+
+        List<APIResource> removedResources = apiProvider
+                .getRemovedProductResources(createURITemplates("GET:/pizza/{orderid}"), existingAPI);
+
+        Assert.assertEquals("A letter case only change of a path parameter was not detected as a removed resource",
+                1, removedResources.size());
+        Assert.assertEquals(new APIResource("GET", "/pizza/{orderId}"), removedResources.get(0));
+    }
+
+    /**
+     * HTTP verbs are persisted in upper case and are written to the API definition in lower case, therefore the verb
+     * comparison has to stay case-insensitive.
+     */
+    @Test
+    public void testGetRemovedProductResourcesWhenHttpVerbLetterCaseChanged() throws APIManagementException {
+
+        APIProviderImplWrapper apiProvider = new APIProviderImplWrapper(apimgtDAO, scopesDAO);
+        API existingAPI = createAPIWithResources(true, "GET:/hello");
+
+        List<APIResource> removedResources = apiProvider
+                .getRemovedProductResources(createURITemplates("get:/hello"), existingAPI);
+
+        Assert.assertTrue("A product used resource was reported as removed for an HTTP verb letter case difference: "
+                + removedResources, removedResources.isEmpty());
+    }
+
+    @Test
+    public void testGetRemovedProductResourcesWhenNonProductResourcePathLetterCaseChanged()
+            throws APIManagementException {
+
+        APIProviderImplWrapper apiProvider = new APIProviderImplWrapper(apimgtDAO, scopesDAO);
+        API existingAPI = createAPIWithResources(false, "GET:/hello");
+
+        List<APIResource> removedResources = apiProvider
+                .getRemovedProductResources(createURITemplates("GET:/Hello"), existingAPI);
+
+        Assert.assertTrue("A resource which is not used by any API Product was reported as removed: "
+                + removedResources, removedResources.isEmpty());
+    }
+
+    @Test
+    public void testGetRemovedProductResourcesWhenResourcePathChanged() throws APIManagementException {
+
+        APIProviderImplWrapper apiProvider = new APIProviderImplWrapper(apimgtDAO, scopesDAO);
+        API existingAPI = createAPIWithResources(true, "GET:/v1/hello");
+
+        List<APIResource> removedResources = apiProvider
+                .getRemovedProductResources(createURITemplates("GET:/v3/hello"), existingAPI);
+
+        Assert.assertEquals("A removed product used resource was not detected", 1, removedResources.size());
+        Assert.assertEquals(new APIResource("GET", "/v1/hello"), removedResources.get(0));
+    }
+
+    private API createAPIWithResources(boolean usedByProducts, String... verbAndPaths) {
+        API api = new API(new APIIdentifier("admin", "PizzaShackAPI", "1.0.0"));
+        api.setUuid(apiUUID);
+        api.setUriTemplates(createURITemplates(usedByProducts, verbAndPaths));
+        return api;
+    }
+
+    private Set<URITemplate> createURITemplates(String... verbAndPaths) {
+        return createURITemplates(false, verbAndPaths);
+    }
+
+    private Set<URITemplate> createURITemplates(boolean usedByProducts, String... verbAndPaths) {
+        Set<URITemplate> uriTemplates = new HashSet<>();
+        for (String verbAndPath : verbAndPaths) {
+            uriTemplates.add(createURITemplate(verbAndPath, usedByProducts));
+        }
+        return uriTemplates;
+    }
+
+    private URITemplate createURITemplate(String verbAndPath, boolean usedByProducts) {
+        String[] verbAndPathParts = verbAndPath.split(":", 2);
+        URITemplate uriTemplate = new URITemplate();
+        uriTemplate.setHTTPVerb(verbAndPathParts[0]);
+        uriTemplate.setUriTemplate(verbAndPathParts[1]);
+        uriTemplate.setResourceURI(verbAndPathParts[1]);
+        if (usedByProducts) {
+            uriTemplate.addUsedByProduct(new APIProductIdentifier("admin", "PizzaShackProduct", "1.0.0"));
+        }
+        return uriTemplate;
+    }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/PublisherCommonUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/PublisherCommonUtils.java
@@ -2075,8 +2075,10 @@ public class PublisherCommonUtils {
                     String updatedVerb = updatedOperation.getVerb();
                     String updatedPath = updatedOperation.getTarget();
 
-                    //Check if existing reused resource is among updated resources
-                    if (existingVerb.equalsIgnoreCase(updatedVerb) && existingPath.equalsIgnoreCase(updatedPath)) {
+                    //Check if existing reused resource is among updated resources.
+                    //Resource paths are case-sensitive, hence a change which only alters the letter case of the
+                    //path removes the existing resource. The HTTP verb, however, is case-insensitive.
+                    if (existingVerb.equalsIgnoreCase(updatedVerb) && existingPath.equals(updatedPath)) {
                         isReusedResourceRemoved = false;
                         break;
                     }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/test/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/PublisherCommonUtilsTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/test/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/PublisherCommonUtilsTest.java
@@ -27,20 +27,26 @@ import org.mockito.Mockito;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
+import org.powermock.reflect.Whitebox;
 import org.wso2.carbon.apimgt.api.APIManagementException;
 import org.wso2.carbon.apimgt.api.APIProvider;
 import org.wso2.carbon.apimgt.api.FaultGatewaysException;
+import org.wso2.carbon.apimgt.api.doc.model.APIResource;
+import org.wso2.carbon.apimgt.api.model.API;
+import org.wso2.carbon.apimgt.api.model.APIIdentifier;
 import org.wso2.carbon.apimgt.api.model.APIProduct;
 import org.wso2.carbon.apimgt.api.model.APIProductIdentifier;
 import org.wso2.carbon.apimgt.api.model.APIStatus;
 import org.wso2.carbon.apimgt.api.model.ApiTypeWrapper;
 import org.wso2.carbon.apimgt.api.model.Tier;
+import org.wso2.carbon.apimgt.api.model.URITemplate;
 import org.wso2.carbon.apimgt.impl.APIConstants;
 import org.wso2.carbon.apimgt.impl.utils.APIUtil;
 import org.wso2.carbon.apimgt.impl.utils.TierNameComparator;
 import org.wso2.carbon.apimgt.impl.workflow.WorkflowExecutorFactory;
 import org.wso2.carbon.apimgt.rest.api.common.RestApiCommonUtil;
 import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.APIDTO;
+import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.APIOperationsDTO;
 import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.APIProductDTO;
 import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.AdvertiseInfoDTO;
 import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.DocumentDTO;
@@ -655,4 +661,130 @@ public class PublisherCommonUtilsTest {
         }
     }
 
+    @Test
+    public void testGetRemovedProductResourcesWhenResourceIsUnchanged() throws Exception {
+
+        API existingAPI = createAPIWithResources(true, "GET:/hello", "POST:/hello");
+        APIDTO updatedAPIDTO = createAPIDTOWithOperations("GET:/hello", "POST:/hello");
+
+        List<APIResource> removedResources = Whitebox.invokeMethod(PublisherCommonUtils.class,
+                "getRemovedProductResources", updatedAPIDTO, existingAPI);
+
+        Assert.assertTrue("An unchanged product used resource was reported as removed: " + removedResources,
+                removedResources.isEmpty());
+    }
+
+    /**
+     * Resource paths of an API are case-sensitive, therefore changing only the letter case of a resource path
+     * removes the original resource. This has to be reported when the resource is used by one or more API Products,
+     * otherwise the product to resource mapping of the API Product is left dangling.
+     */
+    @Test
+    public void testGetRemovedProductResourcesWhenResourcePathLetterCaseChanged() throws Exception {
+
+        API existingAPI = createAPIWithResources(true, "GET:/hello");
+        APIDTO updatedAPIDTO = createAPIDTOWithOperations("GET:/Hello");
+
+        List<APIResource> removedResources = Whitebox.invokeMethod(PublisherCommonUtils.class,
+                "getRemovedProductResources", updatedAPIDTO, existingAPI);
+
+        Assert.assertEquals("A letter case only change of a product used resource path was not detected as a "
+                + "removed resource", 1, removedResources.size());
+        Assert.assertEquals(new APIResource("GET", "/hello"), removedResources.get(0));
+    }
+
+    /**
+     * Path parameter names are part of the URL template stored against the API Product, hence a letter case change
+     * of a path parameter has to be treated the same way as any other resource path change.
+     */
+    @Test
+    public void testGetRemovedProductResourcesWhenPathParameterLetterCaseChanged() throws Exception {
+
+        API existingAPI = createAPIWithResources(true, "GET:/pizza/{orderId}");
+        APIDTO updatedAPIDTO = createAPIDTOWithOperations("GET:/pizza/{orderid}");
+
+        List<APIResource> removedResources = Whitebox.invokeMethod(PublisherCommonUtils.class,
+                "getRemovedProductResources", updatedAPIDTO, existingAPI);
+
+        Assert.assertEquals("A letter case only change of a path parameter was not detected as a removed resource",
+                1, removedResources.size());
+        Assert.assertEquals(new APIResource("GET", "/pizza/{orderId}"), removedResources.get(0));
+    }
+
+    /**
+     * HTTP verbs are persisted in upper case and are written to the API definition in lower case, therefore the verb
+     * comparison has to stay case-insensitive.
+     */
+    @Test
+    public void testGetRemovedProductResourcesWhenHttpVerbLetterCaseChanged() throws Exception {
+
+        API existingAPI = createAPIWithResources(true, "GET:/hello");
+        APIDTO updatedAPIDTO = createAPIDTOWithOperations("get:/hello");
+
+        List<APIResource> removedResources = Whitebox.invokeMethod(PublisherCommonUtils.class,
+                "getRemovedProductResources", updatedAPIDTO, existingAPI);
+
+        Assert.assertTrue("A product used resource was reported as removed for an HTTP verb letter case difference: "
+                + removedResources, removedResources.isEmpty());
+    }
+
+    @Test
+    public void testGetRemovedProductResourcesWhenNonProductResourcePathLetterCaseChanged() throws Exception {
+
+        API existingAPI = createAPIWithResources(false, "GET:/hello");
+        APIDTO updatedAPIDTO = createAPIDTOWithOperations("GET:/Hello");
+
+        List<APIResource> removedResources = Whitebox.invokeMethod(PublisherCommonUtils.class,
+                "getRemovedProductResources", updatedAPIDTO, existingAPI);
+
+        Assert.assertTrue("A resource which is not used by any API Product was reported as removed: "
+                + removedResources, removedResources.isEmpty());
+    }
+
+    @Test
+    public void testGetRemovedProductResourcesWhenResourcePathChanged() throws Exception {
+
+        API existingAPI = createAPIWithResources(true, "GET:/v1/hello");
+        APIDTO updatedAPIDTO = createAPIDTOWithOperations("GET:/v3/hello");
+
+        List<APIResource> removedResources = Whitebox.invokeMethod(PublisherCommonUtils.class,
+                "getRemovedProductResources", updatedAPIDTO, existingAPI);
+
+        Assert.assertEquals("A removed product used resource was not detected", 1, removedResources.size());
+        Assert.assertEquals(new APIResource("GET", "/v1/hello"), removedResources.get(0));
+    }
+
+    private API createAPIWithResources(boolean usedByProducts, String... verbAndPaths) {
+        API api = new API(new APIIdentifier(PROVIDER, "PizzaShackAPI", API_PRODUCT_VERSION));
+        api.setUuid(API_ID);
+        Set<URITemplate> uriTemplates = new HashSet<>();
+        for (String verbAndPath : verbAndPaths) {
+            String[] verbAndPathParts = verbAndPath.split(":", 2);
+            URITemplate uriTemplate = new URITemplate();
+            uriTemplate.setHTTPVerb(verbAndPathParts[0]);
+            uriTemplate.setUriTemplate(verbAndPathParts[1]);
+            uriTemplate.setResourceURI(verbAndPathParts[1]);
+            if (usedByProducts) {
+                uriTemplate.addUsedByProduct(
+                        new APIProductIdentifier(PROVIDER, API_PRODUCT_NAME, API_PRODUCT_VERSION));
+            }
+            uriTemplates.add(uriTemplate);
+        }
+        api.setUriTemplates(uriTemplates);
+        return api;
+    }
+
+    private APIDTO createAPIDTOWithOperations(String... verbAndPaths) {
+        APIDTO apiDto = new APIDTO();
+        List<APIOperationsDTO> operations = new ArrayList<>();
+        for (String verbAndPath : verbAndPaths) {
+            String[] verbAndPathParts = verbAndPath.split(":", 2);
+            APIOperationsDTO operation = new APIOperationsDTO();
+            operation.setVerb(verbAndPathParts[0]);
+            operation.setTarget(verbAndPathParts[1]);
+            operations.add(operation);
+        }
+        apiDto.setOperations(operations);
+        return apiDto;
+    }
 }


### PR DESCRIPTION
### Purpose

- Add case sensitivity check when updating API to check whether the any of the resource path has been already bounded to a API product
- Related to : https://github.com/wso2/api-manager/issues/5173