### PR TITLE
Adopt orphaned Key Manager scopes instead of failing with 900984

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
@@ -1251,13 +1251,24 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
                 log.debug("Checking if scope: " + scope + " exists in Key Manager for tenant: " + tenantDomain);
             }
             if (isScopeKeyExistInKeyManager(scope, tenantDomain)) {
-                if (!isCreateNewVersion) {
+                if (isCreateNewVersion) {
+                    if (log.isDebugEnabled()) {
+                        log.debug("Scope: " + scope + " is already registered in Key Manager; skipping validation" +
+                                " because we are creating a new API version.");
+                    }
+                } else if (isScopeKeyExist(scope, tenantId)) {
+                    // The scope is owned by another API or by a shared scope in API Manager, so attaching it here
+                    // would be a genuine conflict.
                     log.error("Scope: " + scope + " is already registered in Key Manager.");
                     throw new APIManagementException(ExceptionCodes.from(ExceptionCodes.SCOPE_ALREADY_REGISTERED,
                             scope));
-                } else if (log.isDebugEnabled()) {
-                   log.debug("Scope: " + scope + " is already registered in Key Manager; skipping validation" +
-                            " because we are creating a new API version.");
+                } else {
+                    // The scope exists in the Key Manager but API Manager holds no record of it, i.e. it is
+                    // orphaned - typically left behind by a failed scope deletion. Adopt it instead of failing:
+                    // registering the scope is idempotent, and the Key Manager reconciles its metadata afterwards.
+                    log.warn("Scope: " + scope + " exists in the Key Manager but is not registered in API Manager. " +
+                            "Treating it as an orphaned scope and adopting it for API: " + api.getId().getApiName() +
+                            ". Its Key Manager metadata will be reconciled with this API's scope definition.");
                 }
             }
         }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ScopesApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ScopesApiServiceImpl.java
@@ -119,10 +119,17 @@ public class ScopesApiServiceImpl implements ScopesApiService {
                 log.warn("Attempt to create scope with restricted prefix: " + scopeName);
                 throw new APIManagementException(ExceptionCodes.INVALID_SCOPE_NAME);
             }
