### PR TITLE
Test the endpoint existence check and the reference API lookup key

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/test/java/TemplateBuilderUtilTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/test/java/TemplateBuilderUtilTest.java
@@ -23,18 +23,24 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.wso2.carbon.apimgt.api.APIManagementException;
+import org.wso2.carbon.apimgt.api.dto.EndpointDTO;
 import org.wso2.carbon.apimgt.api.gateway.GatewayAPIDTO;
 import org.wso2.carbon.apimgt.api.gateway.GatewayContentDTO;
 import org.wso2.carbon.apimgt.api.model.API;
 import org.wso2.carbon.apimgt.api.model.APIIdentifier;
+import org.wso2.carbon.apimgt.api.model.SimplifiedEndpoint;
 import org.wso2.carbon.apimgt.api.model.URITemplate;
 import org.wso2.carbon.apimgt.api.model.WebSocketTopicMappingConfiguration;
 import org.wso2.carbon.apimgt.impl.APIConstants;
 import org.wso2.carbon.apimgt.impl.template.APITemplateBuilder;
 import org.wso2.carbon.apimgt.rest.api.publisher.v1.common.TemplateBuilderUtil;
 
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -325,5 +331,144 @@ public class TemplateBuilderUtilTest {
             Assert.assertEquals(httpSandboxUrl.replace(APIConstants.HTTP_PROTOCOL_URL_PREFIX,
                     APIConstants.WS_PROTOCOL_URL_PREFIX), wsSandboxUrl);
         }
