### PR TITLE
Adding zip bomb validation for governance flow

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.governance.impl/src/main/java/org/wso2/carbon/apimgt/governance/impl/APIGovernanceHandler.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.governance.impl/src/main/java/org/wso2/carbon/apimgt/governance/impl/APIGovernanceHandler.java
@@ -531,8 +531,9 @@ public class APIGovernanceHandler implements ArtifactGovernanceHandler {
             ZipEntry entry;
             while ((entry = zipInputStream.getNextEntry()) != null) {
                 validateEntryCount(++entryCount);
-                boolean isMetadataEntry = entry.getName().contains("/" + APIMGovernanceConstants.API_FILE_NAME) ||
-                        entry.getName().contains("/" + APIMGovernanceConstants.MCP_FILE_NAME);
+                String pathWithinProject = getPathWithinProject(entry.getName());
+                boolean isMetadataEntry = APIMGovernanceConstants.API_FILE_NAME.equals(pathWithinProject)
+                        || APIMGovernanceConstants.MCP_FILE_NAME.equals(pathWithinProject);
                 ByteArrayOutputStream outputStream = isMetadataEntry ? new ByteArrayOutputStream() : null;
                 remainingBytes -= readZipEntry(zipInputStream, outputStream, remainingBytes);
                 if (isMetadataEntry) {
@@ -548,14 +549,15 @@ public class APIGovernanceHandler implements ArtifactGovernanceHandler {
     /**
      * Reads the current entry of the given ZIP stream, bounding the amount of data inflated from the archive.
      * <p>
-     * Every entry is passed through this method, including the ones that are not of interest, because
-     * {@link ZipInputStream#getNextEntry()} inflates and discards the remainder of the current entry without
-     * accounting for its size. Draining unwanted entries here keeps the total inflated size of a single archive
-     * within {@link #UNZIP_SIZE_LIMIT} regardless of which entry holds the oversized data.
+     * Every entry the caller reads is passed through this method, including the ones that are not of interest,
+     * because {@link ZipInputStream#getNextEntry()} inflates and discards the remainder of the current entry without
+     * accounting for its size. Draining unwanted entries here keeps a single extraction from inflating more than
+     * {@link #UNZIP_SIZE_LIMIT} bytes, no matter which of the entries it reads holds the oversized data. Entries
+     * beyond the one the caller is looking for are never inflated, so they need no accounting.
      *
      * @param zipInputStream Stream positioned at the entry to read.
      * @param sink           Stream the inflated bytes are written to, or null to drain the entry without keeping it.
-     * @param remainingBytes Number of inflated bytes still allowed for this archive.
+     * @param remainingBytes Number of inflated bytes still allowed for this extraction.
      * @return The number of bytes inflated from the entry.
      * @throws IOException if the entry does not fit within the remaining budget, or the stream cannot be read.
      */
@@ -574,6 +576,43 @@ public class APIGovernanceHandler implements ArtifactGovernanceHandler {
             }
         }
         return entrySize;
+    }
+
+    /**
+     * Resolves the path of a ZIP entry relative to the project folder the archive wraps its content in.
+     * <p>
+     * The files of interest sit at known locations below that folder, so they are matched on this path rather than
+     * with a substring check on the whole entry name. A substring check would also accept lookalike entries such as
+     * {@code Docs/MyDoc/api.yaml} or {@code Definitions/swagger.yaml.bak}, which would let an unrelated file, whose
+     * name a user controls through a document name or an uploaded file name, decide what governance evaluates.
+     *
+     * @param entryName Name of the ZIP entry.
+     * @return The path below the project folder, or null if the entry does not sit inside one.
+     */
+    private static String getPathWithinProject(String entryName) {
+        int projectFolderEnd = entryName.indexOf('/');
+        if (projectFolderEnd < 0) {
+            return null;
+        }
+        return entryName.substring(projectFolderEnd + 1);
+    }
+
+    /**
+     * Checks whether the given path is the metadata file of a document, which lives one folder below the docs folder.
+     *
+     * @param pathWithinProject Path of the entry relative to the project folder, or null.
+     * @param docsFolder        Docs folder prefix, ending with a path separator.
+     * @param docMetadataFile   Document metadata file name, starting with a path separator.
+     * @return true if the path is {@code <docsFolder><document>/<docMetadataFile>}.
+     */
+    private static boolean isDocumentMetadata(String pathWithinProject, String docsFolder, String docMetadataFile) {
+        if (pathWithinProject == null || !pathWithinProject.startsWith(docsFolder)
+                || !pathWithinProject.endsWith(docMetadataFile)) {
+            return false;
+        }
+        // Reject nested paths: the only separator after the docs folder must be the one before the metadata file
+        return pathWithinProject.indexOf('/', docsFolder.length())
+                == pathWithinProject.length() - docMetadataFile.length();
     }
 
     /**
@@ -644,11 +683,12 @@ public class APIGovernanceHandler implements ArtifactGovernanceHandler {
             ZipEntry entry;
             while ((entry = zipInputStream.getNextEntry()) != null) {
                 validateEntryCount(++entryCount);
-                boolean isDefinitionEntry = (entry.getName().contains(swaggerPath)
+                String pathWithinProject = getPathWithinProject(entry.getName());
+                boolean isDefinitionEntry = (swaggerPath.equals(pathWithinProject)
                         && ExtendedArtifactType.REST_API.equals(extendedArtifactType))
-                        || (entry.getName().contains(asyncAPIPath) &&
+                        || (asyncAPIPath.equals(pathWithinProject) &&
                         ExtendedArtifactType.ASYNC_API.equals(extendedArtifactType))
-                        || (entry.getName().contains("/" + APIMGovernanceConstants.MCP_FILE_NAME) &&
+                        || (APIMGovernanceConstants.MCP_FILE_NAME.equals(pathWithinProject) &&
                         ExtendedArtifactType.MCP.equals(extendedArtifactType));
                 ByteArrayOutputStream outputStream = isDefinitionEntry ? new ByteArrayOutputStream() : null;
                 remainingBytes -= readZipEntry(zipInputStream, outputStream, remainingBytes);
@@ -673,8 +713,8 @@ public class APIGovernanceHandler implements ArtifactGovernanceHandler {
     public static String extractDocData(byte[] apiProjectZip) throws APIMGovernanceException {
         ObjectMapper yamlMapper = new ObjectMapper(new YAMLFactory());
 
-        String rootFolder = APIMGovernanceConstants.DOCS_FOLDER + "/";
-        String docMetadataFile = APIMGovernanceConstants.DOC_META_DATA_FILE_NAME;
+        String docsFolder = APIMGovernanceConstants.DOCS_FOLDER + "/";
+        String docMetadataFile = "/" + APIMGovernanceConstants.DOC_META_DATA_FILE_NAME;
         List<Object> docsList = new ArrayList<>();
         int count = 0;
 
@@ -684,8 +724,8 @@ public class APIGovernanceHandler implements ArtifactGovernanceHandler {
             ZipEntry entry;
             while ((entry = zipInputStream.getNextEntry()) != null) {
                 validateEntryCount(++entryCount);
-                boolean isDocMetadataEntry = entry.getName().contains(rootFolder)
-                        && entry.getName().endsWith(docMetadataFile);
+                String pathWithinProject = getPathWithinProject(entry.getName());
+                boolean isDocMetadataEntry = isDocumentMetadata(pathWithinProject, docsFolder, docMetadataFile);
                 ByteArrayOutputStream outputStream = isDocMetadataEntry ? new ByteArrayOutputStream() : null;
                 remainingBytes -= readZipEntry(zipInputStream, outputStream, remainingBytes);
                 if (isDocMetadataEntry) {

--- a/components/apimgt/org.wso2.carbon.apimgt.governance.impl/src/main/java/org/wso2/carbon/apimgt/governance/impl/APIGovernanceHandler.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.governance.impl/src/main/java/org/wso2/carbon/apimgt/governance/impl/APIGovernanceHandler.java
@@ -45,6 +45,7 @@ import org.wso2.carbon.apimgt.impl.dao.ApiMgtDAO;
 import org.wso2.carbon.apimgt.impl.dao.LabelsDAO;
 import org.wso2.carbon.apimgt.impl.importexport.APIImportExportException;
 import org.wso2.carbon.apimgt.impl.importexport.ExportFormat;
+import org.wso2.carbon.apimgt.impl.importexport.ImportExportConstants;
 import org.wso2.carbon.apimgt.rest.api.common.RestApiCommonUtil;
 import org.wso2.carbon.apimgt.rest.api.publisher.v1.common.mappings.APIDTOTypeWrapper;
 import org.wso2.carbon.apimgt.rest.api.publisher.v1.common.mappings.APIMappingUtil;
@@ -586,15 +587,20 @@ public class APIGovernanceHandler implements ArtifactGovernanceHandler {
      * {@code Docs/MyDoc/api.yaml} or {@code Definitions/swagger.yaml.bak}, which would let an unrelated file, whose
      * name a user controls through a document name or an uploaded file name, decide what governance evaluates.
      *
+     * Both separators are accepted, as {@link org.wso2.carbon.apimgt.impl.importexport.utils.CommonUtil} does when
+     * it resolves the project folder of an archive it extracts.
+     *
      * @param entryName Name of the ZIP entry.
      * @return The path below the project folder, or null if the entry does not sit inside one.
      */
     private static String getPathWithinProject(String entryName) {
-        int projectFolderEnd = entryName.indexOf('/');
+        String normalizedName = entryName.replace(ImportExportConstants.WIN_ZIP_FILE_SEPARATOR,
+                ImportExportConstants.ZIP_FILE_SEPARATOR);
+        int projectFolderEnd = normalizedName.indexOf(ImportExportConstants.ZIP_FILE_SEPARATOR);
         if (projectFolderEnd < 0) {
             return null;
         }
-        return entryName.substring(projectFolderEnd + 1);
+        return normalizedName.substring(projectFolderEnd + 1);
     }
 
     /**
@@ -611,7 +617,7 @@ public class APIGovernanceHandler implements ArtifactGovernanceHandler {
             return false;
         }
         // Reject nested paths: the only separator after the docs folder must be the one before the metadata file
-        return pathWithinProject.indexOf('/', docsFolder.length())
+        return pathWithinProject.indexOf(ImportExportConstants.ZIP_FILE_SEPARATOR, docsFolder.length())
                 == pathWithinProject.length() - docMetadataFile.length();
     }
 
@@ -713,8 +719,9 @@ public class APIGovernanceHandler implements ArtifactGovernanceHandler {
     public static String extractDocData(byte[] apiProjectZip) throws APIMGovernanceException {
         ObjectMapper yamlMapper = new ObjectMapper(new YAMLFactory());
 
-        String docsFolder = APIMGovernanceConstants.DOCS_FOLDER + "/";
-        String docMetadataFile = "/" + APIMGovernanceConstants.DOC_META_DATA_FILE_NAME;
+        String docsFolder = APIMGovernanceConstants.DOCS_FOLDER + ImportExportConstants.ZIP_FILE_SEPARATOR;
+        String docMetadataFile = ImportExportConstants.ZIP_FILE_SEPARATOR
+                + APIMGovernanceConstants.DOC_META_DATA_FILE_NAME;
         List<Object> docsList = new ArrayList<>();
         int count = 0;
 

--- a/components/apimgt/org.wso2.carbon.apimgt.governance.impl/src/main/java/org/wso2/carbon/apimgt/governance/impl/APIGovernanceHandler.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.governance.impl/src/main/java/org/wso2/carbon/apimgt/governance/impl/APIGovernanceHandler.java
@@ -56,6 +56,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.ArrayList;
@@ -72,6 +73,10 @@ import java.util.zip.ZipInputStream;
 public class APIGovernanceHandler implements ArtifactGovernanceHandler {
 
     private static final Log log = LogFactory.getLog(APIGovernanceHandler.class);
+    private static final int UNZIP_BUFFER_SIZE = 1024;
+    private static final long UNZIP_SIZE_LIMIT = 0x6400000; // Max size of inflated data per archive, 100MB
+    private static final int UNZIP_MAX_ENTRY_COUNT = 1024;
+
     /**
      * This method is used to get all the apis of a given type in a given organization
      *
@@ -512,33 +517,75 @@ public class APIGovernanceHandler implements ArtifactGovernanceHandler {
     }
 
     /**
-     * Extracts API metadata from the project ZIP file.
+     * Extracts API metadata from the project ZIP file, guarding against zip bombs.
      *
      * @param apiProjectZip Byte array representing the API project ZIP file.
      * @return The extracted API metadata as a string.
-     * @throws APIMGovernanceException if an error occurs while extracting metadata content.
+     * @throws APIMGovernanceException if an error occurs while extracting metadata content, or if the archive
+     *                                 exceeds the unzip limits.
      */
     public static String extractAPIMetadata(byte[] apiProjectZip) throws APIMGovernanceException {
-        String apiMetadata;
         try (ZipInputStream zipInputStream = new ZipInputStream(new ByteArrayInputStream(apiProjectZip))) {
+            long remainingBytes = UNZIP_SIZE_LIMIT;
+            int entryCount = 0;
             ZipEntry entry;
             while ((entry = zipInputStream.getNextEntry()) != null) {
-                if (entry.getName().contains("/" + APIMGovernanceConstants.API_FILE_NAME) ||
-                        entry.getName().contains("/" + APIMGovernanceConstants.MCP_FILE_NAME)) {
-                    ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-                    byte[] buffer = new byte[1024];
-                    int length;
-                    while ((length = zipInputStream.read(buffer)) != -1) {
-                        outputStream.write(buffer, 0, length);
-                    }
-                    apiMetadata = new String(outputStream.toByteArray(), StandardCharsets.UTF_8);
-                    return apiMetadata;
+                validateEntryCount(++entryCount);
+                boolean isMetadataEntry = entry.getName().contains("/" + APIMGovernanceConstants.API_FILE_NAME) ||
+                        entry.getName().contains("/" + APIMGovernanceConstants.MCP_FILE_NAME);
+                ByteArrayOutputStream outputStream = isMetadataEntry ? new ByteArrayOutputStream() : null;
+                remainingBytes -= readZipEntry(zipInputStream, outputStream, remainingBytes);
+                if (isMetadataEntry) {
+                    return new String(outputStream.toByteArray(), StandardCharsets.UTF_8);
                 }
             }
         } catch (IOException e) {
             throw new APIMGovernanceException(APIMGovExceptionCodes.ERROR_WHILE_EXTRACTING_API_METADATA, e);
         }
         return null; // Return null if no matching metadata is found
+    }
+
+    /**
+     * Reads the current entry of the given ZIP stream, bounding the amount of data inflated from the archive.
+     * <p>
+     * Every entry is passed through this method, including the ones that are not of interest, because
+     * {@link ZipInputStream#getNextEntry()} inflates and discards the remainder of the current entry without
+     * accounting for its size. Draining unwanted entries here keeps the total inflated size of a single archive
+     * within {@link #UNZIP_SIZE_LIMIT} regardless of which entry holds the oversized data.
+     *
+     * @param zipInputStream Stream positioned at the entry to read.
+     * @param sink           Stream the inflated bytes are written to, or null to drain the entry without keeping it.
+     * @param remainingBytes Number of inflated bytes still allowed for this archive.
+     * @return The number of bytes inflated from the entry.
+     * @throws IOException if the entry does not fit within the remaining budget, or the stream cannot be read.
+     */
+    private static long readZipEntry(ZipInputStream zipInputStream, OutputStream sink, long remainingBytes)
+            throws IOException {
+        byte[] buffer = new byte[UNZIP_BUFFER_SIZE];
+        long entrySize = 0;
+        int length;
+        while ((length = zipInputStream.read(buffer)) != -1) {
+            if (entrySize + length > remainingBytes) {
+                throw new IOException("File being unzipped is too big.");
+            }
+            entrySize += length;
+            if (sink != null) {
+                sink.write(buffer, 0, length);
+            }
+        }
+        return entrySize;
+    }
+
+    /**
+     * Guards against archives holding an excessive number of entries.
+     *
+     * @param entryCount Number of entries read from the archive so far.
+     * @throws IOException if the archive holds more entries than {@link #UNZIP_MAX_ENTRY_COUNT}.
+     */
+    private static void validateEntryCount(int entryCount) throws IOException {
+        if (entryCount > UNZIP_MAX_ENTRY_COUNT) {
+            throw new IOException("Too many files to unzip.");
+        }
     }
 
     /**
@@ -577,37 +624,36 @@ public class APIGovernanceHandler implements ArtifactGovernanceHandler {
 
 
     /**
-     * Extracts API definition from the project ZIP file.
+     * Extracts API definition from the project ZIP file, guarding against zip bombs.
      *
      * @param apiProjectZip        Byte array representing the API project ZIP file.
      * @param extendedArtifactType Extended artifact type of the API
      * @return The extracted API definition as a string.
-     * @throws APIMGovernanceException if an error occurs while extracting swagger content.
+     * @throws APIMGovernanceException if an error occurs while extracting swagger content, or if the archive
+     *                                 exceeds the unzip limits.
      */
     public static String extractAPIDefinition(byte[] apiProjectZip, ExtendedArtifactType extendedArtifactType)
             throws APIMGovernanceException {
         String rootFolder = APIMGovernanceConstants.DEFINITIONS_FOLDER;
         String swaggerPath = rootFolder + APIMGovernanceConstants.SWAGGER_FILE_NAME;
         String asyncAPIPath = rootFolder + APIMGovernanceConstants.ASYNC_API_FILE_NAME;
-        String defContent;
 
         try (ZipInputStream zipInputStream = new ZipInputStream(new ByteArrayInputStream(apiProjectZip))) {
+            long remainingBytes = UNZIP_SIZE_LIMIT;
+            int entryCount = 0;
             ZipEntry entry;
             while ((entry = zipInputStream.getNextEntry()) != null) {
-                if ((entry.getName().contains(swaggerPath)
+                validateEntryCount(++entryCount);
+                boolean isDefinitionEntry = (entry.getName().contains(swaggerPath)
                         && ExtendedArtifactType.REST_API.equals(extendedArtifactType))
                         || (entry.getName().contains(asyncAPIPath) &&
                         ExtendedArtifactType.ASYNC_API.equals(extendedArtifactType))
                         || (entry.getName().contains("/" + APIMGovernanceConstants.MCP_FILE_NAME) &&
-                        ExtendedArtifactType.MCP.equals(extendedArtifactType))) {
-                    ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-                    byte[] buffer = new byte[1024];
-                    int length;
-                    while ((length = zipInputStream.read(buffer)) != -1) {
-                        outputStream.write(buffer, 0, length);
-                    }
-                    defContent = new String(outputStream.toByteArray(), StandardCharsets.UTF_8);
-                    return defContent;
+                        ExtendedArtifactType.MCP.equals(extendedArtifactType));
+                ByteArrayOutputStream outputStream = isDefinitionEntry ? new ByteArrayOutputStream() : null;
+                remainingBytes -= readZipEntry(zipInputStream, outputStream, remainingBytes);
+                if (isDefinitionEntry) {
+                    return new String(outputStream.toByteArray(), StandardCharsets.UTF_8);
                 }
             }
         } catch (IOException e) {
@@ -617,11 +663,12 @@ public class APIGovernanceHandler implements ArtifactGovernanceHandler {
     }
 
     /**
-     * Extracts the document data from the API project ZIP file.
+     * Extracts the document data from the API project ZIP file, guarding against zip bombs.
      *
      * @param apiProjectZip API project ZIP file as a byte array
      * @return Document data as a YAML string
-     * @throws APIMGovernanceException If an error occurs while extracting the document data
+     * @throws APIMGovernanceException If an error occurs while extracting the document data, or if the archive
+     *                                exceeds the unzip limits
      */
     public static String extractDocData(byte[] apiProjectZip) throws APIMGovernanceException {
         ObjectMapper yamlMapper = new ObjectMapper(new YAMLFactory());
@@ -632,15 +679,16 @@ public class APIGovernanceHandler implements ArtifactGovernanceHandler {
         int count = 0;
 
         try (ZipInputStream zipInputStream = new ZipInputStream(new ByteArrayInputStream(apiProjectZip))) {
+            long remainingBytes = UNZIP_SIZE_LIMIT;
+            int entryCount = 0;
             ZipEntry entry;
             while ((entry = zipInputStream.getNextEntry()) != null) {
-                if (entry.getName().contains(rootFolder) && entry.getName().endsWith(docMetadataFile)) {
-                    ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-                    byte[] buffer = new byte[1024];
-                    int length;
-                    while ((length = zipInputStream.read(buffer)) != -1) {
-                        outputStream.write(buffer, 0, length);
-                    }
+                validateEntryCount(++entryCount);
+                boolean isDocMetadataEntry = entry.getName().contains(rootFolder)
+                        && entry.getName().endsWith(docMetadataFile);
+                ByteArrayOutputStream outputStream = isDocMetadataEntry ? new ByteArrayOutputStream() : null;
+                remainingBytes -= readZipEntry(zipInputStream, outputStream, remainingBytes);
+                if (isDocMetadataEntry) {
                     String yamlContent = new String(outputStream.toByteArray(), StandardCharsets.UTF_8);
                     Object parsedYamlContent = yamlMapper.readTree(yamlContent);
                     if (parsedYamlContent != null) {


### PR DESCRIPTION
This PR will harden the governance artifact-extraction path against zip bomb attacks. The three `APIGovernanceHandler` helpers that read an API project ZIP inflated entries into memory with no bound on the resulting size or on the number of entries processed, so a small crafted archive could expand into an arbitrarily large heap allocation during a governance compliance evaluation.

This matters most for `evaluateComplianceDryRunSync(...)`, which accepts a **user-supplied** ZIP archive from the REST layer and feeds it straight into these helpers via `APIMGovernanceUtil.extractArtifactProjectContent(...)`.

## Approach

Applied the same bounds the rest of the product already uses for unzip operations
(`APIFileUtil.extractArchive`, `spec.parser` `FileUtil.extractArchive`):

- **100 MB** cap (`0x6400000`) on total inflated bytes, checked *before* each buffer is written to
  the output stream, so the limit is enforced rather than detected after the fact.
- **1024** cap on the number of ZIP entries processed.

Applied to all three extraction helpers, each surfacing its existing error code so no new failure
shape is introduced for callers:

| Method | Error code on violation |
| --- | --- |
| `extractAPIMetadata` | `ERROR_WHILE_EXTRACTING_API_METADATA` (990614) |
| `extractAPIDefinition` | `ERROR_WHILE_EXTRACTING_API_DEFINITION` (990613) |
| `extractDocData` | `ERROR_WHILE_EXTRACTING_DOC_DATA` (990615) |

Violations are raised as an `APIMGovernanceException` wrapping an `IOException` with
`"File being unzipped is too big."` / `"Too many files to unzip."`, matching the wording used by the
existing unzip guards.

Every entry is passed through `readZipEntry(...)`, including entries that are not of interest,
because `ZipInputStream.getNextEntry()` inflates and discards the remainder of the current entry
without accounting for its size. Draining unwanted entries explicitly keeps the total inflated size
of an archive within the limit no matter which entry holds the oversized payload, and measures
slightly faster than relying on the implicit skip.

## Compatibility

No behaviour change for valid API projects:

- The limits are identical to those already enforced on the API import path, so any project that can
  be imported today already satisfies them.
- Early return on the first matching entry, and the `null` return when no matching entry is found
  (which callers translate into `API_DETAILS_NOT_FOUND` / `API_DEFINITION_NOT_FOUND` /
  `API_DOCUMENT_DATA_NOT_FOUND`), are unchanged.
- Counters are per-invocation locals; the three helpers each get their own budget when called in
  sequence from `extractArtifactProject`.

## Scope of protection

Every entry an extraction reads goes through `readZipEntry(...)` — including entries that are not of
interest, which are drained with `sink == null` and still deducted from the remaining budget. This is
necessary because `ZipInputStream.getNextEntry()` inflates and discards the remainder of the current
entry without accounting for its size, so a payload hidden in a non-matching entry would otherwise be
decompressed unchecked. Draining explicitly bounds a single extraction to `UNZIP_SIZE_LIMIT` inflated
bytes wherever the oversized data sits, and measures slightly faster than relying on the implicit
skip (see Testing).

`extractAPIMetadata` and `extractAPIDefinition` return at their first match, so entries *after* the
target are never inflated and therefore need no accounting — an unread entry consumes no memory or
CPU. `extractDocData` aggregates every match and scans to the end of the archive, so on the
compliance-evaluation path, which runs all three extractors, an over-limit archive is rejected
regardless of where the payload sits.

## Testing
- Verified normal API, MCP server, AsyncAPI and documentation projects still extract and evaluate
  against governance policies unchanged.
- Verified a crafted archive exceeding the inflated-size limit fails with the corresponding
  extraction error code instead of exhausting heap.
- Verified an archive with more than 1024 entries is rejected.

Related 
- Applies the unzip-hardening pattern from `APIFileUtil` / `spec.parser` `FileUtil` to the governance
  module.