-            if (apiProvider.isScopeKeyExist(scopeName, APIUtil.getTenantIdFromTenantDomain(tenantDomain)) ||
-                    apiProvider.isScopeKeyExistInKeyManager(scopeName, tenantDomain)) {
+            if (apiProvider.isScopeKeyExist(scopeName, APIUtil.getTenantIdFromTenantDomain(tenantDomain))) {
                 throw new APIManagementException(ExceptionCodes.from(ExceptionCodes.SCOPE_ALREADY_REGISTERED,
                         scopeName));
+            }
+            if (apiProvider.isScopeKeyExistInKeyManager(scopeName, tenantDomain)) {
+                // The scope exists in the Key Manager but API Manager holds no record of it, i.e. it is orphaned -
+                // typically left behind by a failed scope deletion. Adopt it instead of failing: registering the
+                // scope is idempotent, and the Key Manager reconciles its metadata afterwards.
+                log.warn("Scope: " + scopeName + " exists in the Key Manager but is not registered in API Manager. " +
+                        "Treating it as an orphaned scope and adopting it as a shared scope. Its Key Manager " +
+                        "metadata will be reconciled with this shared scope definition.");
             }
             Scope scopeToAdd = SharedScopeMappingUtil.fromDTOToScope(body);
             String sharedScopeId = apiProvider.addSharedScope(scopeToAdd, tenantDomain);


### PR DESCRIPTION
## Purpose

A scope that exists in the Key Manager but has no record in API Manager — an **orphaned scope** —
permanently blocks any attempt to use that scope name again. Both entry points reject it with
`900984 Scope already exists`, and no API Manager operation can clear it. The only remedy today is
deleting the scope directly from the Key Manager.

Orphans arise whenever a scope deletion fails on the Key Manager side while API Manager has already
dropped its own record. The case that prompted this: WSO2 IS 7 returns 404 for
`DELETE /api-resources/{apiResourceId}/scopes/{scopeName}` when the scope name contains `/`
(wso2/product-is#26457). API Manager logs the failure, keeps going, and removes its record — leaving
the scope stranded in IS. The next import of the same API then fails pre-flight with `900984`
(wso2/api-manager#5187). The connector-side fix for that IS issue is
wso2-extensions/apim-km-wso2is#190, but it only prevents *new* orphans; it cannot clear existing
ones, because the pre-flight check queries the Key Manager and the scope really is there.

## Change

Distinguish "the scope is registered in API Manager" from "the scope exists in the Key Manager".
API Manager already has both checks; they were simply OR'd together, collapsing the distinction.

| | `isScopeKeyExist` (API Manager DB) | `isScopeKeyExistInKeyManager` | Now |
|---|---|---|---|
| Genuine conflict | true | true | rejected `900984` (unchanged) |
| **Orphan** | **false** | **true** | **adopted, logged at WARN** |
| New scope | false | false | created (unchanged) |

- `APIProviderImpl` — the local-scope pre-flight now also consults `isScopeKeyExist(scope, tenantId)`
  and only rejects when API Manager itself knows the scope.
- `ScopesApiServiceImpl.addSharedScope` — the OR'd condition is split so only the API Manager DB hit
  rejects.

Adoption is safe because registering a scope is already idempotent: the Key Manager skips scopes
that exist, then reconciles their metadata to the API Manager definition. Nothing is duplicated.

## This behaviour already exists in the product

`APIProviderImpl` **already skips this exact check** when `isCreateNewVersion` is true. Creating a
new version of an API whose scope is orphaned therefore adopts it today. Verified end to end against
APIM 4.7.0 + IS 7.1.0:

```
orphan created (in IS, absent from API Manager)
  new API with that scope name           -> 409 / 900984      <- the wall
  new VERSION with that scope name       -> 201, adopted
    scope in API Manager v2 = True, in IS = True, IS copies = 1 (not duplicated)
```

So the change makes an existing, accepted behaviour consistent across entry points rather than
introducing a new one.

## The check being narrowed is not the primary guard against scope collisions

Worth stating explicitly, because it bounds the risk. The genuine "another API already owns this
local scope" case is caught **earlier and independently**, from the API Manager database:

- `PublisherCommonUtils` / `CommonUtils` → `900988 SCOPE_ALREADY_ASSIGNED`
- `APIProviderImpl#isScopeKeyAssignedLocally` → `903204 SCOPE_ALREADY_ASSIGNED_FOR_DIFFERENT_API`

Measured on unpatched 9.33.171: a second API claiming another API's local scope is rejected with
**400 / 900988**, never reaching the Key Manager pre-flight. Duplicate shared scopes are rejected by
`isScopeKeyExist` alone (**409 / 900984**). The Key Manager pre-flight's only *unique* contribution
is rejecting scopes present in the Key Manager but absent from API Manager — orphans, and scopes
created directly in the Key Manager by someone else.

This change also only ever *narrows* a rejection, so it can allow more flows to succeed but cannot
make a previously-succeeding flow fail.

---

# Decision required from the product team

The one real behavioural consequence: **a scope created directly in the Key Manager, outside API
Manager, will now be silently adopted** if an API later claims that name. Once adopted, API Manager
manages it — overwriting its `displayName`/`description` with the API's values, and deleting it when
the API or scope is deleted. Today `900984` prevents that.

Three options:

1. **Adopt with a WARN log — implemented here.** Self-healing with no operator action. The trade is
   the external-scope case above. Mitigated by the fact that adoption is already the behaviour on
   the `isCreateNewVersion` path, and that `900988`/`903204` still guard real collisions.
2. **Gate it behind configuration** (e.g. `reconcile_orphaned_scopes`, default off). Preserves
   today's behaviour exactly unless an operator opts in. Costs a new `APIManagerConfiguration`
   entry plus documentation, and leaves affected customers needing a config change before they can
   recover.
3. **Reject and provide explicit tooling instead** — keep `900984` and add an admin API or migration
   step that lists Key Manager scopes unknown to API Manager and deletes them. Most conservative,
   most surface area, and still requires deliberate operator action.

My recommendation is **1** for the local-scope path, where `scopesToAdd` is already filtered to the
API's own scopes and the collision risk is lowest, and I would accept **2** for `addSharedScope`
if the team prefers caution on the tenant-wide namespace. Happy to reshape this either way — the
diff for option 2 is one condition per call site.

Two secondary questions:

- **Log level.** WARN per adopted scope, or INFO with a single WARN summary per API? A large import
  could emit many lines.
- **Multi Key Manager.** `isScopeKeyExistInKeyManager` returns true if *any* Key Manager has the
  scope. With several Key Managers configured, adoption registers the scope in the ones missing it.
  That looks like the desired convergence, but it is worth an explicit opinion.

---

## Testing

Verified against **APIM 4.7.0 + IS 7 as a third-party Key Manager**. To avoid asserting my own
expectations, the suite records the **raw outcome** of each scenario and the before/after runs are
diffed; a regression is any preserved row whose outcome changes. Both runs used jars built from
tag `v9.33.171` (the pack's exact version) so the only variable is this patch, and AspectJ weaving
was confirmed intact in the rebuilt bundle (16 `aroundBody` methods, same as the shipped jar).

```
ID        SCENARIO                                    BEFORE                 AFTER
KEEP-1    first API claims a local scope              http=201 code=None     http=201 code=None      same
KEEP-2    2nd API claims the SAME local scope         http=400 code=900988   http=400 code=900988    same
KEEP-3    shared scope reuses an existing local key   http=409 code=900984   http=409 code=900984    same
KEEP-4    first shared scope                          http=201 code=None     http=201 code=None      same
KEEP-5    duplicate shared scope                      http=409 code=900984   http=409 code=900984    same
KEEP-6    local scope reuses an existing SHARED key    http=201 code=None     http=201 code=None      same
KEEP-7    restricted scope prefix                     http=400 code=901004   http=400 code=901004    same
KEEP-8    create API with a fresh local scope         http=201 code=None     http=201 code=None      same
KEEP-9    update API, no scope change                 http=200 errors=0      http=200 errors=0       same
KEEP-10   add a NEW local scope to an existing API    http=200 code=None     http=200 code=None      same
KEEP-11   new API VERSION reusing its own scopes      http=201 code=None     http=201 code=None      same
KEEP-12   remove a local scope (plain name)           http=200 code=None     http=200 code=None      same
ADOPT-1   new API claims the ORPHANED local scope     http=409 code=900984   http=201 code=None      CHANGED
ADOPT-3   shared scope claims the ORPHANED scope      http=409 code=900984   http=201 code=None      CHANGED

PRESERVED rows changed (regressions): NONE
TARGET rows changed (intended):       ADOPT-1, ADOPT-3
```

Note `KEEP-2` is rejected with `900988`, not `900984` — confirming the genuine collision is caught
by the API Manager database check before the Key Manager pre-flight is reached. `KEEP-6` returning
`201` is pre-existing behaviour (`isSharedScopeNameExists` treats the key as the shared scope and
skips registration); it is unchanged here.

Adoption warnings emitted on the two changed rows:

```
WARN - APIProviderImpl Scope: adoptA/local_orphan exists in the Key Manager but is not registered
  in API Manager. Treating it as an orphaned scope and adopting it for API: AD1A. Its Key Manager
  metadata will be reconciled with this API's scope definition.
WARN - ScopesApiServiceImpl Scope: adoptA/shared_orphan exists in the Key Manager but is not
  registered in API Manager. Treating it as an orphaned scope and adopting it as a shared scope.
  Its Key Manager metadata will be reconciled with this shared scope definition.
```

Also re-ran the full IS 7 scope matrix (local/global × `/`-containing/plain names × connector flag
off/on, in `carbon.super` and in a tenant with its own IS) to confirm the connector-side behaviour
is unaffected by this change.

## Related

- Connector-side fix for the IS 404: wso2-extensions/apim-km-wso2is#190
- Public issue: wso2/api-manager#5187
- IS side: wso2/product-is#26457

🤖 Generated with [Claude Code](https://claude.com/claude-code)