+    }
+
+    private static final String NO_ENDPOINTS_IN_CONFIG = "{\"endpoint_type\":\"http\"}";
+    private static final String PRODUCTION_ENDPOINT_IN_CONFIG =
+            "{\"endpoint_type\":\"http\",\"production_endpoints\":{\"url\":\"https://production.com\"}}";
+    private static final String SANDBOX_ENDPOINT_IN_CONFIG =
+            "{\"endpoint_type\":\"http\",\"sandbox_endpoints\":{\"url\":\"https://sandbox.com\"}}";
+
+    /**
+     * Builds an API of the given subtype holding the given endpoint configuration.
+     *
+     * @param subtype        subtype of the API, {@link APIConstants#API_SUBTYPE_AI_API} or anything else
+     * @param endpointConfig the legacy endpoint configuration JSON the API carries
+     * @return the API
+     */
+    private static API apiOfSubtype(String subtype, String endpointConfig) {
+
+        API api = new API(new APIIdentifier("admin", "EndpointCheckAPI", "1.0.0"));
+        api.setSubtype(subtype);
+        api.setEndpointConfig(endpointConfig);
+        return api;
+    }
+
+    /**
+     * Builds the endpoint collection of a single named endpoint of the given deployment stage. These are the endpoints
+     * an AI API holds outside its endpoint configuration.
+     *
+     * @param deploymentStage {@link APIConstants.APIEndpoint#PRODUCTION} or {@link APIConstants.APIEndpoint#SANDBOX}
+     * @return a collection holding one endpoint of that stage
+     */
+    private static List<SimplifiedEndpoint> oneNamedEndpoint(String deploymentStage) {
+
+        EndpointDTO endpointDTO = new EndpointDTO();
+        endpointDTO.setId("f2c6d3a1-7b4e-4d90-9a11-6c8e5b2d7f43");
+        endpointDTO.setName("Named " + deploymentStage + " Endpoint");
+        endpointDTO.setDeploymentStage(deploymentStage);
+        List<SimplifiedEndpoint> endpoints = new ArrayList<>();
+        endpoints.add(new SimplifiedEndpoint(endpointDTO));
+        return endpoints;
+    }
+
+    /**
+     * Invokes the endpoint existence check that guards a deployment to a non-hybrid gateway.
+     *
+     * @param api             the API being deployed
+     * @param deploymentStage the deployment stage of the gateway being deployed to
+     * @param endpoints       the named endpoints of that stage
+     * @return true when an endpoint exists for that stage
+     */
+    private static boolean hasEndpoint(API api, String deploymentStage, List<SimplifiedEndpoint> endpoints)
+            throws Exception {
+
+        Method hasEndpoint = TemplateBuilderUtil.class.getDeclaredMethod("hasEndpoint", API.class, String.class,
+                List.class);
+        hasEndpoint.setAccessible(true);
+        return (boolean) hasEndpoint.invoke(null, api, deploymentStage, endpoints);
+    }
+
+    /**
+     * An AI API holds its endpoints as named endpoints outside the endpoint configuration. Its first endpoint having
+     * been removed empties the endpoint configuration while a named endpoint of that stage remains, and the deployment
+     * has to be allowed on the strength of that named endpoint.
+     */
+    @Test
+    public void testAiApiHasProductionEndpointFromItsNamedEndpoints() throws Exception {
+
+        Assert.assertTrue("An AI API holding a named production endpoint has a production endpoint, even though its "
+                        + "endpoint configuration carries none",
+                hasEndpoint(apiOfSubtype(APIConstants.API_SUBTYPE_AI_API, NO_ENDPOINTS_IN_CONFIG),
+                        APIConstants.APIEndpoint.PRODUCTION, oneNamedEndpoint(APIConstants.APIEndpoint.PRODUCTION)));
+    }
+
+    @Test
+    public void testAiApiHasSandboxEndpointFromItsNamedEndpoints() throws Exception {
+
+        Assert.assertTrue("An AI API holding a named sandbox endpoint has a sandbox endpoint, even though its "
+                        + "endpoint configuration carries none",
+                hasEndpoint(apiOfSubtype(APIConstants.API_SUBTYPE_AI_API, NO_ENDPOINTS_IN_CONFIG),
+                        APIConstants.APIEndpoint.SANDBOX, oneNamedEndpoint(APIConstants.APIEndpoint.SANDBOX)));
+    }
+
+    /**
+     * An AI API with no named endpoint of the stage being deployed to has no endpoint for it, and the deployment is
+     * refused. The check has to keep refusing these, otherwise an AI API reaches a gateway with no backend behind it.
+     */
+    @Test
+    public void testAiApiWithoutNamedProductionEndpointsHasNoProductionEndpoint() throws Exception {
+
+        Assert.assertFalse("An AI API holding no named production endpoint has no production endpoint",
+                hasEndpoint(apiOfSubtype(APIConstants.API_SUBTYPE_AI_API, NO_ENDPOINTS_IN_CONFIG),
+                        APIConstants.APIEndpoint.PRODUCTION, Collections.emptyList()));
+    }
+
+    @Test
+    public void testAiApiWithoutNamedSandboxEndpointsHasNoSandboxEndpoint() throws Exception {
+
+        Assert.assertFalse("An AI API holding no named sandbox endpoint has no sandbox endpoint",
+                hasEndpoint(apiOfSubtype(APIConstants.API_SUBTYPE_AI_API, NO_ENDPOINTS_IN_CONFIG),
+                        APIConstants.APIEndpoint.SANDBOX, Collections.emptyList()));
+    }
+
+    /**
+     * Every API that is not an AI API keeps its endpoints in its endpoint configuration, and is checked against it.
+     */
+    @Test
+    public void testNonAiApiHasProductionEndpointFromItsEndpointConfiguration() throws Exception {
+
+        Assert.assertTrue("An API carrying a production endpoint in its endpoint configuration has one",
+                hasEndpoint(apiOfSubtype(null, PRODUCTION_ENDPOINT_IN_CONFIG),
+                        APIConstants.APIEndpoint.PRODUCTION, Collections.emptyList()));
+    }
+
+    @Test
+    public void testNonAiApiHasSandboxEndpointFromItsEndpointConfiguration() throws Exception {
+
+        Assert.assertTrue("An API carrying a sandbox endpoint in its endpoint configuration has one",
+                hasEndpoint(apiOfSubtype(null, SANDBOX_ENDPOINT_IN_CONFIG),
+                        APIConstants.APIEndpoint.SANDBOX, Collections.emptyList()));
+    }
+
+    @Test
+    public void testNonAiApiWithoutEndpointsInItsEndpointConfigurationHasNoProductionEndpoint() throws Exception {
+
+        Assert.assertFalse("An API carrying no production endpoint in its endpoint configuration has none",
+                hasEndpoint(apiOfSubtype(null, NO_ENDPOINTS_IN_CONFIG),
+                        APIConstants.APIEndpoint.PRODUCTION, Collections.emptyList()));
+    }
+
+    /**
+     * The named endpoints are read for an AI API only. Reading them for every API would let an API whose endpoint
+     * configuration carries no endpoint of the stage being deployed to reach that gateway with no backend behind it,
+     * which is what the check exists to prevent.
+     */
+    @Test
+    public void testNonAiApiIsNotGivenAnEndpointByTheNamedEndpoints() throws Exception {
+
+        Assert.assertFalse("An API that is not an AI API is checked against its endpoint configuration alone",
+                hasEndpoint(apiOfSubtype(null, NO_ENDPOINTS_IN_CONFIG),
+                        APIConstants.APIEndpoint.PRODUCTION, oneNamedEndpoint(APIConstants.APIEndpoint.PRODUCTION)));
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/test/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ImportUtilsMCPServerTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/test/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ImportUtilsMCPServerTest.java
@@ -61,6 +61,9 @@ public class ImportUtilsMCPServerTest {
     private static final String API_VERSION = "1.0.0";
     private static final String API_CONTEXT = "/test-mcp";
     private static final String EXTRACTED_PATH = "/tmp/test-mcp-import";
+    // Deliberately unlike the identity of the MCP Server itself, so that a lookup made with the wrong key shows up.
+    private static final String REFERENCED_API_NAME = "BackendPizzaAPI";
+    private static final String REFERENCED_API_VERSION = "2.5.0";
 
     private APIProvider apiProvider;
     private API targetApi;
@@ -482,5 +485,25 @@ public class ImportUtilsMCPServerTest {
             Assert.assertEquals("A reference that cannot be resolved is a bad request",
                     400, e.getErrorHandler().getHttpStatusCode());
         }
+    }
+
+    /**
+     * The key the referenced API is looked up by is its own name and version as carried by the artifact, not the
+     * identity of the MCP Server holding it. A lookup made with the wrong key resolves the mapping onto the wrong API,
+     * or onto nothing at all, and either way leaves behind a UUID that looks resolved.
+     */
+    @Test
+    public void testImportMCPServerLooksUpTheReferencedApiByItsOwnNameAndVersion() throws Exception {
+
+        withReferencedApi("uuid-of-the-source-environment", REFERENCED_API_NAME, REFERENCED_API_VERSION);
+        setupMCPServerDTOMock(mcpServerDTO);
+
+        ImportUtils.importMCPServer(EXTRACTED_PATH, mcpServerDTO, true, false, true,
+                false, false, tokenScopes, null, ORGANIZATION);
+
+        PowerMockito.verifyPrivate(ImportUtils.class).invoke("retrieveApiToOverwrite",
+                ArgumentMatchers.eq(REFERENCED_API_NAME), ArgumentMatchers.eq(REFERENCED_API_VERSION),
+                ArgumentMatchers.anyString(), ArgumentMatchers.any(APIProvider.class),
+                ArgumentMatchers.any(Boolean.class), ArgumentMatchers.anyString());
     }
 }


