### PR TITLE
Fix StackOverflowError on circular ref in MCP tool schema generation

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.spec.parser/src/main/java/org/wso2/carbon/apimgt/spec/parser/definitions/OAS2Parser.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.spec.parser/src/main/java/org/wso2/carbon/apimgt/spec/parser/definitions/OAS2Parser.java
@@ -58,6 +58,7 @@ import io.swagger.models.parameters.PathParameter;
 import io.swagger.models.parameters.RefParameter;
 import io.swagger.models.properties.AbstractProperty;
 import io.swagger.models.properties.ArrayProperty;
+import io.swagger.models.properties.ComposedProperty;
 import io.swagger.models.properties.MapProperty;
 import io.swagger.models.properties.ObjectProperty;
 import io.swagger.models.properties.Property;
@@ -3020,6 +3021,11 @@ public class OAS2Parser extends APIDefinition {
                     }
                     return objProp;
                 }
+                // The definition the reference names does not exist. Drop the field rather than
+                // emitting the reference unresolved: the generated schema carries no definitions
+                // section, so a surviving $ref points at nothing.
+                log.warn("Component not found in reference: " + ref);
+                return null;
             } finally {
                 visitedRefs.remove(ref);
             }
@@ -3032,6 +3038,26 @@ public class OAS2Parser extends APIDefinition {
             resolvedArray.setMaxItems(array.getMaxItems());
             resolvedArray.setItems(resolveProperty(array.getItems(), swagger, visitedRefs));
             return resolvedArray;
+        } else if (property instanceof ComposedProperty) {
+            // A property written as an inline allOf. Merged into one object, the same way
+            // resolveModel merges a ComposedModel and the same way OAS3Parser renders allOf, so
+            // that a consumer sees one plain object rather than a composition to interpret.
+            // Leaving it unresolved emitted a $ref the generated schema cannot follow.
+            ComposedProperty composed = (ComposedProperty) property;
+            ObjectProperty merged = new ObjectProperty();
+            copyCommonPropertyFields(composed, merged);
+            Map<String, Property> mergedProps = new LinkedHashMap<>();
+            if (composed.getAllOf() != null) {
+                for (Property part : composed.getAllOf()) {
+                    Property resolvedPart = resolveProperty(part, swagger, visitedRefs);
+                    if (resolvedPart instanceof ObjectProperty
+                            && ((ObjectProperty) resolvedPart).getProperties() != null) {
+                        mergedProps.putAll(((ObjectProperty) resolvedPart).getProperties());
+                    }
+                }
+            }
+            merged.setProperties(mergedProps);
+            return merged;
         } else if (property instanceof MapProperty) {
             MapProperty map = (MapProperty) property;
             MapProperty resolvedMap = new MapProperty();

--- a/components/apimgt/org.wso2.carbon.apimgt.spec.parser/src/main/java/org/wso2/carbon/apimgt/spec/parser/definitions/OAS2Parser.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.spec.parser/src/main/java/org/wso2/carbon/apimgt/spec/parser/definitions/OAS2Parser.java
@@ -2828,7 +2828,7 @@ public class OAS2Parser extends APIDefinition {
                     }
                     BodyParameter bodyParam = (BodyParameter) param;
                     Model rawModel = bodyParam.getSchema();
-                    Model resolvedModel = resolveModel(rawModel, swagger);
+                    Model resolvedModel = resolveModel(rawModel, swagger, new HashSet<>());
 
                     Map<String, Object> requestBodyNode = new LinkedHashMap<>();
                     requestBodyNode.put(APISpecParserConstants.TYPE, APISpecParserConstants.OBJECT);
@@ -2873,18 +2873,6 @@ public class OAS2Parser extends APIDefinition {
         }
 
         return root;
-    }
-
-    /**
-     * Resolves a model by following references and composed models in the Swagger definition.
-     * It merges properties from all referenced models and handles composed models.
-     *
-     * @param model   the model to resolve
-     * @param swagger the Swagger definition containing model references
-     * @return the resolved ModelImpl or ComposedModel
-     */
-    private Model resolveModel(Model model, Swagger swagger) {
-        return resolveModel(model, swagger, new HashSet<>());
     }
 
     /**

--- a/components/apimgt/org.wso2.carbon.apimgt.spec.parser/src/main/java/org/wso2/carbon/apimgt/spec/parser/definitions/OAS2Parser.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.spec.parser/src/main/java/org/wso2/carbon/apimgt/spec/parser/definitions/OAS2Parser.java
@@ -3019,7 +3019,11 @@ public class OAS2Parser extends APIDefinition {
             visitedRefs.add(ref);
             try {
                 Model refModel = swagger.getDefinitions().get(ref);
-                if (refModel instanceof ModelImpl) {
+                if (refModel != null) {
+                    // resolveModel merges a composed (allOf) definition into a plain one, so a
+                    // reference to either kind of definition is expanded here. Accepting only
+                    // ModelImpl left a reference to a composed definition unresolved, emitting a
+                    // $ref the generated schema cannot follow: it carries no definitions section.
                     Model resolvedModel = resolveModel(refModel, swagger, visitedRefs);
                     ObjectProperty objProp = new ObjectProperty();
                     copyCommonPropertyFields((RefProperty) property, objProp);

--- a/components/apimgt/org.wso2.carbon.apimgt.spec.parser/src/main/java/org/wso2/carbon/apimgt/spec/parser/definitions/OAS2Parser.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.spec.parser/src/main/java/org/wso2/carbon/apimgt/spec/parser/definitions/OAS2Parser.java
@@ -2964,10 +2964,6 @@ public class OAS2Parser extends APIDefinition {
         return model;
     }
 
-    private Property resolveProperty(Property property, Swagger swagger) {
-        return resolveProperty(property, swagger, new HashSet<>());
-    }
-
     /**
      * Resolves a property by following references and handling nested properties.
      * It recursively resolves RefProperties, ArrayProperties, and ObjectProperties.

--- a/components/apimgt/org.wso2.carbon.apimgt.spec.parser/src/main/java/org/wso2/carbon/apimgt/spec/parser/definitions/OAS2Parser.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.spec.parser/src/main/java/org/wso2/carbon/apimgt/spec/parser/definitions/OAS2Parser.java
@@ -56,6 +56,7 @@ import io.swagger.models.parameters.BodyParameter;
 import io.swagger.models.parameters.Parameter;
 import io.swagger.models.parameters.PathParameter;
 import io.swagger.models.parameters.RefParameter;
+import io.swagger.models.properties.AbstractProperty;
 import io.swagger.models.properties.ArrayProperty;
 import io.swagger.models.properties.ObjectProperty;
 import io.swagger.models.properties.Property;
@@ -2882,24 +2883,38 @@ public class OAS2Parser extends APIDefinition {
      * @return the resolved ModelImpl or ComposedModel
      */
     private Model resolveModel(Model model, Swagger swagger) {
+        return resolveModel(model, swagger, new HashSet<>());
+    }
+
+    /**
+     * Resolves a model, tracking the references already visited on the current resolution path so
+     * that a circular reference terminates instead of recursing until the stack overflows.
+     * <p>
+     * The visited set is the path currently being walked, not everything seen so far: each reference
+     * is removed again as the recursion unwinds, so a model referenced from two unrelated places is
+     * still expanded at both. Every nested call must be given this same set - starting a fresh one
+     * loses the path, which is what made a cycle through an object's properties recurse forever.
+     *
+     * @param model       the model to resolve
+     * @param swagger     the Swagger definition containing model references
+     * @param visitedRefs references on the current resolution path
+     * @return the resolved ModelImpl or ComposedModel
+     */
+    private Model resolveModel(Model model, Swagger swagger, Set<String> visitedRefs) {
 
         if (model == null) {
             return null;
         }
-        Set<String> visitedRefs = new HashSet<>();
 
+        // resolveComponentRef follows nested RefModels internally and never returns one, so this
+        // resolves the whole reference chain and terminates.
         while (model instanceof RefModel) {
             String ref = ((RefModel) model).getSimpleRef();
             model = resolveComponentRef(ref, swagger, visitedRefs, Model.class);
-            if (model == null) break;
-            if (visitedRefs.contains(ref)) {
-                log.warn("Circular reference detected for model: " + ref);
-                break;
+            if (model == null) {
+                // resolveComponentRef has already logged why it could not be resolved.
+                return null;
             }
-            visitedRefs.add(ref);
-            Model resolved = swagger.getDefinitions().get(ref);
-            if (resolved == null || resolved == model) break;
-            model = resolved;
         }
 
         if (model instanceof ComposedModel) {
@@ -2910,7 +2925,7 @@ public class OAS2Parser extends APIDefinition {
 
             if (composed.getAllOf() != null) {
                 for (Model part : composed.getAllOf()) {
-                    Model resolvedPart = resolveModel(part, swagger);
+                    Model resolvedPart = resolveModel(part, swagger, visitedRefs);
                     if (resolvedPart instanceof ModelImpl) {
                         ModelImpl impl = (ModelImpl) resolvedPart;
                         if (impl.getProperties() != null) mergedProps.putAll(impl.getProperties());
@@ -2927,9 +2942,23 @@ public class OAS2Parser extends APIDefinition {
         if (model instanceof ModelImpl && model.getProperties() != null) {
             Map<String, Property> resolvedProps = new LinkedHashMap<>();
             for (Map.Entry<String, Property> entry : model.getProperties().entrySet()) {
-                resolvedProps.put(entry.getKey(), resolveProperty(entry.getValue(), swagger));
+                resolvedProps.put(entry.getKey(), resolveProperty(entry.getValue(), swagger, visitedRefs));
             }
-            model.setProperties(resolvedProps);
+            // Hand the resolved properties back on a separate model instead of writing them onto the
+            // definition. The definition belongs to the parsed Swagger object; once a cycle is
+            // truncated a resolved property can contain the definition it came from, and writing
+            // that back would make the definition its own descendant and impossible to serialise.
+            //
+            // Only getProperties() and getRequired() are read back from the returned model - the
+            // model is never serialised itself, only the properties it carries - so a carrier for
+            // those two is enough.
+            ModelImpl resolvedModel = new ModelImpl();
+            resolvedModel.setProperties(resolvedProps);
+            List<String> required = ((ModelImpl) model).getRequired();
+            if (required != null) {
+                resolvedModel.setRequired(required);
+            }
+            return resolvedModel;
         }
 
         return model;
@@ -2942,9 +2971,17 @@ public class OAS2Parser extends APIDefinition {
     /**
      * Resolves a property by following references and handling nested properties.
      * It recursively resolves RefProperties, ArrayProperties, and ObjectProperties.
+     * <p>
+     * The visited set is shared with {@link #resolveModel(Model, Swagger, Set)} and with every
+     * nested call below, so that a cycle running through an object's properties, a list's item type
+     * or an inline object is detected instead of recursed into indefinitely.
+     * <p>
+     * Each branch builds a new property rather than resolving the existing one in place, so that
+     * resolution leaves the parsed Swagger object untouched.
      *
-     * @param property the property to resolve
-     * @param swagger  the Swagger definition containing model references
+     * @param property    the property to resolve
+     * @param swagger     the Swagger definition containing model references
+     * @param visitedRefs references on the current resolution path
      * @return the resolved Property
      */
     private Property resolveProperty(Property property, Swagger swagger, Set<String> visitedRefs) {
@@ -2952,42 +2989,97 @@ public class OAS2Parser extends APIDefinition {
         if (property instanceof RefProperty) {
             String ref = ((RefProperty) property).getSimpleRef();
             if (visitedRefs.contains(ref)) {
-                log.warn("Circular reference detected for property: " + ref);
-                return property;
+                log.warn("Circular reference truncated while resolving property reference: " + ref);
+                return unexpandedObjectProperty((RefProperty) property, ref);
             }
             visitedRefs.add(ref);
-            Model refModel = swagger.getDefinitions().get(ref);
-            if (refModel instanceof ModelImpl) {
-                ModelImpl impl = (ModelImpl) resolveModel(refModel, swagger);
-                ObjectProperty objProp = new ObjectProperty();
-                objProp.setDescription(property.getDescription());
-                objProp.setExample(property.getExample());
-                if (impl.getProperties() != null) {
-                    Map<String, Property> nested = new LinkedHashMap<>();
-                    for (Map.Entry<String, Property> entry : impl.getProperties().entrySet()) {
-                        nested.put(entry.getKey(), resolveProperty(entry.getValue(), swagger, visitedRefs));
+            try {
+                Model refModel = swagger.getDefinitions().get(ref);
+                if (refModel instanceof ModelImpl) {
+                    Model resolvedModel = resolveModel(refModel, swagger, visitedRefs);
+                    ObjectProperty objProp = new ObjectProperty();
+                    copyCommonPropertyFields((RefProperty) property, objProp);
+                    if (resolvedModel != null && resolvedModel.getProperties() != null) {
+                        objProp.setProperties(new LinkedHashMap<>(resolvedModel.getProperties()));
                     }
-                    objProp.setProperties(nested);
+                    return objProp;
                 }
-                return objProp;
+            } finally {
+                visitedRefs.remove(ref);
             }
         } else if (property instanceof ArrayProperty) {
             ArrayProperty array = (ArrayProperty) property;
-            array.setItems(resolveProperty(array.getItems(), swagger));
-            return array;
+            ArrayProperty resolvedArray = new ArrayProperty();
+            copyCommonPropertyFields(array, resolvedArray);
+            resolvedArray.setUniqueItems(array.getUniqueItems());
+            resolvedArray.setMinItems(array.getMinItems());
+            resolvedArray.setMaxItems(array.getMaxItems());
+            resolvedArray.setItems(resolveProperty(array.getItems(), swagger, visitedRefs));
+            return resolvedArray;
         } else if (property instanceof ObjectProperty) {
             ObjectProperty obj = (ObjectProperty) property;
+            ObjectProperty resolvedObj = new ObjectProperty();
+            copyCommonPropertyFields(obj, resolvedObj);
             if (obj.getProperties() != null) {
                 Map<String, Property> resolved = new LinkedHashMap<>();
                 for (Map.Entry<String, Property> entry : obj.getProperties().entrySet()) {
-                    resolved.put(entry.getKey(), resolveProperty(entry.getValue(), swagger));
+                    resolved.put(entry.getKey(), resolveProperty(entry.getValue(), swagger, visitedRefs));
                 }
-                obj.setProperties(resolved);
+                resolvedObj.setProperties(resolved);
             }
-            return obj;
+            return resolvedObj;
         }
 
         return property;
+    }
+
+    /**
+     * Builds the property emitted in place of a reference that closes a circular chain. An object
+     * with no declared properties states what is true of it - the field takes an object, whose shape
+     * cannot be written out without recursing forever. Dropping the field instead would claim the
+     * API does not accept it, and returning the reference unresolved would leave a $ref no consumer
+     * can follow, because the generated schema carries no definitions section.
+     *
+     * @param original the reference that could not be expanded
+     * @param ref      the definition name it points at
+     * @return an object property standing in for the unexpanded reference
+     */
+    private ObjectProperty unexpandedObjectProperty(RefProperty original, String ref) {
+        ObjectProperty placeholder = new ObjectProperty();
+        copyCommonPropertyFields(original, placeholder);
+        if (StringUtils.isBlank(placeholder.getDescription())) {
+            placeholder.setDescription("Circular reference to '" + ref
+                    + "'; nested properties are omitted.");
+        }
+        return placeholder;
+    }
+
+    /**
+     * Copies every attribute a property carries in its own right onto a resolved copy, so that
+     * resolution changes only nested content and nothing about how the property is rendered.
+     * <p>
+     * Two of the declared fields are deliberately not copied: type, because each property class sets
+     * its own, and xml, which swagger-models exposes no getter for and therefore never serialises
+     * either. OAS2ParserTest guards this list against changes in the library.
+     *
+     * @param from the property being resolved
+     * @param to   the copy being built
+     */
+    private void copyCommonPropertyFields(AbstractProperty from, AbstractProperty to) {
+        to.setName(from.getName());
+        to.setTitle(from.getTitle());
+        to.setDescription(from.getDescription());
+        to.setFormat(from.getFormat());
+        to.setExample(from.getExample());
+        to.setRequired(from.getRequired());
+        to.setReadOnly(from.getReadOnly());
+        to.setAllowEmptyValue(from.getAllowEmptyValue());
+        to.setAccess(from.getAccess());
+        to.setPosition(from.getPosition());
+        to.setBooleanValue(from.getBooleanValue());
+        if (from.getVendorExtensions() != null && !from.getVendorExtensions().isEmpty()) {
+            to.setVendorExtensionMap(from.getVendorExtensions());
+        }
     }
 
     /**
@@ -3017,30 +3109,38 @@ public class OAS2Parser extends APIDefinition {
             return null;
         }
         visitedRefs.add(ref);
-        Object resolved = null;
-        if (swagger.getDefinitions() != null && swagger.getDefinitions().containsKey(ref)) {
-            resolved = swagger.getDefinitions().get(ref);
+        // Removed again on the way out so the set stays the path currently being walked. Keeping it
+        // would leave a component unresolved the second time it is referenced from an unrelated
+        // place - for instance an allOf whose two branches both compose the same model.
+        try {
+            Object resolved = null;
+            if (swagger.getDefinitions() != null && swagger.getDefinitions().containsKey(ref)) {
+                resolved = swagger.getDefinitions().get(ref);
+            }
+            if (resolved == null && swagger.getParameters() != null && swagger.getParameters().containsKey(ref)) {
+                resolved = swagger.getParameters().get(ref);
+            }
+            if (resolved == null && swagger.getResponses() != null && swagger.getResponses().containsKey(ref)) {
+                resolved = swagger.getResponses().get(ref);
+            }
+            if (resolved == null) {
+                log.warn("Component not found in reference: " + ref);
+                return null;
+            }
+            if (resolved instanceof RefModel) {
+                return (T) resolveComponentRef(((RefModel) resolved).getSimpleRef(), swagger, visitedRefs,
+                        expectedType);
+            } else if (resolved instanceof RefParameter) {
+                return (T) resolveComponentRef(((RefParameter) resolved).getSimpleRef(), swagger, visitedRefs,
+                        expectedType);
+            } else if (resolved instanceof Response && ((Response) resolved).getSchema() instanceof RefModel) {
+                return (T) resolveComponentRef(((RefModel) ((Response) resolved).getSchema()).getSimpleRef(), swagger,
+                        visitedRefs, expectedType);
+            }
+            return expectedType.cast(resolved);
+        } finally {
+            visitedRefs.remove(ref);
         }
-        if (resolved == null && swagger.getParameters() != null && swagger.getParameters().containsKey(ref)) {
-            resolved = swagger.getParameters().get(ref);
-        }
-        if (resolved == null && swagger.getResponses() != null && swagger.getResponses().containsKey(ref)) {
-            resolved = swagger.getResponses().get(ref);
-        }
-        if (resolved == null) {
-            log.warn("Component not found in reference: " + ref);
-            return null;
-        }
-        if (resolved instanceof RefModel) {
-            return (T) resolveComponentRef(((RefModel) resolved).getSimpleRef(), swagger, visitedRefs, expectedType);
-        } else if (resolved instanceof RefParameter) {
-            return (T) resolveComponentRef(((RefParameter) resolved).getSimpleRef(), swagger, visitedRefs,
-                    expectedType);
-        } else if (resolved instanceof Response && ((Response) resolved).getSchema() instanceof RefModel) {
-            return (T) resolveComponentRef(((RefModel) ((Response) resolved).getSchema()).getSimpleRef(), swagger,
-                    visitedRefs, expectedType);
-        }
-        return expectedType.cast(resolved);
     }
 
     /**

--- a/components/apimgt/org.wso2.carbon.apimgt.spec.parser/src/main/java/org/wso2/carbon/apimgt/spec/parser/definitions/OAS2Parser.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.spec.parser/src/main/java/org/wso2/carbon/apimgt/spec/parser/definitions/OAS2Parser.java
@@ -58,6 +58,7 @@ import io.swagger.models.parameters.PathParameter;
 import io.swagger.models.parameters.RefParameter;
 import io.swagger.models.properties.AbstractProperty;
 import io.swagger.models.properties.ArrayProperty;
+import io.swagger.models.properties.MapProperty;
 import io.swagger.models.properties.ObjectProperty;
 import io.swagger.models.properties.Property;
 import io.swagger.models.properties.RefProperty;
@@ -2907,15 +2908,42 @@ public class OAS2Parser extends APIDefinition {
         }
 
         // resolveComponentRef follows nested RefModels internally and never returns one, so this
-        // resolves the whole reference chain and terminates.
+        // runs at most once and resolves the whole reference chain.
+        String heldRef = null;
         while (model instanceof RefModel) {
             String ref = ((RefModel) model).getSimpleRef();
             model = resolveComponentRef(ref, swagger, visitedRefs, Model.class);
             if (model == null) {
-                // resolveComponentRef has already logged why it could not be resolved.
+                // Either undefined, or already on the path. resolveComponentRef has logged which.
                 return null;
             }
+            // resolveComponentRef releases the reference as soon as its lookup finishes. Hold it
+            // again for the whole traversal of the resolved model's body, otherwise a cycle that
+            // runs through allOf rather than through a property is never detected: nothing else on
+            // that path registers the reference.
+            visitedRefs.add(ref);
+            heldRef = ref;
         }
+        try {
+            return resolveModelBody(model, swagger, visitedRefs);
+        } finally {
+            if (heldRef != null) {
+                visitedRefs.remove(heldRef);
+            }
+        }
+    }
+
+    /**
+     * Resolves the composed parts or the properties of a model that has already been dereferenced.
+     * Split out of {@link #resolveModel(Model, Swagger, Set)} so that the reference the model came
+     * from stays on the visited path for the whole traversal.
+     *
+     * @param model       dereferenced model whose body should be resolved
+     * @param swagger     the Swagger definition containing model references
+     * @param visitedRefs references on the current resolution path
+     * @return the resolved ModelImpl
+     */
+    private Model resolveModelBody(Model model, Swagger swagger, Set<String> visitedRefs) {
 
         if (model instanceof ComposedModel) {
             ComposedModel composed = (ComposedModel) model;
@@ -3012,6 +3040,15 @@ public class OAS2Parser extends APIDefinition {
             resolvedArray.setMaxItems(array.getMaxItems());
             resolvedArray.setItems(resolveProperty(array.getItems(), swagger, visitedRefs));
             return resolvedArray;
+        } else if (property instanceof MapProperty) {
+            MapProperty map = (MapProperty) property;
+            MapProperty resolvedMap = new MapProperty();
+            copyCommonPropertyFields(map, resolvedMap);
+            resolvedMap.setMinProperties(map.getMinProperties());
+            resolvedMap.setMaxProperties(map.getMaxProperties());
+            resolvedMap.setAdditionalProperties(
+                    resolveProperty(map.getAdditionalProperties(), swagger, visitedRefs));
+            return resolvedMap;
         } else if (property instanceof ObjectProperty) {
             ObjectProperty obj = (ObjectProperty) property;
             ObjectProperty resolvedObj = new ObjectProperty();

--- a/components/apimgt/org.wso2.carbon.apimgt.spec.parser/src/main/java/org/wso2/carbon/apimgt/spec/parser/definitions/OAS3Parser.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.spec.parser/src/main/java/org/wso2/carbon/apimgt/spec/parser/definitions/OAS3Parser.java
@@ -3212,7 +3212,7 @@ public class OAS3Parser extends APIDefinition {
 
                 String name = param.getIn() + "_" + param.getName();
                 Map<String, Object> paramSchema = new LinkedHashMap<>();
-                Schema<?> schema = resolveSchema(param.getSchema(), openAPI);
+                Schema<?> schema = resolveSchema(param.getSchema(), openAPI, new HashSet<>());
 
                 if (schema != null) {
                     paramSchema.put(APISpecParserConstants.TYPE, schema.getType());
@@ -3247,7 +3247,7 @@ public class OAS3Parser extends APIDefinition {
                 Schema<?> rawSchema =
                         requestBody.getContent().get(APISpecParserConstants.APPLICATION_JSON_MEDIA_TYPE).getSchema();
 
-                Schema<?> bodySchema = resolveSchema(rawSchema, openAPI);
+                Schema<?> bodySchema = resolveSchema(rawSchema, openAPI, new HashSet<>());
 
                 Map<String, Object> requestBodyNode = new LinkedHashMap<>();
                 requestBodyNode.put(APISpecParserConstants.TYPE, APISpecParserConstants.OBJECT);
@@ -3272,19 +3272,6 @@ public class OAS3Parser extends APIDefinition {
             root.put(APISpecParserConstants.REQUIRED, requiredFields);
         }
         return root;
-    }
-
-    /**
-     * Resolves a schema by recursively resolving $ref, allOf, oneOf, anyOf, and not properties.
-     * Returns the resolved Schema object.
-     *
-     * @param schema   Schema to resolve
-     * @param openAPI  OpenAPI definition to resolve against
-     * @return Resolved Schema object
-     */
-    private Schema<?> resolveSchema(Schema<?> schema, OpenAPI openAPI) {
-
-        return resolveSchema(schema, openAPI, new HashSet<>());
     }
 
     /**

--- a/components/apimgt/org.wso2.carbon.apimgt.spec.parser/src/main/java/org/wso2/carbon/apimgt/spec/parser/definitions/OAS3Parser.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.spec.parser/src/main/java/org/wso2/carbon/apimgt/spec/parser/definitions/OAS3Parser.java
@@ -3307,11 +3307,11 @@ public class OAS3Parser extends APIDefinition {
             }
             schema = resolveComponentRef(ref, openAPI, visitedRefs, Schema.class);
             if (schema == null) {
-                // resolveComponentRef returns null both for a component that does not exist and for
-                // a chain of aliases that closes on itself. When the component does exist the chain
-                // was circular, so describe the field as an object rather than dropping it - that
-                // matches how every other cycle is rendered.
-                if (isDeclaredSchema(name, openAPI)) {
+                // resolveComponentRef returns null both for a chain of aliases that closes on
+                // itself and for one that ends at a component the definition never declares. Only a
+                // cycle is described as an object, matching how every other cycle is rendered; an
+                // unresolved reference keeps its existing behaviour and its field is dropped.
+                if (closesCycle(ref, openAPI, visitedRefs)) {
                     log.warn("Circular reference truncated while resolving schema reference: " + ref);
                     return unexpandedObjectSchema(reference, name);
                 }
@@ -3426,18 +3426,53 @@ public class OAS3Parser extends APIDefinition {
     }
 
     /**
-     * Reports whether a schema of this name is declared in the components section. Used to tell a
-     * reference that could not be resolved because it is circular from one that names a component
-     * the definition never declares.
+     * Reports whether following this reference revisits a component that is already being resolved.
+     * Used to tell a reference that failed because its chain of aliases closes on itself from one
+     * that simply ends at a component the definition never declares - resolveComponentRef returns
+     * null for both, but only the first should be described rather than dropped.
      *
-     * @param name    component name
-     * @param openAPI OpenAPI definition to look in
-     * @return true if the definition declares a schema of that name
+     * @param ref         the reference to follow
+     * @param openAPI     OpenAPI definition to resolve against
+     * @param visitedRefs references already on the current resolution path
+     * @return true if following the reference closes a cycle
      */
-    private boolean isDeclaredSchema(String name, OpenAPI openAPI) {
-        return openAPI != null && openAPI.getComponents() != null
-                && openAPI.getComponents().getSchemas() != null
-                && openAPI.getComponents().getSchemas().containsKey(name);
+    private boolean closesCycle(String ref, OpenAPI openAPI, Set<String> visitedRefs) {
+        Set<String> chain = new HashSet<>(visitedRefs);
+        String current = ref;
+        while (current != null) {
+            String key = componentRefKey(current);
+            if (key == null) {
+                // Not a component reference this parser follows.
+                return false;
+            }
+            if (!chain.add(key)) {
+                // Already on the chain, so the reference closes a cycle.
+                return true;
+            }
+            Schema<?> target = declaredSchema(key, openAPI);
+            if (target == null) {
+                // The chain ends at a component the definition does not declare.
+                return false;
+            }
+            current = target.get$ref();
+        }
+        return false;
+    }
+
+    /**
+     * Looks up the schema a tracking key names, or null if the definition declares no such schema.
+     *
+     * @param refKey  key produced by {@link #componentRefKey(String)}
+     * @param openAPI OpenAPI definition to look in
+     * @return the declared schema, or null
+     */
+    private Schema<?> declaredSchema(String refKey, OpenAPI openAPI) {
+        if (refKey == null || !refKey.startsWith(APISpecParserConstants.SCHEMAS + ":")
+                || openAPI == null || openAPI.getComponents() == null
+                || openAPI.getComponents().getSchemas() == null) {
+            return null;
+        }
+        return openAPI.getComponents().getSchemas().get(refKey.substring(refKey.indexOf(':') + 1));
     }
 
     /**

--- a/components/apimgt/org.wso2.carbon.apimgt.spec.parser/src/main/java/org/wso2/carbon/apimgt/spec/parser/definitions/OAS3Parser.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.spec.parser/src/main/java/org/wso2/carbon/apimgt/spec/parser/definitions/OAS3Parser.java
@@ -3299,7 +3299,9 @@ public class OAS3Parser extends APIDefinition {
             String refKey = componentRefKey(ref);
             if (refKey != null && visitedRefs.contains(refKey)) {
                 log.warn("Circular reference truncated while resolving schema reference: " + ref);
-                return unexpandedObjectSchema(schema, ref);
+                // refKey is "<category>:<name>"; the component name alone reads better in the
+                // emitted description than the whole JSON Pointer.
+                return unexpandedObjectSchema(schema, refKey.substring(refKey.indexOf(':') + 1));
             }
             schema = resolveComponentRef(ref, openAPI, visitedRefs, Schema.class);
             if (schema == null) {
@@ -3399,15 +3401,15 @@ public class OAS3Parser extends APIDefinition {
      * can follow, because the generated schema carries no components section.
      *
      * @param original the reference that could not be expanded
-     * @param ref      the reference string it points at
+     * @param name     the name of the component it points at
      * @return an object schema standing in for the unexpanded reference
      */
-    private Schema<?> unexpandedObjectSchema(Schema<?> original, String ref) {
+    private Schema<?> unexpandedObjectSchema(Schema<?> original, String name) {
         ObjectSchema placeholder = new ObjectSchema();
         if (original != null && StringUtils.isNotBlank(original.getDescription())) {
             placeholder.setDescription(original.getDescription());
         } else {
-            placeholder.setDescription("Circular reference to '" + ref
+            placeholder.setDescription("Circular reference to '" + name
                     + "'; nested properties are omitted.");
         }
         return placeholder;

--- a/components/apimgt/org.wso2.carbon.apimgt.spec.parser/src/main/java/org/wso2/carbon/apimgt/spec/parser/definitions/OAS3Parser.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.spec.parser/src/main/java/org/wso2/carbon/apimgt/spec/parser/definitions/OAS3Parser.java
@@ -3295,16 +3295,26 @@ public class OAS3Parser extends APIDefinition {
 
         String heldRefKey = null;
         if (schema.get$ref() != null) {
+            Schema<?> reference = schema;
             String ref = schema.get$ref();
             String refKey = componentRefKey(ref);
+            // refKey is "<category>:<name>"; the component name alone reads better in the emitted
+            // description than the whole JSON Pointer.
+            String name = refKey == null ? ref : refKey.substring(refKey.indexOf(':') + 1);
             if (refKey != null && visitedRefs.contains(refKey)) {
                 log.warn("Circular reference truncated while resolving schema reference: " + ref);
-                // refKey is "<category>:<name>"; the component name alone reads better in the
-                // emitted description than the whole JSON Pointer.
-                return unexpandedObjectSchema(schema, refKey.substring(refKey.indexOf(':') + 1));
+                return unexpandedObjectSchema(reference, name);
             }
             schema = resolveComponentRef(ref, openAPI, visitedRefs, Schema.class);
             if (schema == null) {
+                // resolveComponentRef returns null both for a component that does not exist and for
+                // a chain of aliases that closes on itself. When the component does exist the chain
+                // was circular, so describe the field as an object rather than dropping it - that
+                // matches how every other cycle is rendered.
+                if (isDeclaredSchema(name, openAPI)) {
+                    log.warn("Circular reference truncated while resolving schema reference: " + ref);
+                    return unexpandedObjectSchema(reference, name);
+                }
                 return null;
             }
             // resolveComponentRef releases the reference as soon as its lookup finishes. Hold it
@@ -3413,6 +3423,21 @@ public class OAS3Parser extends APIDefinition {
                     + "'; nested properties are omitted.");
         }
         return placeholder;
+    }
+
+    /**
+     * Reports whether a schema of this name is declared in the components section. Used to tell a
+     * reference that could not be resolved because it is circular from one that names a component
+     * the definition never declares.
+     *
+     * @param name    component name
+     * @param openAPI OpenAPI definition to look in
+     * @return true if the definition declares a schema of that name
+     */
+    private boolean isDeclaredSchema(String name, OpenAPI openAPI) {
+        return openAPI != null && openAPI.getComponents() != null
+                && openAPI.getComponents().getSchemas() != null
+                && openAPI.getComponents().getSchemas().containsKey(name);
     }
 
     /**

--- a/components/apimgt/org.wso2.carbon.apimgt.spec.parser/src/main/java/org/wso2/carbon/apimgt/spec/parser/definitions/OAS3Parser.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.spec.parser/src/main/java/org/wso2/carbon/apimgt/spec/parser/definitions/OAS3Parser.java
@@ -2872,10 +2872,17 @@ public class OAS3Parser extends APIDefinition {
                 continue;
             }
 
+            // Resolve each tool against its own parse of the definition. Resolving a schema writes
+            // the expanded content back onto the components it walks, so sharing one parsed
+            // definition would let the first tool's resolution change what the later ones see: a
+            // tool whose body is a schema an earlier tool reached through a circular reference would
+            // inherit that truncation instead of expanding it.
+            OpenAPI toolDefinition = getOpenAPI(backendApiDefinition);
+            mergePathParametersIntoOperations(toolDefinition);
             OperationMatch match =
-                    findMatchingOperation(backendDefinition, backendOperation.getTarget(), backendOperation.getVerb());
+                    findMatchingOperation(toolDefinition, backendOperation.getTarget(), backendOperation.getVerb());
             if (match != null) {
-                URITemplate toolTemplate = populateURITemplate(template, match, backendDefinition, backendId,
+                URITemplate toolTemplate = populateURITemplate(template, match, toolDefinition, backendId,
                         refApiId, true);
                 if (!tools.add(toolTemplate.getUriTemplate())) {
                     log.error("Duplicate MCP tool detected: " + toolTemplate.getUriTemplate());
@@ -2923,11 +2930,18 @@ public class OAS3Parser extends APIDefinition {
                 continue;
             }
 
-            OperationMatch match = findMatchingOperation(backendDefinition, backendOperation.getTarget(),
+            // Resolve each tool against its own parse of the definition. Resolving a schema writes
+            // the expanded content back onto the components it walks, so sharing one parsed
+            // definition would let the first tool's resolution change what the later ones see: a
+            // tool whose body is a schema an earlier tool reached through a circular reference would
+            // inherit that truncation instead of expanding it.
+            OpenAPI toolDefinition = getOpenAPI(backendApiDefinition);
+            mergePathParametersIntoOperations(toolDefinition);
+            OperationMatch match = findMatchingOperation(toolDefinition, backendOperation.getTarget(),
                     backendOperation.getVerb());
 
             if (match != null) {
-                URITemplate populated = populateURITemplate(template, match, backendDefinition, backendId, refApiId,
+                URITemplate populated = populateURITemplate(template, match, toolDefinition, backendId, refApiId,
                         false);
                 if (!tools.add(populated.getUriTemplate())) {
                     log.error("Duplicate MCP tool detected: " + populated.getUriTemplate());
@@ -3275,30 +3289,74 @@ public class OAS3Parser extends APIDefinition {
 
     /**
      * Resolves a schema by recursively resolving $ref, allOf, oneOf, anyOf, and not properties.
-     * This version tracks visited references to prevent circular references.
+     * This version tracks the references already visited on the current resolution path so that a
+     * circular reference terminates instead of recursing until the stack overflows.
+     * <p>
+     * The visited set is the path currently being walked, not everything seen so far: each reference
+     * is removed again as the recursion unwinds, so a schema referenced from two unrelated places is
+     * still expanded at both. Every nested call must be given this same set - starting a fresh one
+     * loses the path, which is what made a cycle through a schema's properties recurse forever.
      *
      * @param schema      Schema to resolve
      * @param openAPI     OpenAPI definition to resolve against
-     * @param visitedRefs Set of visited reference names to detect circular references
+     * @param visitedRefs Set of visited reference keys on the current resolution path
      * @return Resolved Schema object
      */
     private Schema<?> resolveSchema(Schema<?> schema, OpenAPI openAPI, Set<String> visitedRefs) {
 
         if (schema == null) return null;
 
+        String heldRefKey = null;
         if (schema.get$ref() != null) {
-            schema = resolveComponentRef(schema.get$ref(), openAPI, visitedRefs, Schema.class);
+            String ref = schema.get$ref();
+            String refKey = componentRefKey(ref);
+            if (refKey != null && visitedRefs.contains(refKey)) {
+                log.warn("Circular reference truncated while resolving schema reference: " + ref);
+                return unexpandedObjectSchema(schema, ref);
+            }
+            schema = resolveComponentRef(ref, openAPI, visitedRefs, Schema.class);
+            if (schema == null) {
+                return null;
+            }
+            // resolveComponentRef releases the reference as soon as its lookup finishes. Hold it
+            // again for the whole traversal of the resolved schema's body, otherwise a schema that
+            // refers back to itself is looked up afresh at every level and never terminates.
+            if (refKey != null) {
+                visitedRefs.add(refKey);
+                heldRefKey = refKey;
+            }
         }
-        if (schema == null) {
-            return null;
+        try {
+            return resolveSchemaBody(schema, openAPI, visitedRefs);
+        } finally {
+            if (heldRefKey != null) {
+                visitedRefs.remove(heldRefKey);
+            }
         }
+    }
+
+    /**
+     * Resolves the composition keywords, properties, items and additional properties of a schema
+     * that has already been dereferenced. Split out of {@link #resolveSchema(Schema, OpenAPI, Set)}
+     * so that the reference the schema came from stays on the visited path for the whole traversal.
+     *
+     * @param schema      dereferenced schema whose body should be resolved
+     * @param openAPI     OpenAPI definition to resolve against
+     * @param visitedRefs Set of visited reference keys on the current resolution path
+     * @return Resolved Schema object
+     */
+    private Schema<?> resolveSchemaBody(Schema<?> schema, OpenAPI openAPI, Set<String> visitedRefs) {
+
         // Resolve allOf
         if (schema.getAllOf() != null && !schema.getAllOf().isEmpty()) {
             Schema<?> merged = new ObjectSchema();
             Map<String, Schema> mergedProps = new LinkedHashMap<>();
             List<String> mergedRequired = new ArrayList<>();
             for (Schema<?> part : schema.getAllOf()) {
-                Schema<?> resolved = resolveSchema(part, openAPI);
+                Schema<?> resolved = resolveSchema(part, openAPI, visitedRefs);
+                if (resolved == null) {
+                    continue;
+                }
                 if (resolved.getProperties() != null) mergedProps.putAll(resolved.getProperties());
                 if (resolved.getRequired() != null) mergedRequired.addAll(resolved.getRequired());
             }
@@ -3310,39 +3368,82 @@ public class OAS3Parser extends APIDefinition {
         // oneOf / anyOf
         if (schema.getOneOf() != null) {
             schema.setOneOf(schema.getOneOf().stream()
-                    .map(s -> resolveSchema(s, openAPI))
+                    .map(s -> resolveSchema(s, openAPI, visitedRefs))
                     .collect(Collectors.toList()));
         }
 
         if (schema.getAnyOf() != null) {
             schema.setAnyOf(schema.getAnyOf().stream()
-                    .map(s -> resolveSchema(s, openAPI))
+                    .map(s -> resolveSchema(s, openAPI, visitedRefs))
                     .collect(Collectors.toList()));
         }
         if (schema.getNot() != null) {
-            schema.setNot(resolveSchema(schema.getNot(), openAPI));
+            schema.setNot(resolveSchema(schema.getNot(), openAPI, visitedRefs));
         }
 
         // Recursively resolve properties
         if (schema.getProperties() != null) {
             Map<String, Schema> resolvedProps = new LinkedHashMap<>();
             for (Map.Entry<String, Schema> entry : schema.getProperties().entrySet()) {
-                resolvedProps.put(entry.getKey(), resolveSchema(entry.getValue(), openAPI));
+                resolvedProps.put(entry.getKey(), resolveSchema(entry.getValue(), openAPI, visitedRefs));
             }
             schema.setProperties(resolvedProps);
         }
 
         // Array items
         if ("array".equals(schema.getType()) && schema.getItems() != null) {
-            schema.setItems(resolveSchema(schema.getItems(), openAPI));
+            schema.setItems(resolveSchema(schema.getItems(), openAPI, visitedRefs));
         }
 
         // Additional properties
         if (schema.getAdditionalProperties() instanceof Schema) {
-            schema.setAdditionalProperties(resolveSchema((Schema<?>) schema.getAdditionalProperties(), openAPI));
+            schema.setAdditionalProperties(
+                    resolveSchema((Schema<?>) schema.getAdditionalProperties(), openAPI, visitedRefs));
         }
 
         return schema;
+    }
+
+    /**
+     * Builds the schema emitted in place of a reference that closes a circular chain. An object with
+     * no declared properties states what is true of it - the field takes an object, whose shape
+     * cannot be written out without recursing forever. Dropping the field instead would claim the
+     * API does not accept it, and returning the reference unresolved would leave a $ref no consumer
+     * can follow, because the generated schema carries no components section.
+     *
+     * @param original the reference that could not be expanded
+     * @param ref      the reference string it points at
+     * @return an object schema standing in for the unexpanded reference
+     */
+    private Schema<?> unexpandedObjectSchema(Schema<?> original, String ref) {
+        ObjectSchema placeholder = new ObjectSchema();
+        if (original != null && StringUtils.isNotBlank(original.getDescription())) {
+            placeholder.setDescription(original.getDescription());
+        } else {
+            placeholder.setDescription("Circular reference to '" + ref
+                    + "'; nested properties are omitted.");
+        }
+        return placeholder;
+    }
+
+    /**
+     * Derives the key used to track a component reference on the current resolution path. Kept in
+     * one place so that the cycle check in {@link #resolveSchema(Schema, OpenAPI, Set)} and the one
+     * in {@link #resolveComponentRef(String, OpenAPI, Set, Class)} always agree.
+     *
+     * @param ref Reference string (e.g. "#/components/schemas/ComponentName")
+     * @return the tracking key, or null if this is not a resolvable component reference
+     */
+    private String componentRefKey(String ref) {
+        if (ref == null || !ref.startsWith("#/components/")) {
+            return null;
+        }
+        String[] parts = ref.split("/");
+        if (parts.length < 4) {
+            return null;
+        }
+        String name = parts[3].replace("~1", "/").replace("~0", "~"); // JSON Pointer unescape
+        return parts[2] + ":" + name;
     }
 
     /**
@@ -3371,9 +3472,13 @@ public class OAS3Parser extends APIDefinition {
             log.warn("Malformed component reference: " + ref);
             return null;
         }
-        String category = parts[2];
-        String name = parts[3].replace("~1", "/").replace("~0", "~"); // JSON Pointer unescape
-        String refKey = category + ":" + name;
+        // Past both guards above componentRefKey cannot return null - they are exactly its own
+        // conditions - so category and name are derived from the very key the cycle check uses,
+        // and the JSON Pointer unescape rule stays in one place.
+        String refKey = componentRefKey(ref);
+        int separator = refKey.indexOf(':');
+        String category = refKey.substring(0, separator);
+        String name = refKey.substring(separator + 1);
         if (visitedRefs.contains(refKey)) {
             if (log.isDebugEnabled()) {
                 log.debug("Circular reference detected: " + refKey);
@@ -3381,38 +3486,45 @@ public class OAS3Parser extends APIDefinition {
             return null;
         }
         visitedRefs.add(refKey);
-        Object resolved = null;
-        if (openAPI == null || openAPI.getComponents() == null) {
-            return null;
-        }
-        switch (category) {
-            case APISpecParserConstants.SCHEMAS:
-                resolved = openAPI.getComponents().getSchemas() != null ?
-                        openAPI.getComponents().getSchemas().get(name) : null;
-                break;
-            case APISpecParserConstants.REQUEST_BODIES:
-                resolved = openAPI.getComponents().getRequestBodies() != null ?
-                        openAPI.getComponents().getRequestBodies().get(name) : null;
-                break;
-            case APISpecParserConstants.PARAMETERS:
-                resolved = openAPI.getComponents().getParameters() != null ?
-                        openAPI.getComponents().getParameters().get(name) : null;
-                break;
-            default:
+        // Removed again on the way out so the set stays the path currently being walked. Keeping it
+        // would leave a component unresolved the second time it is referenced from an unrelated
+        // place - for instance an allOf whose two branches both compose the same schema.
+        try {
+            Object resolved = null;
+            if (openAPI == null || openAPI.getComponents() == null) {
                 return null;
+            }
+            switch (category) {
+                case APISpecParserConstants.SCHEMAS:
+                    resolved = openAPI.getComponents().getSchemas() != null ?
+                            openAPI.getComponents().getSchemas().get(name) : null;
+                    break;
+                case APISpecParserConstants.REQUEST_BODIES:
+                    resolved = openAPI.getComponents().getRequestBodies() != null ?
+                            openAPI.getComponents().getRequestBodies().get(name) : null;
+                    break;
+                case APISpecParserConstants.PARAMETERS:
+                    resolved = openAPI.getComponents().getParameters() != null ?
+                            openAPI.getComponents().getParameters().get(name) : null;
+                    break;
+                default:
+                    return null;
+            }
+            if (resolved == null) {
+                log.warn("Unknown component category: " + category + " in reference: " + ref);
+                return null;
+            }
+            if (resolved instanceof Schema && ((Schema<?>) resolved).get$ref() != null) {
+                return (T) resolveComponentRef(((Schema<?>) resolved).get$ref(), openAPI, visitedRefs, expectedType);
+            } else if (resolved instanceof RequestBody && ((RequestBody) resolved).get$ref() != null) {
+                return (T) resolveComponentRef(((RequestBody) resolved).get$ref(), openAPI, visitedRefs, expectedType);
+            } else if (resolved instanceof Parameter && ((Parameter) resolved).get$ref() != null) {
+                return (T) resolveComponentRef(((Parameter) resolved).get$ref(), openAPI, visitedRefs, expectedType);
+            }
+            return expectedType.isInstance(resolved) ? expectedType.cast(resolved) : null;
+        } finally {
+            visitedRefs.remove(refKey);
         }
-        if (resolved == null) {
-            log.warn("Unknown component category: " + category + " in reference: " + ref);
-            return null;
-        }
-        if (resolved instanceof Schema && ((Schema<?>) resolved).get$ref() != null) {
-            return (T) resolveComponentRef(((Schema<?>) resolved).get$ref(), openAPI, visitedRefs, expectedType);
-        } else if (resolved instanceof RequestBody && ((RequestBody) resolved).get$ref() != null) {
-            return (T) resolveComponentRef(((RequestBody) resolved).get$ref(), openAPI, visitedRefs, expectedType);
-        } else if (resolved instanceof Parameter && ((Parameter) resolved).get$ref() != null) {
-            return (T) resolveComponentRef(((Parameter) resolved).get$ref(), openAPI, visitedRefs, expectedType);
-        }
-        return expectedType.isInstance(resolved) ? expectedType.cast(resolved) : null;
     }
 
     /**

--- a/components/apimgt/org.wso2.carbon.apimgt.spec.parser/src/test/java/org/wso2/carbon/apimgt/spec/parser/definitions/OAS2ParserTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.spec.parser/src/test/java/org/wso2/carbon/apimgt/spec/parser/definitions/OAS2ParserTest.java
@@ -546,6 +546,13 @@ public class OAS2ParserTest extends OASTestBase {
         Assert.assertTrue("The circular field should still be declared", props.has("parent"));
         Assert.assertEquals("An unexpanded cycle should render as a plain object",
                 "object", props.path("parent").path("type").asText());
+        // The description is the only signal an agent has that content was omitted rather than
+        // genuinely absent, and it is the only place the omitted model is named.
+        String description = props.path("parent").path("description").asText();
+        Assert.assertTrue("An unexpanded cycle should say that its nested properties were omitted, "
+                + "but the description was: " + description, description.contains("omitted"));
+        Assert.assertTrue("The description should name the model that was omitted, "
+                + "but the description was: " + description, description.contains("Comment"));
     }
 
     @Test(timeout = CIRCULAR_TIMEOUT_MS)

--- a/components/apimgt/org.wso2.carbon.apimgt.spec.parser/src/test/java/org/wso2/carbon/apimgt/spec/parser/definitions/OAS2ParserTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.spec.parser/src/test/java/org/wso2/carbon/apimgt/spec/parser/definitions/OAS2ParserTest.java
@@ -33,6 +33,7 @@ import org.junit.Test;
 import org.mockito.Mockito;
 import io.swagger.models.properties.AbstractProperty;
 import io.swagger.models.properties.ArrayProperty;
+import io.swagger.models.properties.ComposedProperty;
 import io.swagger.models.properties.MapProperty;
 import io.swagger.models.properties.ObjectProperty;
 import org.wso2.carbon.apimgt.api.APIConstants;
@@ -858,6 +859,7 @@ public class OAS2ParserTest extends OASTestBase {
         assertDeclaredFields(ArrayProperty.class, "TYPE", "uniqueItems", "items", "maxItems", "minItems");
         assertDeclaredFields(ObjectProperty.class, "TYPE", "properties");
         assertDeclaredFields(MapProperty.class, "property", "minProperties", "maxProperties");
+        assertDeclaredFields(ComposedProperty.class, "TYPE", "allOf");
     }
 
     private void assertDeclaredFields(Class<?> type, String... expected) {
@@ -1024,6 +1026,74 @@ public class OAS2ParserTest extends OASTestBase {
                 "integer", props.path("query_limit").path("type").asText());
         Assert.assertEquals("The circular body should still resolve alongside the parameters",
                 "string", props.path("requestBody").path("properties").path("text").path("type").asText());
+        assertNoUnresolvedReference(schema, "");
+    }
+
+    /**
+     * A property written as an inline allOf parses to a ComposedProperty. resolveProperty handled
+     * Ref, Array, Map and Object properties only, so its allOf entries were never traversed and any
+     * $ref inside them survived into the generated schema.
+     */
+    @Test(timeout = CIRCULAR_TIMEOUT_MS)
+    public void testComposedPropertyIsMergedIntoOneObject() throws Exception {
+        String definition = swagger20("/entries", "Entry",
+                "    \"Common\": { \"type\": \"object\",\n"
+                + "      \"properties\": { \"id\": { \"type\": \"string\" } } },\n"
+                + "    \"Entry\": { \"type\": \"object\", \"properties\": {\n"
+                + "        \"merged\": { \"allOf\": [ { \"$ref\": \"#/definitions/Common\" },\n"
+                + "            { \"type\": \"object\",\n"
+                + "              \"properties\": { \"note\": { \"type\": \"string\" } } } ] } } }");
+
+        JsonNode schema = generateToolSchema(definition, "/entries");
+        JsonNode merged = requestBodyProperties(schema).path("merged");
+
+        Assert.assertEquals("The composed property should render as one object",
+                "object", merged.path("type").asText());
+        Assert.assertEquals("Properties from the referenced part should be merged in",
+                "string", merged.path("properties").path("id").path("type").asText());
+        Assert.assertEquals("Properties declared inline should be merged in",
+                "string", merged.path("properties").path("note").path("type").asText());
+        assertNoUnresolvedReference(schema, "");
+    }
+
+    /** A composed property whose allOf points back at an enclosing model must still terminate. */
+    @Test(timeout = CIRCULAR_TIMEOUT_MS)
+    public void testCircularComposedPropertyTerminates() throws Exception {
+        String definition = swagger20("/nodes", "Node",
+                "    \"Node\": { \"type\": \"object\", \"properties\": {\n"
+                + "        \"label\": { \"type\": \"string\" },\n"
+                + "        \"child\": { \"allOf\": [ { \"$ref\": \"#/definitions/Node\" } ] } } }");
+
+        JsonNode schema = generateToolSchema(definition, "/nodes");
+        JsonNode props = requestBodyProperties(schema);
+
+        Assert.assertEquals("string", props.path("label").path("type").asText());
+        Assert.assertTrue("The composed field should still be declared", props.has("child"));
+        assertNoUnresolvedReference(schema, "");
+    }
+
+    /**
+     * A reference naming a definition that does not exist. It fails to resolve exactly as a
+     * circular one does, but it is not a cycle: the field is dropped rather than being emitted with
+     * an unresolved $ref, matching how OAS3Parser treats an undeclared component.
+     */
+    @Test(timeout = CIRCULAR_TIMEOUT_MS)
+    public void testUnknownDefinitionReferenceIsDropped() throws Exception {
+        String definition = swagger20("/holders", "Holder",
+                "    \"Holder\": {\n"
+                + "      \"type\": \"object\",\n"
+                + "      \"properties\": {\n"
+                + "        \"name\":    { \"type\": \"string\" },\n"
+                + "        \"missing\": { \"$ref\": \"#/definitions/DoesNotExist\" }\n"
+                + "      }\n"
+                + "    }");
+
+        JsonNode schema = generateToolSchema(definition, "/holders");
+        JsonNode props = requestBodyProperties(schema);
+
+        Assert.assertEquals("string", props.path("name").path("type").asText());
+        Assert.assertFalse("An undefined reference should not survive in the schema",
+                props.has("missing"));
         assertNoUnresolvedReference(schema, "");
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.spec.parser/src/test/java/org/wso2/carbon/apimgt/spec/parser/definitions/OAS2ParserTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.spec.parser/src/test/java/org/wso2/carbon/apimgt/spec/parser/definitions/OAS2ParserTest.java
@@ -36,6 +36,8 @@ import io.swagger.models.properties.ArrayProperty;
 import io.swagger.models.properties.ComposedProperty;
 import io.swagger.models.properties.MapProperty;
 import io.swagger.models.properties.ObjectProperty;
+import io.swagger.models.properties.Property;
+import io.swagger.models.properties.StringProperty;
 import org.wso2.carbon.apimgt.api.APIConstants;
 import org.wso2.carbon.apimgt.api.APIDefinition;
 import org.wso2.carbon.apimgt.api.APIDefinitionValidationResponse;
@@ -50,7 +52,10 @@ import org.wso2.carbon.apimgt.api.model.URITemplate;
 
 import java.io.File;
 import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -852,7 +857,7 @@ public class OAS2ParserTest extends OASTestBase {
      * copyCommonPropertyFields before updating the expected names here.
      */
     @Test
-    public void testCopiedPropertyFieldsAreStillComplete() {
+    public void testPropertyFieldsHaveNotChanged() {
         assertDeclaredFields(AbstractProperty.class, "name", "type", "format", "example", "xml",
                 "required", "position", "description", "title", "readOnly", "allowEmptyValue",
                 "access", "vendorExtensions", "booleanValue");
@@ -1095,5 +1100,144 @@ public class OAS2ParserTest extends OASTestBase {
         Assert.assertFalse("An undefined reference should not survive in the schema",
                 props.has("missing"));
         assertNoUnresolvedReference(schema, "");
+    }
+
+    /**
+     * Fields that resolution deliberately does not carry across to a rebuilt property.
+     */
+    private static final Set<String> FIELDS_NOT_CARRIED = new HashSet<>(Arrays.asList(
+            "type",   // each property class fixes its own type in its constructor
+            "xml"));  // swagger-models exposes no getter, so it can neither be copied nor serialised
+
+    /**
+     * Fields holding nested content, which resolution rewrites by design. Checked for presence
+     * rather than equality.
+     */
+    private static final Set<String> FIELDS_RESOLVED = new HashSet<>(Arrays.asList(
+            "items",       // ArrayProperty
+            "properties",  // ObjectProperty
+            "property",    // MapProperty, its additionalProperties
+            "allOf"));     // ComposedProperty
+
+    /**
+     * Verifies behaviourally that resolution carries every field a property declares.
+     *
+     * Resolution rebuilds properties rather than editing them in place, so anything the rebuild
+     * forgets is dropped silently from every generated schema. testPropertyFieldsHaveNotChanged
+     * only notices when swagger-models changes shape; this drives the copy itself, so a field added
+     * to these classes fails here by name even if someone updates that list without updating the
+     * copy.
+     */
+    @Test
+    public void testResolutionCarriesEveryDeclaredPropertyField() throws Exception {
+        Swagger swagger = new SwaggerParser().parse(swagger20("/x", "Empty",
+                "    \"Empty\": { \"type\": \"object\", \"properties\": {} }"));
+
+        for (Class<? extends AbstractProperty> type : Arrays.asList(
+                ArrayProperty.class, ObjectProperty.class, MapProperty.class, ComposedProperty.class)) {
+
+            AbstractProperty source = type.getDeclaredConstructor().newInstance();
+            for (Field f : declaredFieldsOf(type)) {
+                Object value = sampleValue(f);
+                if (value != null) {
+                    f.setAccessible(true);
+                    f.set(source, value);
+                }
+            }
+
+            Property resolved = invokeResolveProperty(source, swagger);
+            Assert.assertNotNull(type.getSimpleName() + " should resolve to a property", resolved);
+
+            for (Field f : declaredFieldsOf(type)) {
+                String name = f.getName();
+                if (FIELDS_NOT_CARRIED.contains(name)) {
+                    continue;
+                }
+                f.setAccessible(true);
+                Object before = f.get(source);
+                if (FIELDS_RESOLVED.contains(name)) {
+                    // rewritten by design; only its presence is meaningful
+                    Field target = fieldOn(resolved.getClass(), name);
+                    if (target != null) {
+                        target.setAccessible(true);
+                        Assert.assertNotNull(type.getSimpleName() + "." + name
+                                + " lost its nested content during resolution", target.get(resolved));
+                    }
+                    continue;
+                }
+                Field target = fieldOn(resolved.getClass(), name);
+                Assert.assertNotNull(type.getSimpleName() + "." + name
+                        + " has no counterpart on the resolved property", target);
+                target.setAccessible(true);
+                Assert.assertEquals(type.getSimpleName() + "." + name
+                                + " was not carried across by resolution - add it to "
+                                + "OAS2Parser.copyCommonPropertyFields or to the branch that "
+                                + "rebuilds this property type",
+                        before, target.get(resolved));
+            }
+        }
+    }
+
+    /** Declared fields of the class itself plus those it inherits from AbstractProperty. */
+    private List<Field> declaredFieldsOf(Class<?> type) {
+        List<Field> fields = new ArrayList<>();
+        for (Class<?> c = type; c != null && AbstractProperty.class.isAssignableFrom(c); c = c.getSuperclass()) {
+            for (Field f : c.getDeclaredFields()) {
+                if (!f.isSynthetic() && !java.lang.reflect.Modifier.isStatic(f.getModifiers())) {
+                    fields.add(f);
+                }
+            }
+        }
+        return fields;
+    }
+
+    private Field fieldOn(Class<?> type, String name) {
+        for (Class<?> c = type; c != null; c = c.getSuperclass()) {
+            try {
+                return c.getDeclaredField(name);
+            } catch (NoSuchFieldException ignored) {
+                // keep walking up
+            }
+        }
+        return null;
+    }
+
+    private Object sampleValue(Field f) {
+        Class<?> t = f.getType();
+        String name = f.getName();
+        if (FIELDS_NOT_CARRIED.contains(name)) {
+            return null;
+        }
+        if (t == String.class) {
+            return "value-of-" + name;
+        }
+        if (t == Boolean.class || t == boolean.class) {
+            return Boolean.TRUE;
+        }
+        if (t == Integer.class) {
+            return 7;
+        }
+        if (t == java.util.List.class) {
+            return Collections.singletonList(new ObjectProperty());
+        }
+        if (t == java.util.Map.class) {
+            return "vendorExtensions".equals(name)
+                    ? Collections.singletonMap("x-sample", (Object) "on")
+                    : Collections.singletonMap("nested", new StringProperty());
+        }
+        if (Property.class.isAssignableFrom(t)) {
+            return new StringProperty();
+        }
+        if (t == Object.class) {
+            return "example-of-" + name;
+        }
+        return null;
+    }
+
+    private Property invokeResolveProperty(Property property, Swagger swagger) throws Exception {
+        Method m = OAS2Parser.class.getDeclaredMethod("resolveProperty",
+                Property.class, Swagger.class, Set.class);
+        m.setAccessible(true);
+        return (Property) m.invoke(oas2Parser, property, swagger, new HashSet<String>());
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.spec.parser/src/test/java/org/wso2/carbon/apimgt/spec/parser/definitions/OAS2ParserTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.spec.parser/src/test/java/org/wso2/carbon/apimgt/spec/parser/definitions/OAS2ParserTest.java
@@ -941,4 +941,39 @@ public class OAS2ParserTest extends OASTestBase {
                         .path("sku").path("type").asText());
         assertNoUnresolvedReference(schema, "");
     }
+
+    /**
+     * A property referencing an allOf model. resolveModel merges composed models, but resolveProperty
+     * used to expand a reference only when its target was a plain model, so this came back as an
+     * unresolved $ref pointing at a definitions section the generated schema does not carry.
+     */
+    @Test(timeout = CIRCULAR_TIMEOUT_MS)
+    public void testPropertyReferenceToComposedModelIsExpanded() throws Exception {
+        String definition = swagger20("/records", "Record",
+                "    \"Common\": {\n"
+                + "      \"type\": \"object\",\n"
+                + "      \"properties\": { \"id\": { \"type\": \"string\" } }\n"
+                + "    },\n"
+                + "    \"Left\": {\n"
+                + "      \"allOf\": [\n"
+                + "        { \"$ref\": \"#/definitions/Common\" },\n"
+                + "        { \"type\": \"object\", \"properties\": { \"leftField\": { \"type\": \"string\" } } }\n"
+                + "      ]\n"
+                + "    },\n"
+                + "    \"Record\": {\n"
+                + "      \"type\": \"object\",\n"
+                + "      \"properties\": { \"left\": { \"$ref\": \"#/definitions/Left\" } }\n"
+                + "    }");
+
+        JsonNode schema = generateToolSchema(definition, "/records");
+        JsonNode left = requestBodyProperties(schema).path("left");
+
+        Assert.assertEquals("The composed model should expand to an object",
+                "object", left.path("type").asText());
+        Assert.assertEquals("Properties inherited through allOf should be present",
+                "string", left.path("properties").path("id").path("type").asText());
+        Assert.assertEquals("Properties declared inline in the allOf should be present",
+                "string", left.path("properties").path("leftField").path("type").asText());
+        assertNoUnresolvedReference(schema, "");
+    }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.spec.parser/src/test/java/org/wso2/carbon/apimgt/spec/parser/definitions/OAS2ParserTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.spec.parser/src/test/java/org/wso2/carbon/apimgt/spec/parser/definitions/OAS2ParserTest.java
@@ -19,6 +19,8 @@
 
 package org.wso2.carbon.apimgt.spec.parser.definitions;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.models.HttpMethod;
 import io.swagger.models.Operation;
 import io.swagger.models.Path;
@@ -29,23 +31,34 @@ import org.apache.commons.io.IOUtils;
 import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito;
+import io.swagger.models.properties.AbstractProperty;
+import io.swagger.models.properties.ArrayProperty;
+import io.swagger.models.properties.ObjectProperty;
+import org.wso2.carbon.apimgt.api.APIConstants;
 import org.wso2.carbon.apimgt.api.APIDefinition;
 import org.wso2.carbon.apimgt.api.APIDefinitionValidationResponse;
 import org.wso2.carbon.apimgt.api.ExceptionCodes;
 import org.wso2.carbon.apimgt.api.model.API;
 import org.wso2.carbon.apimgt.api.model.APIIdentifier;
+import org.wso2.carbon.apimgt.api.model.BackendOperation;
+import org.wso2.carbon.apimgt.api.model.BackendOperationMapping;
 import org.wso2.carbon.apimgt.api.model.Scope;
 import org.wso2.carbon.apimgt.api.model.SwaggerData;
 import org.wso2.carbon.apimgt.api.model.URITemplate;
 
 import java.io.File;
+import java.lang.reflect.Field;
+import java.util.Arrays;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
 
 import static org.mockito.Mockito.when;
 
@@ -416,4 +429,440 @@ public class OAS2ParserTest extends OASTestBase {
         return apiScopes;
     }
 
+    // -------------------------------------------------------------------------
+    // Circular $ref handling in MCP tool schema generation.
+    //
+    // resolveModel and resolveProperty are mutually recursive. Each used to start a fresh
+    // visitedRefs set instead of passing on the one it was given, so a cycle running through a
+    // model's properties lost the path and recursed until the stack overflowed. These cover the
+    // shapes a self-referential model actually takes, and the case a naive fix breaks: a model
+    // referenced twice from unrelated places must still be expanded at both.
+    //
+    // Every test carries a timeout so a regression fails rather than hanging the build.
+    // -------------------------------------------------------------------------
+
+    private static final int CIRCULAR_TIMEOUT_MS = 30000;
+    private static final String CIRCULAR_BACKEND_ID = "forum-backend";
+    private static final APIIdentifier CIRCULAR_REF_API_ID =
+            new APIIdentifier("admin", "ForumAPI", "1.0.0");
+    private final ObjectMapper circularMapper = new ObjectMapper();
+
+    private static String swagger20(String path, String bodyRef, String definitions) {
+        return "{\n"
+                + "  \"swagger\": \"2.0\",\n"
+                + "  \"info\": { \"title\": \"Forum\", \"version\": \"1.0\" },\n"
+                + "  \"paths\": {\n"
+                + "    \"" + path + "\": {\n"
+                + "      \"post\": {\n"
+                + "        \"parameters\": [\n"
+                + "          { \"name\": \"body\", \"in\": \"body\",\n"
+                + "            \"schema\": { \"$ref\": \"#/definitions/" + bodyRef + "\" } }\n"
+                + "        ],\n"
+                + "        \"responses\": { \"200\": { \"description\": \"OK\" } }\n"
+                + "      }\n"
+                + "    }\n"
+                + "  },\n"
+                + "  \"definitions\": {\n" + definitions + "\n  }\n"
+                + "}";
+    }
+
+    private URITemplate mcpTool(String name, String target, String verb) {
+        URITemplate template = new URITemplate();
+        template.setUriTemplate(name);
+        template.setHTTPVerb(APISpecParserConstants.HTTP_VERB_TOOL);
+        BackendOperationMapping mapping = new BackendOperationMapping();
+        mapping.setBackendId(CIRCULAR_BACKEND_ID);
+        BackendOperation op = new BackendOperation();
+        op.setTarget(target);
+        op.setVerb(APIConstants.SupportedHTTPVerbs.valueOf(verb));
+        mapping.setBackendOperation(op);
+        template.setBackendOperationMapping(mapping);
+        return template;
+    }
+
+    private JsonNode generateToolSchema(String definition, String target) throws Exception {
+        Set<URITemplate> templates = new LinkedHashSet<>();
+        templates.add(mcpTool("theTool", target, "POST"));
+        Set<URITemplate> result = oas2Parser.generateMCPTools(definition, CIRCULAR_REF_API_ID,
+                CIRCULAR_BACKEND_ID, APISpecParserConstants.API_SUBTYPE_DIRECT_BACKEND, templates);
+        Assert.assertEquals("Expected exactly one generated tool", 1, result.size());
+        String schema = result.iterator().next().getSchemaDefinition();
+        Assert.assertNotNull("A schema should have been generated", schema);
+        return circularMapper.readTree(schema);
+    }
+
+    private JsonNode requestBodyProperties(JsonNode schema) {
+        JsonNode requestBody = schema.path("properties").path("requestBody");
+        Assert.assertTrue("Schema should carry a requestBody property",
+                schema.path("properties").has("requestBody"));
+        Assert.assertTrue("requestBody should carry its resolved properties",
+                requestBody.has("properties"));
+        return requestBody.path("properties");
+    }
+
+    /**
+     * Walks the whole tree looking for a leftover reference. The generated schema carries no
+     * definitions section, so any surviving $ref would point at nothing.
+     */
+    private void assertNoUnresolvedReference(JsonNode node, String path) {
+        if (node.isObject()) {
+            Iterator<String> names = node.fieldNames();
+            while (names.hasNext()) {
+                String name = names.next();
+                Assert.assertNotEquals("Unresolved reference left at " + path + "/" + name,
+                        "$ref", name);
+                assertNoUnresolvedReference(node.get(name), path + "/" + name);
+            }
+        } else if (node.isArray()) {
+            for (int i = 0; i < node.size(); i++) {
+                assertNoUnresolvedReference(node.get(i), path + "/" + i);
+            }
+        }
+    }
+
+    @Test(timeout = CIRCULAR_TIMEOUT_MS)
+    public void testCircularRefThroughFieldTerminates() throws Exception {
+        String definition = swagger20("/comments", "Comment",
+                "    \"Comment\": {\n"
+                + "      \"type\": \"object\",\n"
+                + "      \"required\": [\"text\"],\n"
+                + "      \"properties\": {\n"
+                + "        \"text\": { \"type\": \"string\" },\n"
+                + "        \"parent\": { \"$ref\": \"#/definitions/Comment\" }\n"
+                + "      }\n"
+                + "    }");
+
+        JsonNode props = requestBodyProperties(generateToolSchema(definition, "/comments"));
+
+        Assert.assertEquals("A non-circular sibling should still resolve",
+                "string", props.path("text").path("type").asText());
+        Assert.assertTrue("The circular field should still be declared", props.has("parent"));
+        Assert.assertEquals("An unexpanded cycle should render as a plain object",
+                "object", props.path("parent").path("type").asText());
+    }
+
+    @Test(timeout = CIRCULAR_TIMEOUT_MS)
+    public void testCircularRefThroughListTerminates() throws Exception {
+        String definition = swagger20("/comments", "Comment",
+                "    \"Comment\": {\n"
+                + "      \"type\": \"object\",\n"
+                + "      \"properties\": {\n"
+                + "        \"text\": { \"type\": \"string\" },\n"
+                + "        \"replies\": {\n"
+                + "          \"type\": \"array\",\n"
+                + "          \"items\": { \"$ref\": \"#/definitions/Comment\" }\n"
+                + "        }\n"
+                + "      }\n"
+                + "    }");
+
+        JsonNode props = requestBodyProperties(generateToolSchema(definition, "/comments"));
+
+        Assert.assertEquals("array", props.path("replies").path("type").asText());
+        Assert.assertEquals("The recursive item type should still be described",
+                "object", props.path("replies").path("items").path("type").asText());
+    }
+
+    @Test(timeout = CIRCULAR_TIMEOUT_MS)
+    public void testIndirectCircularRefTerminates() throws Exception {
+        String definition = swagger20("/threads", "Thread",
+                "    \"Thread\": {\n"
+                + "      \"type\": \"object\",\n"
+                + "      \"properties\": {\n"
+                + "        \"title\": { \"type\": \"string\" },\n"
+                + "        \"author\": { \"$ref\": \"#/definitions/User\" }\n"
+                + "      }\n"
+                + "    },\n"
+                + "    \"User\": {\n"
+                + "      \"type\": \"object\",\n"
+                + "      \"properties\": {\n"
+                + "        \"name\": { \"type\": \"string\" },\n"
+                + "        \"lastThread\": { \"$ref\": \"#/definitions/Thread\" }\n"
+                + "      }\n"
+                + "    }");
+
+        JsonNode props = requestBodyProperties(generateToolSchema(definition, "/threads"));
+        JsonNode author = props.path("author");
+
+        Assert.assertEquals("The intermediate model should expand",
+                "string", author.path("properties").path("name").path("type").asText());
+        Assert.assertEquals("The back-reference should still be described",
+                "object", author.path("properties").path("lastThread").path("type").asText());
+    }
+
+    @Test(timeout = CIRCULAR_TIMEOUT_MS)
+    public void testCircularRefThroughNestedObjectTerminates() throws Exception {
+        String definition = swagger20("/comments", "Comment",
+                "    \"Comment\": {\n"
+                + "      \"type\": \"object\",\n"
+                + "      \"properties\": {\n"
+                + "        \"text\": { \"type\": \"string\" },\n"
+                + "        \"meta\": {\n"
+                + "          \"type\": \"object\",\n"
+                + "          \"properties\": {\n"
+                + "            \"origin\": { \"$ref\": \"#/definitions/Comment\" }\n"
+                + "          }\n"
+                + "        }\n"
+                + "      }\n"
+                + "    }");
+
+        JsonNode props = requestBodyProperties(generateToolSchema(definition, "/comments"));
+
+        Assert.assertEquals("The inline object should survive",
+                "object", props.path("meta").path("type").asText());
+        Assert.assertEquals("The cycle inside the inline object should be described",
+                "object", props.path("meta").path("properties").path("origin").path("type").asText());
+    }
+
+    @Test(timeout = CIRCULAR_TIMEOUT_MS)
+    public void testCircularRefThroughAllOfTerminates() throws Exception {
+        String definition = swagger20("/nodes", "Node",
+                "    \"Audit\": {\n"
+                + "      \"type\": \"object\",\n"
+                + "      \"properties\": { \"createdBy\": { \"type\": \"string\" } }\n"
+                + "    },\n"
+                + "    \"Node\": {\n"
+                + "      \"allOf\": [\n"
+                + "        { \"$ref\": \"#/definitions/Audit\" },\n"
+                + "        { \"type\": \"object\",\n"
+                + "          \"properties\": {\n"
+                + "            \"label\": { \"type\": \"string\" },\n"
+                + "            \"child\": { \"$ref\": \"#/definitions/Node\" }\n"
+                + "          }\n"
+                + "        }\n"
+                + "      ]\n"
+                + "    }");
+
+        JsonNode props = requestBodyProperties(generateToolSchema(definition, "/nodes"));
+
+        Assert.assertTrue("Properties merged from the composed model should be present",
+                props.has("createdBy"));
+        Assert.assertTrue("Properties declared inline in the allOf should be present",
+                props.has("label"));
+        Assert.assertTrue("The circular field should still be declared", props.has("child"));
+    }
+
+    @Test(timeout = CIRCULAR_TIMEOUT_MS)
+    public void testGeneratedToolSchemaHasNoUnresolvedReference() throws Exception {
+        String definition = swagger20("/comments", "Comment",
+                "    \"Comment\": {\n"
+                + "      \"type\": \"object\",\n"
+                + "      \"properties\": {\n"
+                + "        \"text\": { \"type\": \"string\" },\n"
+                + "        \"parent\": { \"$ref\": \"#/definitions/Comment\" },\n"
+                + "        \"replies\": {\n"
+                + "          \"type\": \"array\",\n"
+                + "          \"items\": { \"$ref\": \"#/definitions/Comment\" }\n"
+                + "        }\n"
+                + "      }\n"
+                + "    }");
+
+        assertNoUnresolvedReference(generateToolSchema(definition, "/comments"), "");
+    }
+
+    /**
+     * No cycle at all. Order refers to Address twice, and both occurrences must stay fully
+     * expanded - the visited set tracks the current path, not everything seen so far.
+     */
+    @Test(timeout = CIRCULAR_TIMEOUT_MS)
+    public void testSharedNonCircularRefExpandedAtEveryOccurrence() throws Exception {
+        String definition = swagger20("/orders", "Order",
+                "    \"Address\": {\n"
+                + "      \"type\": \"object\",\n"
+                + "      \"properties\": {\n"
+                + "        \"street\": { \"type\": \"string\" },\n"
+                + "        \"city\": { \"type\": \"string\" }\n"
+                + "      }\n"
+                + "    },\n"
+                + "    \"Order\": {\n"
+                + "      \"type\": \"object\",\n"
+                + "      \"properties\": {\n"
+                + "        \"billingAddress\": { \"$ref\": \"#/definitions/Address\" },\n"
+                + "        \"shippingAddress\": { \"$ref\": \"#/definitions/Address\" }\n"
+                + "      }\n"
+                + "    }");
+
+        JsonNode props = requestBodyProperties(generateToolSchema(definition, "/orders"));
+
+        for (String field : new String[] { "billingAddress", "shippingAddress" }) {
+            Assert.assertEquals(field + " should keep its street field", "string",
+                    props.path(field).path("properties").path("street").path("type").asText());
+            Assert.assertEquals(field + " should keep its city field", "string",
+                    props.path(field).path("properties").path("city").path("type").asText());
+        }
+    }
+
+    /**
+     * Nested allOf where two branches compose the same non-circular model. Resolving the left branch
+     * must not leave Common on the visited path and make the right branch skip it.
+     */
+    @Test(timeout = CIRCULAR_TIMEOUT_MS)
+    public void testAllOfBranchesSharingAModelBothContribute() throws Exception {
+        String definition = swagger20("/records", "Wrapper",
+                "    \"Common\": {\n"
+                + "      \"type\": \"object\",\n"
+                + "      \"properties\": { \"id\": { \"type\": \"string\" } }\n"
+                + "    },\n"
+                + "    \"Left\": {\n"
+                + "      \"allOf\": [\n"
+                + "        { \"$ref\": \"#/definitions/Common\" },\n"
+                + "        { \"type\": \"object\", \"properties\": { \"leftField\": { \"type\": \"string\" } } }\n"
+                + "      ]\n"
+                + "    },\n"
+                + "    \"Right\": {\n"
+                + "      \"allOf\": [\n"
+                + "        { \"$ref\": \"#/definitions/Common\" },\n"
+                + "        { \"type\": \"object\", \"properties\": { \"rightField\": { \"type\": \"string\" } } }\n"
+                + "      ]\n"
+                + "    },\n"
+                + "    \"Wrapper\": {\n"
+                + "      \"allOf\": [\n"
+                + "        { \"$ref\": \"#/definitions/Left\" },\n"
+                + "        { \"$ref\": \"#/definitions/Right\" }\n"
+                + "      ]\n"
+                + "    }");
+
+        JsonNode props = requestBodyProperties(generateToolSchema(definition, "/records"));
+
+        Assert.assertTrue("Left branch should contribute its own field", props.has("leftField"));
+        Assert.assertTrue("Right branch should contribute its own field", props.has("rightField"));
+        Assert.assertTrue("The shared model must survive both branches", props.has("id"));
+    }
+
+    /**
+     * Two tools built from one parsed definition. Resolution must not write its results back onto
+     * the definition, or the first tool changes what the second one sees.
+     */
+    @Test(timeout = CIRCULAR_TIMEOUT_MS)
+    public void testResolvingOneToolDoesNotDegradeAnother() throws Exception {
+        String definition = "{\n"
+                + "  \"swagger\": \"2.0\",\n"
+                + "  \"info\": { \"title\": \"Graph\", \"version\": \"1.0\" },\n"
+                + "  \"paths\": {\n"
+                + "    \"/roots\": { \"post\": {\n"
+                + "      \"parameters\": [ { \"name\": \"body\", \"in\": \"body\",\n"
+                + "        \"schema\": { \"$ref\": \"#/definitions/Root\" } } ],\n"
+                + "      \"responses\": { \"200\": { \"description\": \"OK\" } } } },\n"
+                + "    \"/ms\": { \"post\": {\n"
+                + "      \"parameters\": [ { \"name\": \"body\", \"in\": \"body\",\n"
+                + "        \"schema\": { \"$ref\": \"#/definitions/M\" } } ],\n"
+                + "      \"responses\": { \"200\": { \"description\": \"OK\" } } } }\n"
+                + "  },\n"
+                + "  \"definitions\": {\n"
+                + "    \"Root\": {\n"
+                + "      \"type\": \"object\",\n"
+                + "      \"properties\": {\n"
+                + "        \"tag\": { \"type\": \"string\" },\n"
+                + "        \"first\": { \"$ref\": \"#/definitions/M\" },\n"
+                + "        \"second\": { \"$ref\": \"#/definitions/M\" }\n"
+                + "      }\n"
+                + "    },\n"
+                + "    \"M\": {\n"
+                + "      \"type\": \"object\",\n"
+                + "      \"properties\": {\n"
+                + "        \"label\": { \"type\": \"string\" },\n"
+                + "        \"backRef\": { \"$ref\": \"#/definitions/Root\" }\n"
+                + "      }\n"
+                + "    }\n"
+                + "  }\n"
+                + "}";
+
+        Set<URITemplate> templates = new LinkedHashSet<>();
+        templates.add(mcpTool("createRoot", "/roots", "POST"));
+        templates.add(mcpTool("createM", "/ms", "POST"));
+
+        Set<URITemplate> result = oas2Parser.generateMCPTools(definition, CIRCULAR_REF_API_ID,
+                CIRCULAR_BACKEND_ID, APISpecParserConstants.API_SUBTYPE_DIRECT_BACKEND, templates);
+        Assert.assertEquals(2, result.size());
+
+        JsonNode mSchema = null;
+        for (URITemplate template : result) {
+            if ("createM".equals(template.getUriTemplate())) {
+                mSchema = circularMapper.readTree(template.getSchemaDefinition());
+            }
+        }
+        Assert.assertNotNull("The M tool should have been generated", mSchema);
+
+        JsonNode backRef = mSchema.path("properties").path("requestBody").path("properties")
+                .path("backRef");
+        Assert.assertEquals("Root should be expanded inside the M tool regardless of which tool "
+                        + "resolved first", "string",
+                backRef.path("properties").path("tag").path("type").asText());
+    }
+
+    /**
+     * An acyclic definition must come through resolution with every attribute intact. Resolution
+     * rebuilds properties rather than editing them in place, so anything the rebuild forgets to
+     * carry would be lost silently, on definitions that have no cycle at all.
+     */
+    @Test(timeout = CIRCULAR_TIMEOUT_MS)
+    public void testAcyclicDefinitionKeepsPropertyAttributes() throws Exception {
+        String definition = swagger20("/carts", "Cart",
+                "    \"Item\": {\n"
+                + "      \"type\": \"object\",\n"
+                + "      \"properties\": { \"sku\": { \"type\": \"string\" } }\n"
+                + "    },\n"
+                + "    \"Cart\": {\n"
+                + "      \"type\": \"object\",\n"
+                + "      \"properties\": {\n"
+                + "        \"items\": {\n"
+                + "          \"type\": \"array\",\n"
+                + "          \"description\": \"Lines in the cart\",\n"
+                + "          \"uniqueItems\": true,\n"
+                + "          \"minItems\": 1,\n"
+                + "          \"maxItems\": 50,\n"
+                + "          \"items\": { \"$ref\": \"#/definitions/Item\" }\n"
+                + "        },\n"
+                + "        \"audit\": {\n"
+                + "          \"type\": \"object\",\n"
+                + "          \"description\": \"Audit block\",\n"
+                + "          \"readOnly\": true,\n"
+                + "          \"properties\": { \"createdBy\": { \"$ref\": \"#/definitions/Item\" } }\n"
+                + "        }\n"
+                + "      }\n"
+                + "    }");
+
+        JsonNode props = requestBodyProperties(generateToolSchema(definition, "/carts"));
+
+        JsonNode items = props.path("items");
+        Assert.assertEquals("array", items.path("type").asText());
+        Assert.assertEquals("Lines in the cart", items.path("description").asText());
+        Assert.assertTrue("uniqueItems should survive resolution", items.path("uniqueItems").asBoolean());
+        Assert.assertEquals(1, items.path("minItems").asInt());
+        Assert.assertEquals(50, items.path("maxItems").asInt());
+        Assert.assertEquals("The referenced item type should be expanded", "string",
+                items.path("items").path("properties").path("sku").path("type").asText());
+
+        JsonNode audit = props.path("audit");
+        Assert.assertEquals("Audit block", audit.path("description").asText());
+        Assert.assertTrue("readOnly should survive resolution", audit.path("readOnly").asBoolean());
+        Assert.assertEquals("The nested reference should be expanded", "string",
+                audit.path("properties").path("createdBy").path("properties").path("sku")
+                        .path("type").asText());
+    }
+
+    /**
+     * Guards the field list copied by OAS2Parser.copyCommonPropertyFields against changes in
+     * swagger-models. Resolution rebuilds properties, so a field added to these classes by a library
+     * upgrade would be dropped silently from every generated schema. If this fails, review
+     * copyCommonPropertyFields before updating the expected names here.
+     */
+    @Test
+    public void testCopiedPropertyFieldsAreStillComplete() {
+        assertDeclaredFields(AbstractProperty.class, "name", "type", "format", "example", "xml",
+                "required", "position", "description", "title", "readOnly", "allowEmptyValue",
+                "access", "vendorExtensions", "booleanValue");
+        assertDeclaredFields(ArrayProperty.class, "TYPE", "uniqueItems", "items", "maxItems", "minItems");
+        assertDeclaredFields(ObjectProperty.class, "TYPE", "properties");
+    }
+
+    private void assertDeclaredFields(Class<?> type, String... expected) {
+        Set<String> actual = Arrays.stream(type.getDeclaredFields())
+                .filter(f -> !f.isSynthetic())
+                .map(Field::getName)
+                .collect(Collectors.toCollection(TreeSet::new));
+        Set<String> want = new TreeSet<>(Arrays.asList(expected));
+        Assert.assertEquals("swagger-models has changed the fields of " + type.getSimpleName()
+                + ". Review OAS2Parser.copyCommonPropertyFields before updating this list.",
+                want, actual);
+    }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.spec.parser/src/test/java/org/wso2/carbon/apimgt/spec/parser/definitions/OAS2ParserTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.spec.parser/src/test/java/org/wso2/carbon/apimgt/spec/parser/definitions/OAS2ParserTest.java
@@ -976,4 +976,54 @@ public class OAS2ParserTest extends OASTestBase {
                 "string", left.path("properties").path("leftField").path("type").asText());
         assertNoUnresolvedReference(schema, "");
     }
+
+    /**
+     * Non-body parameters sit alongside the request body in the generated schema, keyed by location
+     * so a query parameter and a header of the same name cannot collide. The $ref parameter is
+     * resolved through resolveComponentRef, which now releases its reference on the way out.
+     */
+    @Test(timeout = CIRCULAR_TIMEOUT_MS)
+    public void testParametersAreKeyedByLocationAlongsideCircularBody() throws Exception {
+        String definition = "{\n"
+                + "  \"swagger\": \"2.0\",\n"
+                + "  \"info\": { \"title\": \"Forum\", \"version\": \"1.0\" },\n"
+                + "  \"paths\": {\n"
+                + "    \"/comments/{tenant}\": {\n"
+                + "      \"post\": {\n"
+                + "        \"parameters\": [\n"
+                + "          { \"$ref\": \"#/parameters/TenantId\" },\n"
+                + "          { \"name\": \"limit\", \"in\": \"query\", \"type\": \"integer\" },\n"
+                + "          { \"name\": \"body\", \"in\": \"body\",\n"
+                + "            \"schema\": { \"$ref\": \"#/definitions/Comment\" } }\n"
+                + "        ],\n"
+                + "        \"responses\": { \"200\": { \"description\": \"OK\" } }\n"
+                + "      }\n"
+                + "    }\n"
+                + "  },\n"
+                + "  \"parameters\": {\n"
+                + "    \"TenantId\": { \"name\": \"tenant\", \"in\": \"path\",\n"
+                + "      \"required\": true, \"type\": \"string\" }\n"
+                + "  },\n"
+                + "  \"definitions\": {\n"
+                + "    \"Comment\": {\n"
+                + "      \"type\": \"object\",\n"
+                + "      \"properties\": {\n"
+                + "        \"text\": { \"type\": \"string\" },\n"
+                + "        \"parent\": { \"$ref\": \"#/definitions/Comment\" }\n"
+                + "      }\n"
+                + "    }\n"
+                + "  }\n"
+                + "}";
+
+        JsonNode schema = generateToolSchema(definition, "/comments/{tenant}");
+        JsonNode props = schema.path("properties");
+
+        Assert.assertEquals("A $ref parameter should resolve and be keyed by its location",
+                "string", props.path("path_tenant").path("type").asText());
+        Assert.assertEquals("An inline parameter should be keyed by its location",
+                "integer", props.path("query_limit").path("type").asText());
+        Assert.assertEquals("The circular body should still resolve alongside the parameters",
+                "string", props.path("requestBody").path("properties").path("text").path("type").asText());
+        assertNoUnresolvedReference(schema, "");
+    }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.spec.parser/src/test/java/org/wso2/carbon/apimgt/spec/parser/definitions/OAS2ParserTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.spec.parser/src/test/java/org/wso2/carbon/apimgt/spec/parser/definitions/OAS2ParserTest.java
@@ -33,6 +33,7 @@ import org.junit.Test;
 import org.mockito.Mockito;
 import io.swagger.models.properties.AbstractProperty;
 import io.swagger.models.properties.ArrayProperty;
+import io.swagger.models.properties.MapProperty;
 import io.swagger.models.properties.ObjectProperty;
 import org.wso2.carbon.apimgt.api.APIConstants;
 import org.wso2.carbon.apimgt.api.APIDefinition;
@@ -632,13 +633,16 @@ public class OAS2ParserTest extends OASTestBase {
                 + "      ]\n"
                 + "    }");
 
-        JsonNode props = requestBodyProperties(generateToolSchema(definition, "/nodes"));
+        JsonNode schema = generateToolSchema(definition, "/nodes");
+        JsonNode props = requestBodyProperties(schema);
 
         Assert.assertTrue("Properties merged from the composed model should be present",
                 props.has("createdBy"));
         Assert.assertTrue("Properties declared inline in the allOf should be present",
                 props.has("label"));
-        Assert.assertTrue("The circular field should still be declared", props.has("child"));
+        Assert.assertEquals("The circular field should be described, not left as a raw $ref",
+                "object", props.path("child").path("type").asText());
+        assertNoUnresolvedReference(schema, "");
     }
 
     @Test(timeout = CIRCULAR_TIMEOUT_MS)
@@ -853,6 +857,7 @@ public class OAS2ParserTest extends OASTestBase {
                 "access", "vendorExtensions", "booleanValue");
         assertDeclaredFields(ArrayProperty.class, "TYPE", "uniqueItems", "items", "maxItems", "minItems");
         assertDeclaredFields(ObjectProperty.class, "TYPE", "properties");
+        assertDeclaredFields(MapProperty.class, "property", "minProperties", "maxProperties");
     }
 
     private void assertDeclaredFields(Class<?> type, String... expected) {
@@ -864,5 +869,76 @@ public class OAS2ParserTest extends OASTestBase {
         Assert.assertEquals("swagger-models has changed the fields of " + type.getSimpleName()
                 + ". Review OAS2Parser.copyCommonPropertyFields before updating this list.",
                 want, actual);
+    }
+
+    /**
+     * A cycle that runs only through allOf, never through a property. Nothing on that path
+     * registers the reference unless resolveModel holds it across the traversal of the resolved
+     * model's body, so this recursed until the stack overflowed.
+     */
+    @Test(timeout = CIRCULAR_TIMEOUT_MS)
+    public void testCircularRefThroughAllOfChainTerminates() throws Exception {
+        String definition = swagger20("/nodes", "Alpha",
+                "    \"Alpha\": { \"allOf\": [ { \"$ref\": \"#/definitions/Beta\" } ] },\n"
+                + "    \"Beta\":  { \"allOf\": [ { \"$ref\": \"#/definitions/Alpha\" } ] }");
+
+        JsonNode schema = generateToolSchema(definition, "/nodes");
+
+        Assert.assertTrue("A requestBody should still be emitted",
+                schema.path("properties").has("requestBody"));
+        assertNoUnresolvedReference(schema, "");
+    }
+
+    /**
+     * The cycle runs through a map's value type. resolveProperty handled Ref, Array and Object
+     * properties but not Map, so additionalProperties was never traversed.
+     */
+    @Test(timeout = CIRCULAR_TIMEOUT_MS)
+    public void testCircularRefThroughMapValueTerminates() throws Exception {
+        String definition = swagger20("/trees", "Tree",
+                "    \"Tree\": {\n"
+                + "      \"type\": \"object\",\n"
+                + "      \"properties\": {\n"
+                + "        \"name\": { \"type\": \"string\" },\n"
+                + "        \"children\": {\n"
+                + "          \"type\": \"object\",\n"
+                + "          \"additionalProperties\": { \"$ref\": \"#/definitions/Tree\" }\n"
+                + "        }\n"
+                + "      }\n"
+                + "    }");
+
+        JsonNode schema = generateToolSchema(definition, "/trees");
+        JsonNode props = requestBodyProperties(schema);
+
+        Assert.assertEquals("string", props.path("name").path("type").asText());
+        Assert.assertTrue("The recursive map field should still be declared", props.has("children"));
+        assertNoUnresolvedReference(schema, "");
+    }
+
+    /** A map whose value type is not circular must still be expanded. */
+    @Test(timeout = CIRCULAR_TIMEOUT_MS)
+    public void testNonCircularMapValueIsExpanded() throws Exception {
+        String definition = swagger20("/carts", "Cart",
+                "    \"Item\": {\n"
+                + "      \"type\": \"object\",\n"
+                + "      \"properties\": { \"sku\": { \"type\": \"string\" } }\n"
+                + "    },\n"
+                + "    \"Cart\": {\n"
+                + "      \"type\": \"object\",\n"
+                + "      \"properties\": {\n"
+                + "        \"entries\": {\n"
+                + "          \"type\": \"object\",\n"
+                + "          \"additionalProperties\": { \"$ref\": \"#/definitions/Item\" }\n"
+                + "        }\n"
+                + "      }\n"
+                + "    }");
+
+        JsonNode schema = generateToolSchema(definition, "/carts");
+        JsonNode props = requestBodyProperties(schema);
+
+        Assert.assertEquals("The map value type should be expanded", "string",
+                props.path("entries").path("additionalProperties").path("properties")
+                        .path("sku").path("type").asText());
+        assertNoUnresolvedReference(schema, "");
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.spec.parser/src/test/java/org/wso2/carbon/apimgt/spec/parser/definitions/OAS3ParserMCPToolSchemaTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.spec.parser/src/test/java/org/wso2/carbon/apimgt/spec/parser/definitions/OAS3ParserMCPToolSchemaTest.java
@@ -29,6 +29,8 @@ import org.wso2.carbon.apimgt.api.model.BackendOperationMapping;
 import org.wso2.carbon.apimgt.api.model.URITemplate;
 
 import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.Set;
 
 /**
@@ -341,5 +343,320 @@ public class OAS3ParserMCPToolSchemaTest {
         URITemplate tool = result.iterator().next();
         Assert.assertNull("Unmatched tool should have no schema generated",
                 tool.getSchemaDefinition());
+    }
+
+    // -------------------------------------------------------------------------
+    // Circular $ref handling.
+    //
+    // Each of resolveSchema's recursive branches used to start a fresh visitedRefs set instead of
+    // passing on the one it was given, so a cycle running through a schema's properties lost the
+    // path and recursed until the stack overflowed. A reference that closes a cycle is now replaced
+    // with a plain object, so the field stays declared rather than vanishing.
+    //
+    // Every test carries a timeout so a regression fails rather than hanging the build.
+    // -------------------------------------------------------------------------
+
+    private static final int CIRCULAR_TIMEOUT_MS = 30000;
+
+    private static String openApi30(String path, String bodyRef, String schemas) {
+        return "{\n"
+                + "  \"openapi\": \"3.0.1\",\n"
+                + "  \"info\": { \"title\": \"Forum\", \"version\": \"1.0\" },\n"
+                + "  \"paths\": {\n"
+                + "    \"" + path + "\": {\n"
+                + "      \"post\": {\n"
+                + "        \"requestBody\": { \"content\": { \"application/json\": {\n"
+                + "          \"schema\": { \"$ref\": \"#/components/schemas/" + bodyRef + "\" } } } },\n"
+                + "        \"responses\": { \"200\": { \"description\": \"OK\" } }\n"
+                + "      }\n"
+                + "    }\n"
+                + "  },\n"
+                + "  \"components\": { \"schemas\": {\n" + schemas + "\n  } }\n"
+                + "}";
+    }
+
+    private JsonNode generateToolSchema(String definition, String target) throws Exception {
+        Set<URITemplate> templates = new LinkedHashSet<>();
+        templates.add(createDirectBackendTool("theTool", target, "POST", null));
+        Set<URITemplate> result = parser.generateMCPTools(definition, REF_API_ID, BACKEND_ID,
+                APISpecParserConstants.API_SUBTYPE_DIRECT_BACKEND, templates);
+        Assert.assertEquals("Expected exactly one generated tool", 1, result.size());
+        String schema = result.iterator().next().getSchemaDefinition();
+        Assert.assertNotNull("A schema should have been generated", schema);
+        return objectMapper.readTree(schema);
+    }
+
+    private JsonNode requestBodyProperties(JsonNode schema) {
+        Assert.assertTrue("Schema should carry a requestBody property",
+                schema.path("properties").has("requestBody"));
+        JsonNode requestBody = schema.path("properties").path("requestBody");
+        Assert.assertTrue("requestBody should carry its resolved properties",
+                requestBody.has("properties"));
+        return requestBody.path("properties");
+    }
+
+    private void assertNoUnresolvedReference(JsonNode node, String path) {
+        if (node.isObject()) {
+            Iterator<String> names = node.fieldNames();
+            while (names.hasNext()) {
+                String name = names.next();
+                Assert.assertNotEquals("Unresolved reference left at " + path + "/" + name,
+                        "$ref", name);
+                assertNoUnresolvedReference(node.get(name), path + "/" + name);
+            }
+        } else if (node.isArray()) {
+            for (int i = 0; i < node.size(); i++) {
+                assertNoUnresolvedReference(node.get(i), path + "/" + i);
+            }
+        }
+    }
+
+    @Test(timeout = CIRCULAR_TIMEOUT_MS)
+    public void testCircularRefThroughFieldTerminates() throws Exception {
+        String definition = openApi30("/comments", "Comment",
+                "    \"Comment\": {\n"
+                + "      \"type\": \"object\",\n"
+                + "      \"required\": [\"text\"],\n"
+                + "      \"properties\": {\n"
+                + "        \"text\": { \"type\": \"string\" },\n"
+                + "        \"parent\": { \"$ref\": \"#/components/schemas/Comment\" }\n"
+                + "      }\n"
+                + "    }");
+
+        JsonNode props = requestBodyProperties(generateToolSchema(definition, "/comments"));
+
+        Assert.assertEquals("A non-circular sibling should still resolve",
+                "string", props.path("text").path("type").asText());
+        Assert.assertTrue("The circular field should still be declared", props.has("parent"));
+        Assert.assertEquals("An unexpanded cycle should render as a plain object",
+                "object", props.path("parent").path("type").asText());
+    }
+
+    @Test(timeout = CIRCULAR_TIMEOUT_MS)
+    public void testCircularRefThroughListTerminates() throws Exception {
+        String definition = openApi30("/comments", "Comment",
+                "    \"Comment\": {\n"
+                + "      \"type\": \"object\",\n"
+                + "      \"properties\": {\n"
+                + "        \"text\": { \"type\": \"string\" },\n"
+                + "        \"replies\": {\n"
+                + "          \"type\": \"array\",\n"
+                + "          \"items\": { \"$ref\": \"#/components/schemas/Comment\" }\n"
+                + "        }\n"
+                + "      }\n"
+                + "    }");
+
+        JsonNode props = requestBodyProperties(generateToolSchema(definition, "/comments"));
+
+        Assert.assertEquals("array", props.path("replies").path("type").asText());
+        Assert.assertEquals("The recursive item type should still be described",
+                "object", props.path("replies").path("items").path("type").asText());
+    }
+
+    @Test(timeout = CIRCULAR_TIMEOUT_MS)
+    public void testIndirectCircularRefTerminates() throws Exception {
+        String definition = openApi30("/threads", "Thread",
+                "    \"Thread\": {\n"
+                + "      \"type\": \"object\",\n"
+                + "      \"properties\": {\n"
+                + "        \"title\": { \"type\": \"string\" },\n"
+                + "        \"author\": { \"$ref\": \"#/components/schemas/User\" }\n"
+                + "      }\n"
+                + "    },\n"
+                + "    \"User\": {\n"
+                + "      \"type\": \"object\",\n"
+                + "      \"properties\": {\n"
+                + "        \"name\": { \"type\": \"string\" },\n"
+                + "        \"lastThread\": { \"$ref\": \"#/components/schemas/Thread\" }\n"
+                + "      }\n"
+                + "    }");
+
+        JsonNode props = requestBodyProperties(generateToolSchema(definition, "/threads"));
+        JsonNode author = props.path("author");
+
+        Assert.assertEquals("The intermediate schema should expand",
+                "string", author.path("properties").path("name").path("type").asText());
+        Assert.assertEquals("The back-reference should still be described",
+                "object", author.path("properties").path("lastThread").path("type").asText());
+    }
+
+    @Test(timeout = CIRCULAR_TIMEOUT_MS)
+    public void testCircularRefThroughAllOfTerminates() throws Exception {
+        String definition = openApi30("/nodes", "Node",
+                "    \"Audit\": {\n"
+                + "      \"type\": \"object\",\n"
+                + "      \"properties\": { \"createdBy\": { \"type\": \"string\" } }\n"
+                + "    },\n"
+                + "    \"Node\": {\n"
+                + "      \"allOf\": [\n"
+                + "        { \"$ref\": \"#/components/schemas/Audit\" },\n"
+                + "        { \"type\": \"object\",\n"
+                + "          \"properties\": {\n"
+                + "            \"label\": { \"type\": \"string\" },\n"
+                + "            \"child\": { \"$ref\": \"#/components/schemas/Node\" }\n"
+                + "          }\n"
+                + "        }\n"
+                + "      ]\n"
+                + "    }");
+
+        JsonNode props = requestBodyProperties(generateToolSchema(definition, "/nodes"));
+
+        Assert.assertTrue("Properties merged from the composed schema should be present",
+                props.has("createdBy"));
+        Assert.assertTrue("Properties declared inline in the allOf should be present",
+                props.has("label"));
+    }
+
+    /** oneOf has no Swagger 2.0 equivalent, so it is only covered here. */
+    @Test(timeout = CIRCULAR_TIMEOUT_MS)
+    public void testCircularRefThroughOneOfTerminates() throws Exception {
+        String definition = openApi30("/shapes", "Shape",
+                "    \"Shape\": {\n"
+                + "      \"type\": \"object\",\n"
+                + "      \"properties\": {\n"
+                + "        \"label\": { \"type\": \"string\" },\n"
+                + "        \"variant\": {\n"
+                + "          \"oneOf\": [\n"
+                + "            { \"type\": \"string\" },\n"
+                + "            { \"$ref\": \"#/components/schemas/Shape\" }\n"
+                + "          ]\n"
+                + "        }\n"
+                + "      }\n"
+                + "    }");
+
+        JsonNode props = requestBodyProperties(generateToolSchema(definition, "/shapes"));
+
+        Assert.assertEquals("string", props.path("label").path("type").asText());
+        Assert.assertTrue("The oneOf field should still be declared", props.has("variant"));
+    }
+
+    /** additionalProperties is a separate recursion branch from properties and items. */
+    @Test(timeout = CIRCULAR_TIMEOUT_MS)
+    public void testCircularRefThroughAdditionalPropertiesTerminates() throws Exception {
+        String definition = openApi30("/trees", "Tree",
+                "    \"Tree\": {\n"
+                + "      \"type\": \"object\",\n"
+                + "      \"properties\": {\n"
+                + "        \"name\": { \"type\": \"string\" },\n"
+                + "        \"children\": {\n"
+                + "          \"type\": \"object\",\n"
+                + "          \"additionalProperties\": { \"$ref\": \"#/components/schemas/Tree\" }\n"
+                + "        }\n"
+                + "      }\n"
+                + "    }");
+
+        JsonNode props = requestBodyProperties(generateToolSchema(definition, "/trees"));
+
+        Assert.assertEquals("string", props.path("name").path("type").asText());
+        Assert.assertTrue("The recursive map field should still be declared", props.has("children"));
+    }
+
+    @Test(timeout = CIRCULAR_TIMEOUT_MS)
+    public void testGeneratedToolSchemaHasNoUnresolvedReference() throws Exception {
+        String definition = openApi30("/comments", "Comment",
+                "    \"Comment\": {\n"
+                + "      \"type\": \"object\",\n"
+                + "      \"properties\": {\n"
+                + "        \"text\": { \"type\": \"string\" },\n"
+                + "        \"parent\": { \"$ref\": \"#/components/schemas/Comment\" }\n"
+                + "      }\n"
+                + "    }");
+
+        assertNoUnresolvedReference(generateToolSchema(definition, "/comments"), "");
+    }
+
+    /**
+     * No cycle at all. Order refers to Address twice, and both occurrences must stay fully
+     * expanded - the visited set tracks the current path, not everything seen so far.
+     */
+    @Test(timeout = CIRCULAR_TIMEOUT_MS)
+    public void testSharedNonCircularRefExpandedAtEveryOccurrence() throws Exception {
+        String definition = openApi30("/orders", "Order",
+                "    \"Address\": {\n"
+                + "      \"type\": \"object\",\n"
+                + "      \"properties\": {\n"
+                + "        \"street\": { \"type\": \"string\" },\n"
+                + "        \"city\": { \"type\": \"string\" }\n"
+                + "      }\n"
+                + "    },\n"
+                + "    \"Order\": {\n"
+                + "      \"type\": \"object\",\n"
+                + "      \"properties\": {\n"
+                + "        \"billingAddress\": { \"$ref\": \"#/components/schemas/Address\" },\n"
+                + "        \"shippingAddress\": { \"$ref\": \"#/components/schemas/Address\" }\n"
+                + "      }\n"
+                + "    }");
+
+        JsonNode props = requestBodyProperties(generateToolSchema(definition, "/orders"));
+
+        for (String field : new String[] { "billingAddress", "shippingAddress" }) {
+            Assert.assertEquals(field + " should keep its street field", "string",
+                    props.path(field).path("properties").path("street").path("type").asText());
+            Assert.assertEquals(field + " should keep its city field", "string",
+                    props.path(field).path("properties").path("city").path("type").asText());
+        }
+    }
+
+    /**
+     * Root refers to M twice; M refers back to Root. One tool is generated for a Root body and one
+     * for an M body. Resolving a schema writes its expanded content back onto the components, so
+     * each tool must be resolved against its own parse - otherwise the Root tool's truncation of
+     * M.backRef is what the M tool sees, and which tool is degraded depends on iteration order.
+     */
+    @Test(timeout = CIRCULAR_TIMEOUT_MS)
+    public void testResolvingOneToolDoesNotDegradeAnother() throws Exception {
+        String definition = "{\n"
+                + "  \"openapi\": \"3.0.1\",\n"
+                + "  \"info\": { \"title\": \"Graph\", \"version\": \"1.0\" },\n"
+                + "  \"paths\": {\n"
+                + "    \"/roots\": { \"post\": {\n"
+                + "      \"requestBody\": { \"content\": { \"application/json\": {\n"
+                + "        \"schema\": { \"$ref\": \"#/components/schemas/Root\" } } } },\n"
+                + "      \"responses\": { \"200\": { \"description\": \"OK\" } } } },\n"
+                + "    \"/ms\": { \"post\": {\n"
+                + "      \"requestBody\": { \"content\": { \"application/json\": {\n"
+                + "        \"schema\": { \"$ref\": \"#/components/schemas/M\" } } } },\n"
+                + "      \"responses\": { \"200\": { \"description\": \"OK\" } } } }\n"
+                + "  },\n"
+                + "  \"components\": { \"schemas\": {\n"
+                + "    \"Root\": {\n"
+                + "      \"type\": \"object\",\n"
+                + "      \"properties\": {\n"
+                + "        \"tag\": { \"type\": \"string\" },\n"
+                + "        \"first\": { \"$ref\": \"#/components/schemas/M\" },\n"
+                + "        \"second\": { \"$ref\": \"#/components/schemas/M\" }\n"
+                + "      }\n"
+                + "    },\n"
+                + "    \"M\": {\n"
+                + "      \"type\": \"object\",\n"
+                + "      \"properties\": {\n"
+                + "        \"label\": { \"type\": \"string\" },\n"
+                + "        \"backRef\": { \"$ref\": \"#/components/schemas/Root\" }\n"
+                + "      }\n"
+                + "    }\n"
+                + "  } }\n"
+                + "}";
+
+        Set<URITemplate> templates = new LinkedHashSet<>();
+        templates.add(createDirectBackendTool("createRoot", "/roots", "POST", null));
+        templates.add(createDirectBackendTool("createM", "/ms", "POST", null));
+
+        Set<URITemplate> result = parser.generateMCPTools(definition, REF_API_ID, BACKEND_ID,
+                APISpecParserConstants.API_SUBTYPE_DIRECT_BACKEND, templates);
+        Assert.assertEquals(2, result.size());
+
+        JsonNode mSchema = null;
+        for (URITemplate template : result) {
+            if ("createM".equals(template.getUriTemplate())) {
+                mSchema = objectMapper.readTree(template.getSchemaDefinition());
+            }
+        }
+        Assert.assertNotNull("The M tool should have been generated", mSchema);
+
+        JsonNode backRef = mSchema.path("properties").path("requestBody").path("properties")
+                .path("backRef");
+        Assert.assertEquals("Root should be expanded inside the M tool regardless of which tool "
+                        + "resolved first", "string",
+                backRef.path("properties").path("tag").path("type").asText());
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.spec.parser/src/test/java/org/wso2/carbon/apimgt/spec/parser/definitions/OAS3ParserMCPToolSchemaTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.spec.parser/src/test/java/org/wso2/carbon/apimgt/spec/parser/definitions/OAS3ParserMCPToolSchemaTest.java
@@ -430,6 +430,13 @@ public class OAS3ParserMCPToolSchemaTest {
         Assert.assertTrue("The circular field should still be declared", props.has("parent"));
         Assert.assertEquals("An unexpanded cycle should render as a plain object",
                 "object", props.path("parent").path("type").asText());
+        // The description is the only signal an agent has that content was omitted rather than
+        // genuinely absent, and it is the only place the omitted schema is named.
+        String description = props.path("parent").path("description").asText();
+        Assert.assertTrue("An unexpanded cycle should say that its nested properties were omitted, "
+                + "but the description was: " + description, description.contains("omitted"));
+        Assert.assertTrue("The description should name the schema that was omitted, "
+                + "but the description was: " + description, description.contains("Comment"));
     }
 
     @Test(timeout = CIRCULAR_TIMEOUT_MS)

--- a/components/apimgt/org.wso2.carbon.apimgt.spec.parser/src/test/java/org/wso2/carbon/apimgt/spec/parser/definitions/OAS3ParserMCPToolSchemaTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.spec.parser/src/test/java/org/wso2/carbon/apimgt/spec/parser/definitions/OAS3ParserMCPToolSchemaTest.java
@@ -710,4 +710,52 @@ public class OAS3ParserMCPToolSchemaTest {
                 "string", props.path("requestBody").path("properties").path("label").path("type").asText());
         assertNoUnresolvedReference(schema, "");
     }
+
+    /**
+     * A chain of aliases that closes on itself: Alias1 points at Alias2, which points back at
+     * Alias1. The cycle is discovered inside resolveComponentRef rather than at the entry
+     * reference, and it used to come back as null, silently removing the field from the schema.
+     */
+    @Test(timeout = CIRCULAR_TIMEOUT_MS)
+    public void testCircularAliasChainIsDescribedNotDropped() throws Exception {
+        String definition = openApi30("/holders", "Holder",
+                "    \"Alias1\": { \"$ref\": \"#/components/schemas/Alias2\" },\n"
+                + "    \"Alias2\": { \"$ref\": \"#/components/schemas/Alias1\" },\n"
+                + "    \"Holder\": {\n"
+                + "      \"type\": \"object\",\n"
+                + "      \"properties\": {\n"
+                + "        \"name\": { \"type\": \"string\" },\n"
+                + "        \"aliased\": { \"$ref\": \"#/components/schemas/Alias1\" }\n"
+                + "      }\n"
+                + "    }");
+
+        JsonNode schema = generateToolSchema(definition, "/holders");
+        JsonNode props = requestBodyProperties(schema);
+
+        Assert.assertEquals("string", props.path("name").path("type").asText());
+        Assert.assertTrue("The aliased field must not disappear from the schema",
+                props.has("aliased"));
+        Assert.assertEquals("A circular alias should be described as a plain object",
+                "object", props.path("aliased").path("type").asText());
+        assertNoUnresolvedReference(schema, "");
+    }
+
+    /** A reference naming a component that does not exist is still dropped, not described. */
+    @Test(timeout = CIRCULAR_TIMEOUT_MS)
+    public void testUnknownComponentReferenceIsStillDropped() throws Exception {
+        String definition = openApi30("/holders", "Holder",
+                "    \"Holder\": {\n"
+                + "      \"type\": \"object\",\n"
+                + "      \"properties\": {\n"
+                + "        \"name\": { \"type\": \"string\" },\n"
+                + "        \"missing\": { \"$ref\": \"#/components/schemas/DoesNotExist\" }\n"
+                + "      }\n"
+                + "    }");
+
+        JsonNode props = requestBodyProperties(generateToolSchema(definition, "/holders"));
+
+        Assert.assertEquals("string", props.path("name").path("type").asText());
+        Assert.assertFalse("An undefined reference should not be described as an object",
+                props.has("missing"));
+    }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.spec.parser/src/test/java/org/wso2/carbon/apimgt/spec/parser/definitions/OAS3ParserMCPToolSchemaTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.spec.parser/src/test/java/org/wso2/carbon/apimgt/spec/parser/definitions/OAS3ParserMCPToolSchemaTest.java
@@ -758,4 +758,28 @@ public class OAS3ParserMCPToolSchemaTest {
         Assert.assertFalse("An undefined reference should not be described as an object",
                 props.has("missing"));
     }
+
+    /**
+     * A declared alias whose chain ends at a component the definition never declares. The reference
+     * fails to resolve exactly as a circular one does, but it is not a cycle: the field is dropped
+     * like any other unresolved reference rather than being described as an object.
+     */
+    @Test(timeout = CIRCULAR_TIMEOUT_MS)
+    public void testAliasToUndeclaredComponentIsDropped() throws Exception {
+        String definition = openApi30("/holders", "Holder",
+                "    \"Alias1\": { \"$ref\": \"#/components/schemas/Missing\" },\n"
+                + "    \"Holder\": {\n"
+                + "      \"type\": \"object\",\n"
+                + "      \"properties\": {\n"
+                + "        \"name\": { \"type\": \"string\" },\n"
+                + "        \"aliased\": { \"$ref\": \"#/components/schemas/Alias1\" }\n"
+                + "      }\n"
+                + "    }");
+
+        JsonNode props = requestBodyProperties(generateToolSchema(definition, "/holders"));
+
+        Assert.assertEquals("string", props.path("name").path("type").asText());
+        Assert.assertFalse("An alias whose target does not exist is not a cycle and should not be "
+                + "described as an object", props.has("aliased"));
+    }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.spec.parser/src/test/java/org/wso2/carbon/apimgt/spec/parser/definitions/OAS3ParserMCPToolSchemaTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.spec.parser/src/test/java/org/wso2/carbon/apimgt/spec/parser/definitions/OAS3ParserMCPToolSchemaTest.java
@@ -659,4 +659,55 @@ public class OAS3ParserMCPToolSchemaTest {
                         + "resolved first", "string",
                 backRef.path("properties").path("tag").path("type").asText());
     }
+
+    /**
+     * A parameter's schema can itself reference a circular component. That is a second entry point
+     * into resolution, separate from the request body, and it recursed just as far before the fix.
+     *
+     * buildUnifiedInputSchema reads only type, format, enum and default off a resolved parameter
+     * schema - never its properties - so a circular object parameter is expected to come through as
+     * a bare object. Asserted here so the shape is not later "fixed" back into recursion.
+     */
+    @Test(timeout = CIRCULAR_TIMEOUT_MS)
+    public void testCircularParameterSchemaTerminates() throws Exception {
+        String definition = "{\n"
+                + "  \"openapi\": \"3.0.1\",\n"
+                + "  \"info\": { \"title\": \"Forum\", \"version\": \"1.0\" },\n"
+                + "  \"paths\": {\n"
+                + "    \"/nodes/{tenant}\": {\n"
+                + "      \"post\": {\n"
+                + "        \"parameters\": [\n"
+                + "          { \"name\": \"tenant\", \"in\": \"path\", \"required\": true,\n"
+                + "            \"schema\": { \"type\": \"string\" } },\n"
+                + "          { \"name\": \"filter\", \"in\": \"query\",\n"
+                + "            \"schema\": { \"$ref\": \"#/components/schemas/Node\" } }\n"
+                + "        ],\n"
+                + "        \"requestBody\": { \"content\": { \"application/json\": {\n"
+                + "          \"schema\": { \"$ref\": \"#/components/schemas/Node\" } } } },\n"
+                + "        \"responses\": { \"200\": { \"description\": \"OK\" } }\n"
+                + "      }\n"
+                + "    }\n"
+                + "  },\n"
+                + "  \"components\": { \"schemas\": {\n"
+                + "    \"Node\": {\n"
+                + "      \"type\": \"object\",\n"
+                + "      \"properties\": {\n"
+                + "        \"label\": { \"type\": \"string\" },\n"
+                + "        \"child\": { \"$ref\": \"#/components/schemas/Node\" }\n"
+                + "      }\n"
+                + "    }\n"
+                + "  } }\n"
+                + "}";
+
+        JsonNode schema = generateToolSchema(definition, "/nodes/{tenant}");
+        JsonNode props = schema.path("properties");
+
+        Assert.assertEquals("Parameters should be keyed by their location",
+                "string", props.path("path_tenant").path("type").asText());
+        Assert.assertEquals("A circular parameter schema should resolve to a bare object",
+                "object", props.path("query_filter").path("type").asText());
+        Assert.assertEquals("The body should still expand alongside the parameters",
+                "string", props.path("requestBody").path("properties").path("label").path("type").asText());
+        assertNoUnresolvedReference(schema, "");
+    }
 }


### PR DESCRIPTION
## Purpose

Fix https://github.com/wso2/api-manager/issues/5189

## Issue

Creating an MCP Server from a backend API whose definition contains a circular `$ref` fails — `StackOverflowError` in `OAS2Parser`, endless recursion in `OAS3Parser`.

```yaml
Comment:
  properties:
    text:   { type: string }
    parent: { $ref: '#/definitions/Comment' }   # self-reference
```

## Approach

* Circular `$ref` chains now terminate in both the Swagger 2.0 and OpenAPI 3 parsers, for every shape they take: through a field, a list, an inline object, `allOf` (both via a property and as an `allOf`-only chain), a map value type, `oneOf`, and indirect chains across several models.
* Resolution no longer modifies the parsed API definition, so the schema generated for one tool cannot affect the schemas generated for others.
* Three cases that previously emitted an unresolvable `$ref` into the tool schema are corrected: a property referencing an `allOf` model, a property written as an inline `allOf`, and a reference to a definition that does not exist (now omitted, with a warning logged).
* A misleading `Circular reference detected for model: …` warning has been removed. It was emitted for any `$ref` request body, cyclic or not, so it is not an indicator of this issue.

## What changes in the generated tool schema

A reference that closes a cycle resolves to an object with no declared properties:

```json
"parent": {
  "type": "object",
  "description": "Circular reference to 'Comment'; nested properties are omitted."
}
```

The field remains declared, so an agent still knows it exists and can provide a value; only the nested shape is omitted. Definitions without circular references are unaffected and expand exactly as before. An agent can only infer a suitable value for the circular field, since with the MCP protocol version we currently use there is no way to include the definitions.

## Known limitation

MCP protocol version 2025-06-18 defines a tool's `inputSchema` as `type`/`properties`/`required` only, so a recursive structure cannot be represented by reference. Omitting the nested shape where the cycle closes is therefore the only conformant option at this protocol version. MCP 2026-07-28 permits `$defs`/`$ref`, which would allow recursion to be expressed exactly; that has to be tracked separately since it is beyond the scope of this patch.