### PR DESCRIPTION
Adds unit coverage for the two fixes below. Neither is a behaviour change; both are tests only.

### What these cover

**`hasEndpoint` — the endpoint existence check that guards a deployment to a non-hybrid gateway**
(fix for https://github.com/wso2/api-manager/issues/5184)

The check used to read the legacy endpoint configuration JSON only. An AI API keeps its endpoints as
named endpoints outside that JSON, so removing its first endpoint emptied the configuration while a
named endpoint of the same stage remained, and the deployment was refused with a null
`GatewayAPIDTO`. Eight cases pin both halves of the contract the fix introduced:

| subtype | endpointConfig | named endpoints | expected |
|---|---|---|---|
| AIAPI | `{"endpoint_type":"http"}` | one PRODUCTION | true |
| AIAPI | `{"endpoint_type":"http"}` | one SANDBOX | true |
| AIAPI | `{"endpoint_type":"http"}` | none | false |
| non-AI | has `production_endpoints` | none | true |
| non-AI | has `sandbox_endpoints` | none | true |
| non-AI | `{"endpoint_type":"http"}` | none | false |
| non-AI | `{"endpoint_type":"http"}` | one PRODUCTION | **false** |

The first two fail against the pre-fix check. The last row is the one worth keeping: it fails if the
named endpoints are ever read for every API rather than for AI APIs alone, which would let an API
whose configuration carries no endpoint of the stage being deployed to reach that gateway with no
backend behind it — the thing the check exists to prevent.

**The lookup key used to resolve an MCP Server's reference API at import time**
(fix for https://github.com/wso2/api-manager/issues/5174)

The resolution is only correct if the reference is looked up by the name and the version of the
*referenced API*. The existing tests set those fields themselves and assert on the UUID that comes
back, so they hold whichever key the lookup was made with. This asserts the key, with a reference
name and version deliberately unlike those of the MCP Server holding it so that a lookup made with
the wrong one is visible rather than accidentally matching.

### Verification

Run on this branch, and each test confirmed to fail when the behaviour it guards is reverted:

| Mutation applied to the fix | Result |
|---|---|
| `hasEndpoint` reverted to reading the endpoint configuration only | exactly the two AI API cases fail |
| `hasEndpoint` reads the named endpoints for every API | exactly the non-AI guard row fails |
| the reference looked up by the MCP Server's own name and version | exactly the lookup key test fails |

### Notes

`hasEndpoint` is private, so it is reached by reflection rather than through
`createAPIGatewayDTOtoPublishAPI`, which would need the whole gateway artifact generation pipeline
standing up to reach one predicate.

These guard the fixes in the repository they live in. End-to-end coverage of the same two defects —
deploying an AI API to a production gateway after its first endpoint is removed, and importing an
MCP Server whose reference API UUID belongs to another environment — belongs in product-apim, where
a running server and a gateway are available.

### Related

- https://github.com/wso2/api-manager/issues/5184 — AI APIs cannot be deployed after the primary endpoint is changed
- https://github.com/wso2/api-manager/issues/5174 — EXISTING_API subtype MCP Server import fails cross-environment
