### PR TITLE
Refactor organization handling in internal service endpoints

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.internal.service/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.internal.service/pom.xml
@@ -58,6 +58,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>io.swagger</groupId>
             <artifactId>swagger-jaxrs</artifactId>
             <scope>provided</scope>

--- a/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/main/java/org/wso2/carbon/apimgt/internal/service/impl/ApplicationsApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/main/java/org/wso2/carbon/apimgt/internal/service/impl/ApplicationsApiServiceImpl.java
@@ -25,10 +25,13 @@ import org.wso2.carbon.apimgt.impl.APIConstants;
 import org.wso2.carbon.apimgt.impl.dao.SubscriptionValidationDAO;
 import org.wso2.carbon.apimgt.internal.service.ApplicationsApiService;
 import org.wso2.carbon.apimgt.internal.service.utils.SubscriptionValidationDataUtil;
+import org.wso2.carbon.apimgt.rest.api.common.RestApiCommonUtil;
 import org.wso2.carbon.apimgt.rest.api.util.utils.RestApiUtil;
 import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 import javax.ws.rs.core.Response;
 
 public class ApplicationsApiServiceImpl implements ApplicationsApiService {
@@ -38,7 +41,9 @@ public class ApplicationsApiServiceImpl implements ApplicationsApiService {
 
         SubscriptionValidationDAO subscriptionValidationDAO = new SubscriptionValidationDAO();
         if (appId != null && appId > 0) {
-            List<Application> application = subscriptionValidationDAO.getApplicationById(appId);
+            String authenticatedOrganization = RestApiCommonUtil.getLoggedInUserTenantDomain();
+            List<Application> application =
+                    getApplicationById(subscriptionValidationDAO, appId, authenticatedOrganization);
             return Response.ok().entity(SubscriptionValidationDataUtil.fromApplicationToApplicationListDTO(application)
             ).build();
         }
@@ -59,5 +64,20 @@ public class ApplicationsApiServiceImpl implements ApplicationsApiService {
         }
         return Response.ok().entity(SubscriptionValidationDataUtil.fromApplicationToApplicationListDTO(
                 subscriptionValidationDAO.getAllApplications())).build();
+    }
+
+    static List<Application> getApplicationById(SubscriptionValidationDAO subscriptionValidationDAO, int appId,
+                                                String authenticatedOrganization) {
+
+        if (StringUtils.isEmpty(authenticatedOrganization)) {
+            return Collections.emptyList();
+        }
+        List<Application> applications = subscriptionValidationDAO.getApplicationById(appId);
+        if (MultitenantConstants.SUPER_TENANT_DOMAIN_NAME.equalsIgnoreCase(authenticatedOrganization)) {
+            return applications;
+        }
+        return applications.stream()
+                .filter(application -> authenticatedOrganization.equalsIgnoreCase(application.getOrganization()))
+                .collect(Collectors.toList());
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/main/java/org/wso2/carbon/apimgt/internal/service/impl/LlmProvidersApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/main/java/org/wso2/carbon/apimgt/internal/service/impl/LlmProvidersApiServiceImpl.java
@@ -18,15 +18,18 @@
 
 package org.wso2.carbon.apimgt.internal.service.impl;
 
+import org.apache.commons.lang3.StringUtils;
 import org.wso2.carbon.apimgt.api.APIAdmin;
 import org.wso2.carbon.apimgt.api.APIConstants;
 import org.wso2.carbon.apimgt.api.APIManagementException;
+import org.wso2.carbon.apimgt.api.ExceptionCodes;
 import org.wso2.carbon.apimgt.api.model.LLMProvider;
 import org.wso2.carbon.apimgt.impl.APIAdminImpl;
 import org.wso2.carbon.apimgt.internal.service.LlmProvidersApiService;
 import org.apache.cxf.jaxrs.ext.MessageContext;
 import org.wso2.carbon.apimgt.internal.service.dto.LLMProviderDTO;
 import org.wso2.carbon.apimgt.internal.service.dto.LLMProviderListDTO;
+import org.wso2.carbon.apimgt.rest.api.common.RestApiCommonUtil;
 import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 
 import java.util.ArrayList;
@@ -50,7 +53,7 @@ public class LlmProvidersApiServiceImpl implements LlmProvidersApiService {
             throws APIManagementException {
 
         APIAdmin admin = new APIAdminImpl();
-        String organization = getOrganizationXWSO2Tenant(xWSO2Tenant);
+        String organization = getOrganizationXWSO2Tenant(xWSO2Tenant, RestApiCommonUtil.getLoggedInUserTenantDomain());
         LLMProvider llmProvider = admin.getLLMProvider(organization, llmProviderId);
         LLMProviderDTO llmProviderDto = convertToDTO(llmProvider);
         return Response.ok().entity(llmProviderDto).build();
@@ -68,7 +71,7 @@ public class LlmProvidersApiServiceImpl implements LlmProvidersApiService {
                                     MessageContext messageContext) throws APIManagementException {
 
         APIAdmin admin = new APIAdminImpl();
-        String organization = getOrganizationXWSO2Tenant(xWSO2Tenant);
+        String organization = getOrganizationXWSO2Tenant(xWSO2Tenant, RestApiCommonUtil.getLoggedInUserTenantDomain());
         List<LLMProvider> llmProviderList = admin.getLLMProviders(organization, name,
                 apiVersion, null);
 
@@ -96,7 +99,31 @@ public class LlmProvidersApiServiceImpl implements LlmProvidersApiService {
         return llmProviderDto;
     }
 
-    private String getOrganizationXWSO2Tenant(String xWSO2Tenant) {
+    /**
+     * Resolves the organization whose LLM providers should be returned.
+     * <p>
+     * The requested tenant is honoured only for the super tenant. Any other caller is confined to
+     * its own organization, so a requested tenant cannot widen the result set. The organization
+     * must never be resolved from {@code RestApiUtil.getOrganization(messageContext)} here,
+     * because this web application does not pin the organization header and that value is
+     * therefore supplied by the caller.
+     *
+     * @param xWSO2Tenant              requested tenant, may be null or the all-tenants literal
+     * @param authenticatedOrganization organization of the authenticated caller
+     * @return organization to filter on, or null for an unfiltered super tenant lookup
+     * @throws APIManagementException if the caller's organization cannot be resolved
+     */
+    static String getOrganizationXWSO2Tenant(String xWSO2Tenant, String authenticatedOrganization)
+            throws APIManagementException {
+
+        if (StringUtils.isEmpty(authenticatedOrganization)) {
+            throw new APIManagementException("Unable to resolve the organization of the authenticated user",
+                    ExceptionCodes.ORGANIZATION_NOT_FOUND);
+        }
+
+        if (!MultitenantConstants.SUPER_TENANT_DOMAIN_NAME.equalsIgnoreCase(authenticatedOrganization)) {
+            return authenticatedOrganization;
+        }
 
         return (xWSO2Tenant == null)
                 ? MultitenantConstants.SUPER_TENANT_DOMAIN_NAME

--- a/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/main/java/org/wso2/carbon/apimgt/internal/service/impl/NotifyApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/main/java/org/wso2/carbon/apimgt/internal/service/impl/NotifyApiServiceImpl.java
@@ -7,6 +7,8 @@ import org.json.JSONObject;
 import org.wso2.carbon.apimgt.api.APIManagementException;
 import org.wso2.carbon.apimgt.internal.service.NotifyApiService;
 import org.wso2.carbon.apimgt.notification.NotificationEventService;
+import org.wso2.carbon.apimgt.rest.api.common.RestApiCommonUtil;
+import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
 
 import java.util.Hashtable;
@@ -21,6 +23,12 @@ public class NotifyApiServiceImpl implements NotifyApiService {
     @Override
     public Response notifyPost(String xWSO2KEYManager, String body, MessageContext messageContext) {
 
+        String authenticatedOrganization = RestApiCommonUtil.getLoggedInUserTenantDomain();
+        if (!isNotificationDispatchAllowed(authenticatedOrganization)) {
+            log.warn("Notification event dispatch is not permitted for organization: "
+                    + authenticatedOrganization);
+            return Response.status(Response.Status.FORBIDDEN).build();
+        }
         try {
             NotificationEventService notificationEventService =
                     (NotificationEventService) PrivilegedCarbonContext.getThreadLocalCarbonContext()
@@ -35,5 +43,20 @@ public class NotifyApiServiceImpl implements NotifyApiService {
             String responseStringObj = String.valueOf(responseObj);
             return Response.serverError().entity(responseStringObj).build();
         }
+    }
+
+    /**
+     * Determines whether the authenticated caller may dispatch notification events.
+     * <p>
+     * Notification events are published on behalf of the whole deployment by the key manager, and
+     * the organization an event applies to is carried in the event payload rather than derived
+     * from the caller. Dispatch is therefore restricted to the super tenant.
+     *
+     * @param authenticatedOrganization organization of the authenticated caller
+     * @return true if the caller may dispatch notification events
+     */
+    static boolean isNotificationDispatchAllowed(String authenticatedOrganization) {
+
+        return MultitenantConstants.SUPER_TENANT_DOMAIN_NAME.equalsIgnoreCase(authenticatedOrganization);
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/main/java/org/wso2/carbon/apimgt/internal/service/impl/RevokedjwtApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/main/java/org/wso2/carbon/apimgt/internal/service/impl/RevokedjwtApiServiceImpl.java
@@ -38,7 +38,7 @@ public class RevokedjwtApiServiceImpl implements RevokedjwtApiService {
             return revokedEventsDTO;
         }
 
-        boolean isSuperTenant = MultitenantConstants.SUPER_TENANT_DOMAIN_NAME.equals(tenantDomain);
+        boolean isSuperTenant = MultitenantConstants.SUPER_TENANT_DOMAIN_NAME.equalsIgnoreCase(tenantDomain);
         for (RevokedJWTEventData.RevokedJWTData revokedJWT : revokedJWTEventData.getRevokedJWTList()) {
             if (isSuperTenant || revokedJWT.getTenantId() == tenantId) {
                 RevokedJWTDTO revokedJWTDTO = new RevokedJWTDTO();
@@ -49,13 +49,13 @@ public class RevokedjwtApiServiceImpl implements RevokedjwtApiService {
         }
         for (RevokedJWTConsumerKeyDTO revokedConsumerKey :
                 revokedJWTEventData.getRevokedJWTConsumerKeyList()) {
-            if (isSuperTenant || tenantDomain.equals(revokedConsumerKey.getOrganization())) {
+            if (isSuperTenant || tenantDomain.equalsIgnoreCase(revokedConsumerKey.getOrganization())) {
                 revokedEventsDTO.getRevokedJWTConsumerKeyList().add(revokedConsumerKey);
             }
         }
         for (RevokedJWTSubjectEntityDTO revokedSubjectEntity :
                 revokedJWTEventData.getRevokedJWTSubjectEntityList()) {
-            if (isSuperTenant || tenantDomain.equals(revokedSubjectEntity.getOrganization())) {
+            if (isSuperTenant || tenantDomain.equalsIgnoreCase(revokedSubjectEntity.getOrganization())) {
                 revokedEventsDTO.getRevokedJWTSubjectEntityList().add(revokedSubjectEntity);
             }
         }
@@ -67,7 +67,7 @@ public class RevokedjwtApiServiceImpl implements RevokedjwtApiService {
         if (StringUtils.isBlank(tenantDomain)) {
             return false;
         }
-        boolean isSuperTenantDomain = MultitenantConstants.SUPER_TENANT_DOMAIN_NAME.equals(tenantDomain);
+        boolean isSuperTenantDomain = MultitenantConstants.SUPER_TENANT_DOMAIN_NAME.equalsIgnoreCase(tenantDomain);
         boolean isSuperTenantId = MultitenantConstants.SUPER_TENANT_ID == tenantId;
         return isSuperTenantDomain == isSuperTenantId && (isSuperTenantId || tenantId >= 0);
     }

--- a/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/main/java/org/wso2/carbon/apimgt/internal/service/impl/RevokedjwtApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/main/java/org/wso2/carbon/apimgt/internal/service/impl/RevokedjwtApiServiceImpl.java
@@ -1,9 +1,18 @@
 package org.wso2.carbon.apimgt.internal.service.impl;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.cxf.jaxrs.ext.MessageContext;
 import org.wso2.carbon.apimgt.api.APIManagementException;
 import org.wso2.carbon.apimgt.internal.service.RevokedjwtApiService;
+import org.wso2.carbon.apimgt.internal.service.dto.RevokedEventsDTO;
+import org.wso2.carbon.apimgt.internal.service.dto.RevokedJWTConsumerKeyDTO;
+import org.wso2.carbon.apimgt.internal.service.dto.RevokedJWTDTO;
+import org.wso2.carbon.apimgt.internal.service.dto.RevokedJWTSubjectEntityDTO;
+import org.wso2.carbon.apimgt.internal.service.model.RevokedJWTEventData;
 import org.wso2.carbon.apimgt.internal.service.utils.BlockConditionDBUtil;
+import org.wso2.carbon.apimgt.rest.api.common.RestApiCommonUtil;
+import org.wso2.carbon.context.CarbonContext;
+import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 
 import javax.ws.rs.core.Response;
 
@@ -11,6 +20,55 @@ public class RevokedjwtApiServiceImpl implements RevokedjwtApiService {
 
     @Override
     public Response revokedjwtGet(MessageContext messageContext) throws APIManagementException {
-        return Response.ok().entity(BlockConditionDBUtil.getRevokedJWTEvents()).build();
+
+        String tenantDomain = RestApiCommonUtil.getLoggedInUserTenantDomain();
+        int tenantId = CarbonContext.getThreadLocalCarbonContext().getTenantId();
+        if (!isValidTenantContext(tenantDomain, tenantId)) {
+            return Response.ok().entity(new RevokedEventsDTO()).build();
+        }
+        RevokedJWTEventData revokedJWTEventData = BlockConditionDBUtil.getRevokedJWTEventsWithOwnership();
+        return Response.ok().entity(filterRevokedJWTEvents(revokedJWTEventData, tenantDomain, tenantId)).build();
+    }
+
+    static RevokedEventsDTO filterRevokedJWTEvents(RevokedJWTEventData revokedJWTEventData, String tenantDomain,
+                                                   int tenantId) {
+
+        RevokedEventsDTO revokedEventsDTO = new RevokedEventsDTO();
+        if (revokedJWTEventData == null || !isValidTenantContext(tenantDomain, tenantId)) {
+            return revokedEventsDTO;
+        }
+
+        boolean isSuperTenant = MultitenantConstants.SUPER_TENANT_DOMAIN_NAME.equals(tenantDomain);
+        for (RevokedJWTEventData.RevokedJWTData revokedJWT : revokedJWTEventData.getRevokedJWTList()) {
+            if (isSuperTenant || revokedJWT.getTenantId() == tenantId) {
+                RevokedJWTDTO revokedJWTDTO = new RevokedJWTDTO();
+                revokedJWTDTO.setJwtSignature(revokedJWT.getJwtSignature());
+                revokedJWTDTO.setExpiryTime(revokedJWT.getExpiryTime());
+                revokedEventsDTO.getRevokedJWTList().add(revokedJWTDTO);
+            }
+        }
+        for (RevokedJWTConsumerKeyDTO revokedConsumerKey :
+                revokedJWTEventData.getRevokedJWTConsumerKeyList()) {
+            if (isSuperTenant || tenantDomain.equals(revokedConsumerKey.getOrganization())) {
+                revokedEventsDTO.getRevokedJWTConsumerKeyList().add(revokedConsumerKey);
+            }
+        }
+        for (RevokedJWTSubjectEntityDTO revokedSubjectEntity :
+                revokedJWTEventData.getRevokedJWTSubjectEntityList()) {
+            if (isSuperTenant || tenantDomain.equals(revokedSubjectEntity.getOrganization())) {
+                revokedEventsDTO.getRevokedJWTSubjectEntityList().add(revokedSubjectEntity);
+            }
+        }
+        return revokedEventsDTO;
+    }
+
+    private static boolean isValidTenantContext(String tenantDomain, int tenantId) {
+
+        if (StringUtils.isBlank(tenantDomain)) {
+            return false;
+        }
+        boolean isSuperTenantDomain = MultitenantConstants.SUPER_TENANT_DOMAIN_NAME.equals(tenantDomain);
+        boolean isSuperTenantId = MultitenantConstants.SUPER_TENANT_ID == tenantId;
+        return isSuperTenantDomain == isSuperTenantId && (isSuperTenantId || tenantId >= 0);
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/main/java/org/wso2/carbon/apimgt/internal/service/impl/SubscriptionsApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/main/java/org/wso2/carbon/apimgt/internal/service/impl/SubscriptionsApiServiceImpl.java
@@ -46,7 +46,8 @@ public class SubscriptionsApiServiceImpl implements SubscriptionsApiService {
         SubscriptionValidationDAO subscriptionValidationDAO = new SubscriptionValidationDAO();
         List<Subscription> subscriptionList = new ArrayList<>();
         xWSO2Tenant = SubscriptionValidationDataUtil.validateTenantDomain(xWSO2Tenant, messageContext);
-        String organization = RestApiUtil.getOrganization(messageContext);
+        String organization = validateOrganization(RestApiUtil.getOrganization(messageContext),
+                RestApiCommonUtil.getLoggedInUserTenantDomain());
         if (StringUtils.isNotEmpty(applicationUUID) && StringUtils.isNotEmpty(apiUUID)) {
             String authenticatedOrganization = RestApiCommonUtil.getLoggedInUserTenantDomain();
             Subscription subscription = getSubscription(subscriptionValidationDAO, apiUUID, applicationUUID,
@@ -109,5 +110,14 @@ public class SubscriptionsApiServiceImpl implements SubscriptionsApiService {
         return subscription != null &&
                 (MultitenantConstants.SUPER_TENANT_DOMAIN_NAME.equalsIgnoreCase(organization) ||
                         organization.equalsIgnoreCase(subscription.getAppOrganization()));
+    }
+
+    static String validateOrganization(String requestedOrganization, String authenticatedOrganization) {
+
+        if (StringUtils.isEmpty(authenticatedOrganization)) {
+            return null;
+        }
+        return MultitenantConstants.SUPER_TENANT_DOMAIN_NAME.equals(authenticatedOrganization)
+                ? requestedOrganization : authenticatedOrganization;
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/main/java/org/wso2/carbon/apimgt/internal/service/impl/SubscriptionsApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/main/java/org/wso2/carbon/apimgt/internal/service/impl/SubscriptionsApiServiceImpl.java
@@ -43,13 +43,18 @@ public class SubscriptionsApiServiceImpl implements SubscriptionsApiService {
 
         Response result;
 
-        SubscriptionValidationDAO subscriptionValidationDAO = new SubscriptionValidationDAO();
         List<Subscription> subscriptionList = new ArrayList<>();
+        String authenticatedOrganization = RestApiCommonUtil.getLoggedInUserTenantDomain();
+        if (StringUtils.isEmpty(authenticatedOrganization)) {
+            return Response.ok().entity(
+                    SubscriptionValidationDataUtil.fromSubscriptionToSubscriptionListDTO(subscriptionList)).build();
+        }
+
+        SubscriptionValidationDAO subscriptionValidationDAO = new SubscriptionValidationDAO();
         xWSO2Tenant = SubscriptionValidationDataUtil.validateTenantDomain(xWSO2Tenant, messageContext);
         String organization = validateOrganization(RestApiUtil.getOrganization(messageContext),
-                RestApiCommonUtil.getLoggedInUserTenantDomain());
+                authenticatedOrganization);
         if (StringUtils.isNotEmpty(applicationUUID) && StringUtils.isNotEmpty(apiUUID)) {
-            String authenticatedOrganization = RestApiCommonUtil.getLoggedInUserTenantDomain();
             Subscription subscription = getSubscription(subscriptionValidationDAO, apiUUID, applicationUUID,
                     authenticatedOrganization);
             if (subscription != null) {
@@ -58,7 +63,6 @@ public class SubscriptionsApiServiceImpl implements SubscriptionsApiService {
             result = Response.ok().entity(
                     SubscriptionValidationDataUtil.fromSubscriptionToSubscriptionListDTO(subscriptionList)).build();
         } else if (apiId != null && appId != null) {
-            String authenticatedOrganization = RestApiCommonUtil.getLoggedInUserTenantDomain();
             Subscription subscription = getSubscription(subscriptionValidationDAO, apiId, appId,
                     authenticatedOrganization);
             if (subscription != null) {
@@ -117,7 +121,7 @@ public class SubscriptionsApiServiceImpl implements SubscriptionsApiService {
         if (StringUtils.isEmpty(authenticatedOrganization)) {
             return null;
         }
-        return MultitenantConstants.SUPER_TENANT_DOMAIN_NAME.equals(authenticatedOrganization)
+        return MultitenantConstants.SUPER_TENANT_DOMAIN_NAME.equalsIgnoreCase(authenticatedOrganization)
                 ? requestedOrganization : authenticatedOrganization;
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/main/java/org/wso2/carbon/apimgt/internal/service/impl/SubscriptionsApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/main/java/org/wso2/carbon/apimgt/internal/service/impl/SubscriptionsApiServiceImpl.java
@@ -26,6 +26,7 @@ import org.wso2.carbon.apimgt.impl.APIConstants;
 import org.wso2.carbon.apimgt.impl.dao.SubscriptionValidationDAO;
 import org.wso2.carbon.apimgt.internal.service.SubscriptionsApiService;
 import org.wso2.carbon.apimgt.internal.service.utils.SubscriptionValidationDataUtil;
+import org.wso2.carbon.apimgt.rest.api.common.RestApiCommonUtil;
 import org.wso2.carbon.apimgt.rest.api.util.utils.RestApiUtil;
 import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 
@@ -47,14 +48,18 @@ public class SubscriptionsApiServiceImpl implements SubscriptionsApiService {
         xWSO2Tenant = SubscriptionValidationDataUtil.validateTenantDomain(xWSO2Tenant, messageContext);
         String organization = RestApiUtil.getOrganization(messageContext);
         if (StringUtils.isNotEmpty(applicationUUID) && StringUtils.isNotEmpty(apiUUID)) {
-            Subscription subscription = subscriptionValidationDAO.getSubscription(apiUUID, applicationUUID);
+            String authenticatedOrganization = RestApiCommonUtil.getLoggedInUserTenantDomain();
+            Subscription subscription = getSubscription(subscriptionValidationDAO, apiUUID, applicationUUID,
+                    authenticatedOrganization);
             if (subscription != null) {
                 subscriptionList.add(subscription);
             }
             result = Response.ok().entity(
                     SubscriptionValidationDataUtil.fromSubscriptionToSubscriptionListDTO(subscriptionList)).build();
         } else if (apiId != null && appId != null) {
-            Subscription subscription = subscriptionValidationDAO.getSubscription(apiId, appId);
+            String authenticatedOrganization = RestApiCommonUtil.getLoggedInUserTenantDomain();
+            Subscription subscription = getSubscription(subscriptionValidationDAO, apiId, appId,
+                    authenticatedOrganization);
             if (subscription != null) {
                 subscriptionList.add(subscription);
             }
@@ -77,5 +82,32 @@ public class SubscriptionsApiServiceImpl implements SubscriptionsApiService {
         }
 
         return result;
+    }
+
+    static Subscription getSubscription(SubscriptionValidationDAO subscriptionValidationDAO, String apiUUID,
+                                        String applicationUUID, String authenticatedOrganization) {
+
+        if (StringUtils.isEmpty(authenticatedOrganization)) {
+            return null;
+        }
+        Subscription subscription = subscriptionValidationDAO.getSubscription(apiUUID, applicationUUID);
+        return isSubscriptionAccessibleForOrganization(subscription, authenticatedOrganization) ? subscription : null;
+    }
+
+    static Subscription getSubscription(SubscriptionValidationDAO subscriptionValidationDAO, int apiId, int appId,
+                                        String authenticatedOrganization) {
+
+        if (StringUtils.isEmpty(authenticatedOrganization)) {
+            return null;
+        }
+        Subscription subscription = subscriptionValidationDAO.getSubscription(apiId, appId);
+        return isSubscriptionAccessibleForOrganization(subscription, authenticatedOrganization) ? subscription : null;
+    }
+
+    private static boolean isSubscriptionAccessibleForOrganization(Subscription subscription, String organization) {
+
+        return subscription != null &&
+                (MultitenantConstants.SUPER_TENANT_DOMAIN_NAME.equalsIgnoreCase(organization) ||
+                        organization.equalsIgnoreCase(subscription.getAppOrganization()));
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/main/java/org/wso2/carbon/apimgt/internal/service/model/RevokedJWTEventData.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/main/java/org/wso2/carbon/apimgt/internal/service/model/RevokedJWTEventData.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.apimgt.internal.service.model;
+
+import org.wso2.carbon.apimgt.internal.service.dto.RevokedJWTConsumerKeyDTO;
+import org.wso2.carbon.apimgt.internal.service.dto.RevokedJWTSubjectEntityDTO;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Internal revocation data with the ownership information required by the internal REST service.
+ */
+public class RevokedJWTEventData {
+
+    private final List<RevokedJWTData> revokedJWTList = new ArrayList<>();
+    private final List<RevokedJWTSubjectEntityDTO> revokedJWTSubjectEntityList = new ArrayList<>();
+    private final List<RevokedJWTConsumerKeyDTO> revokedJWTConsumerKeyList = new ArrayList<>();
+
+    public List<RevokedJWTData> getRevokedJWTList() {
+
+        return revokedJWTList;
+    }
+
+    public List<RevokedJWTSubjectEntityDTO> getRevokedJWTSubjectEntityList() {
+
+        return revokedJWTSubjectEntityList;
+    }
+
+    public List<RevokedJWTConsumerKeyDTO> getRevokedJWTConsumerKeyList() {
+
+        return revokedJWTConsumerKeyList;
+    }
+
+    /**
+     * Internal direct JWT revocation record with its owning tenant ID.
+     */
+    public static class RevokedJWTData {
+
+        private final String jwtSignature;
+        private final Long expiryTime;
+        private final int tenantId;
+
+        public RevokedJWTData(String jwtSignature, Long expiryTime, int tenantId) {
+
+            this.jwtSignature = jwtSignature;
+            this.expiryTime = expiryTime;
+            this.tenantId = tenantId;
+        }
+
+        public String getJwtSignature() {
+
+            return jwtSignature;
+        }
+
+        public Long getExpiryTime() {
+
+            return expiryTime;
+        }
+
+        public int getTenantId() {
+
+            return tenantId;
+        }
+    }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/main/java/org/wso2/carbon/apimgt/internal/service/utils/BlockConditionDBUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/main/java/org/wso2/carbon/apimgt/internal/service/utils/BlockConditionDBUtil.java
@@ -25,6 +25,7 @@ import com.google.gson.JsonPrimitive;
 import com.google.gson.JsonSyntaxException;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.apimgt.api.APIManagementException;
 import org.wso2.carbon.apimgt.impl.APIConstants;
 import org.wso2.carbon.apimgt.impl.utils.APIMgtDBUtil;
 import org.wso2.carbon.apimgt.internal.service.dto.BlockConditionsDTO;
@@ -33,6 +34,7 @@ import org.wso2.carbon.apimgt.internal.service.dto.RevokedEventsDTO;
 import org.wso2.carbon.apimgt.internal.service.dto.RevokedJWTConsumerKeyDTO;
 import org.wso2.carbon.apimgt.internal.service.dto.RevokedJWTDTO;
 import org.wso2.carbon.apimgt.internal.service.dto.RevokedJWTSubjectEntityDTO;
+import org.wso2.carbon.apimgt.internal.service.model.RevokedJWTEventData;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
@@ -304,5 +306,77 @@ public final class BlockConditionDBUtil {
         revokedEventsDTO.setRevokedJWTConsumerKeyList(getRevokedJWTConsumerKeys());
         revokedEventsDTO.setRevokedJWTSubjectEntityList(getRevokedJWTSubjectEntities());
         return revokedEventsDTO;
+    }
+
+    /**
+     * Retrieves revoked JWT event data with the ownership information required by the internal REST service.
+     *
+     * @return revoked JWT event data with ownership information
+     */
+    public static RevokedJWTEventData getRevokedJWTEventsWithOwnership() throws APIManagementException {
+
+        try (Connection conn = APIMgtDBUtil.getConnection()) {
+            return getRevokedJWTEventsWithOwnership(conn);
+        } catch (SQLException e) {
+            throw new APIManagementException("Error while fetching revoked JWT events from database", e);
+        }
+    }
+
+    static RevokedJWTEventData getRevokedJWTEventsWithOwnership(Connection connection) throws SQLException {
+
+        RevokedJWTEventData revokedJWTEventData = new RevokedJWTEventData();
+        addRevokedJWTsWithOwnership(connection, revokedJWTEventData);
+        addRevokedJWTConsumerKeysWithOwnership(connection, revokedJWTEventData);
+        addRevokedJWTSubjectEntitiesWithOwnership(connection, revokedJWTEventData);
+        return revokedJWTEventData;
+    }
+
+    static void addRevokedJWTsWithOwnership(Connection connection, RevokedJWTEventData revokedJWTEventData)
+            throws SQLException {
+
+        String sqlQuery = "SELECT SIGNATURE, EXPIRY_TIMESTAMP, TENANT_ID FROM AM_REVOKED_JWT";
+        try (PreparedStatement ps = connection.prepareStatement(sqlQuery);
+             ResultSet rs = ps.executeQuery()) {
+            while (rs.next()) {
+                revokedJWTEventData.getRevokedJWTList().add(new RevokedJWTEventData.RevokedJWTData(
+                        rs.getString("SIGNATURE"), rs.getLong("EXPIRY_TIMESTAMP"), rs.getInt("TENANT_ID")));
+            }
+        }
+    }
+
+    static void addRevokedJWTConsumerKeysWithOwnership(Connection connection,
+                                                       RevokedJWTEventData revokedJWTEventData) throws SQLException {
+
+        String sqlQuery = "SELECT CONSUMER_KEY, TIME_REVOKED, ORGANIZATION FROM AM_APP_REVOKED_EVENT";
+        try (PreparedStatement ps = connection.prepareStatement(sqlQuery);
+             ResultSet rs = ps.executeQuery()) {
+            while (rs.next()) {
+                RevokedJWTConsumerKeyDTO revokedJWTConsumerKeyDTO = new RevokedJWTConsumerKeyDTO();
+                revokedJWTConsumerKeyDTO.setConsumerKey(rs.getString("CONSUMER_KEY"));
+                revokedJWTConsumerKeyDTO.setRevocationTime(rs.getTimestamp("TIME_REVOKED",
+                        Calendar.getInstance(TimeZone.getTimeZone("UTC"))).getTime());
+                revokedJWTConsumerKeyDTO.setOrganization(rs.getString("ORGANIZATION"));
+                revokedJWTEventData.getRevokedJWTConsumerKeyList().add(revokedJWTConsumerKeyDTO);
+            }
+        }
+    }
+
+    static void addRevokedJWTSubjectEntitiesWithOwnership(Connection connection,
+                                                          RevokedJWTEventData revokedJWTEventData) throws SQLException {
+
+        String sqlQuery = "SELECT ENTITY_ID, ENTITY_TYPE, TIME_REVOKED, ORGANIZATION "
+                + "FROM AM_SUBJECT_ENTITY_REVOKED_EVENT";
+        try (PreparedStatement ps = connection.prepareStatement(sqlQuery);
+             ResultSet rs = ps.executeQuery()) {
+            while (rs.next()) {
+                RevokedJWTSubjectEntityDTO revokedJWTSubjectEntityDTO = new RevokedJWTSubjectEntityDTO();
+                revokedJWTSubjectEntityDTO.setEntityId(rs.getString("ENTITY_ID"));
+                revokedJWTSubjectEntityDTO.setEntityType(rs.getString("ENTITY_TYPE"));
+                revokedJWTSubjectEntityDTO.setRevocationTime(rs.getTimestamp("TIME_REVOKED",
+                        Calendar.getInstance(TimeZone.getTimeZone("UTC"))).getTime());
+                revokedJWTSubjectEntityDTO.setOrganization(rs.getString("ORGANIZATION"));
+                revokedJWTEventData.getRevokedJWTSubjectEntityList().add(revokedJWTSubjectEntityDTO);
+            }
+        }
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/test/java/org/wso2/carbon/apimgt/internal/service/impl/ApplicationsApiServiceImplTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/test/java/org/wso2/carbon/apimgt/internal/service/impl/ApplicationsApiServiceImplTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.apimgt.internal.service.impl;
+
+import org.junit.Test;
+import org.wso2.carbon.apimgt.api.model.subscription.Application;
+import org.wso2.carbon.apimgt.impl.dao.SubscriptionValidationDAO;
+import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class ApplicationsApiServiceImplTest {
+
+    private static final int APPLICATION_ID = 42;
+    private static final String TENANT_DOMAIN = "application-owner.example";
+
+    @Test
+    public void testTenantLookupReturnsApplicationFromMatchingOrganization() {
+        RecordingSubscriptionValidationDAO dao = new RecordingSubscriptionValidationDAO();
+        dao.applicationResult = Collections.singletonList(application(TENANT_DOMAIN));
+
+        List<Application> applications =
+                ApplicationsApiServiceImpl.getApplicationById(dao, APPLICATION_ID, TENANT_DOMAIN);
+
+        assertEquals(1, applications.size());
+        assertEquals(1, dao.calls);
+    }
+
+    @Test
+    public void testTenantLookupReturnsEmptyForDifferentOrganization() {
+        RecordingSubscriptionValidationDAO dao = new RecordingSubscriptionValidationDAO();
+        dao.applicationResult = Collections.singletonList(application("other.example"));
+
+        List<Application> applications =
+                ApplicationsApiServiceImpl.getApplicationById(dao, APPLICATION_ID, TENANT_DOMAIN);
+
+        assertTrue(applications.isEmpty());
+        assertEquals(1, dao.calls);
+    }
+
+    @Test
+    public void testSuperTenantLookupPreservesApplicationFromAnyOrganization() {
+        RecordingSubscriptionValidationDAO dao = new RecordingSubscriptionValidationDAO();
+        dao.applicationResult = Collections.singletonList(application("other.example"));
+
+        List<Application> applications = ApplicationsApiServiceImpl.getApplicationById(
+                dao, APPLICATION_ID, MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
+
+        assertEquals(1, applications.size());
+        assertEquals(1, dao.calls);
+    }
+
+    @Test
+    public void testMissingOrganizationDoesNotQueryApplication() {
+        RecordingSubscriptionValidationDAO dao = new RecordingSubscriptionValidationDAO();
+
+        assertTrue(ApplicationsApiServiceImpl.getApplicationById(dao, APPLICATION_ID, null).isEmpty());
+        assertTrue(ApplicationsApiServiceImpl.getApplicationById(dao, APPLICATION_ID, "").isEmpty());
+        assertEquals(0, dao.calls);
+    }
+
+    @Test
+    public void testTenantLookupPreservesEmptyResult() {
+        RecordingSubscriptionValidationDAO dao = new RecordingSubscriptionValidationDAO();
+        dao.applicationResult = Collections.emptyList();
+
+        assertTrue(ApplicationsApiServiceImpl.getApplicationById(dao, APPLICATION_ID, TENANT_DOMAIN).isEmpty());
+        assertEquals(1, dao.calls);
+    }
+
+    private static Application application(String organization) {
+        Application application = new Application();
+        application.setOrganization(organization);
+        return application;
+    }
+
+    private static class RecordingSubscriptionValidationDAO extends SubscriptionValidationDAO {
+
+        private int calls;
+        private List<Application> applicationResult = Collections.emptyList();
+
+        @Override
+        public List<Application> getApplicationById(int applicationId) {
+            calls++;
+            return applicationResult;
+        }
+    }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/test/java/org/wso2/carbon/apimgt/internal/service/impl/LlmProvidersApiServiceImplTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/test/java/org/wso2/carbon/apimgt/internal/service/impl/LlmProvidersApiServiceImplTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.apimgt.internal.service.impl;
+
+import org.junit.Test;
+import org.wso2.carbon.apimgt.api.APIConstants;
+import org.wso2.carbon.apimgt.api.APIManagementException;
+import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
+
+/**
+ * Tests organization resolution for the internal LLM provider endpoints.
+ *
+ * The resolved organization is the only scoping applied before the query, and a null
+ * organization removes the ORGANIZATION predicate from the generated SQL entirely, so
+ * these cases cover both the scoping behaviour and the fail-closed behaviour.
+ */
+public class LlmProvidersApiServiceImplTest {
+
+    private static final String TENANT_DOMAIN = "provider-owner.example";
+    private static final String OTHER_TENANT_DOMAIN = "another-tenant.example";
+    private static final String ALL = APIConstants.AIAPIConstants.LLM_PROVIDER_TENANT_ALL;
+    private static final String SUPER = MultitenantConstants.SUPER_TENANT_DOMAIN_NAME;
+
+    // --- tenant-scoped caller: always pinned to its own organization ---
+
+    @Test
+    public void testTenantCallerRequestingAnotherOrganizationIsPinnedToItsOwn()
+            throws APIManagementException {
+
+        assertEquals(TENANT_DOMAIN,
+                LlmProvidersApiServiceImpl.getOrganizationXWSO2Tenant(OTHER_TENANT_DOMAIN, TENANT_DOMAIN));
+    }
+
+    @Test
+    public void testTenantCallerRequestingSuperTenantIsPinnedToItsOwn() throws APIManagementException {
+
+        assertEquals(TENANT_DOMAIN,
+                LlmProvidersApiServiceImpl.getOrganizationXWSO2Tenant(SUPER, TENANT_DOMAIN));
+    }
+
+    @Test
+    public void testTenantCallerRequestingAllIsPinnedToItsOwn() throws APIManagementException {
+
+        // "ALL" must not widen scope for a tenant caller, and must not resolve to null,
+        // which would drop the ORGANIZATION predicate from the query.
+        assertEquals(TENANT_DOMAIN,
+                LlmProvidersApiServiceImpl.getOrganizationXWSO2Tenant(ALL, TENANT_DOMAIN));
+    }
+
+    @Test
+    public void testTenantCallerRequestingItsOwnOrganizationIsUnchanged() throws APIManagementException {
+
+        assertEquals(TENANT_DOMAIN,
+                LlmProvidersApiServiceImpl.getOrganizationXWSO2Tenant(TENANT_DOMAIN, TENANT_DOMAIN));
+    }
+
+    @Test
+    public void testTenantCallerWithoutRequestedTenantIsPinnedToItsOwn() throws APIManagementException {
+
+        assertEquals(TENANT_DOMAIN,
+                LlmProvidersApiServiceImpl.getOrganizationXWSO2Tenant(null, TENANT_DOMAIN));
+    }
+
+    // --- super tenant caller: existing behaviour preserved ---
+
+    @Test
+    public void testSuperTenantCallerCanRequestAnotherOrganization() throws APIManagementException {
+
+        assertEquals(TENANT_DOMAIN,
+                LlmProvidersApiServiceImpl.getOrganizationXWSO2Tenant(TENANT_DOMAIN, SUPER));
+    }
+
+    @Test
+    public void testSuperTenantCallerRequestingAllResolvesToNoOrganizationFilter()
+            throws APIManagementException {
+
+        assertNull(LlmProvidersApiServiceImpl.getOrganizationXWSO2Tenant(ALL, SUPER));
+    }
+
+    @Test
+    public void testSuperTenantCallerWithoutRequestedTenantDefaultsToSuperTenant()
+            throws APIManagementException {
+
+        assertEquals(SUPER, LlmProvidersApiServiceImpl.getOrganizationXWSO2Tenant(null, SUPER));
+    }
+
+    // --- unresolvable caller organization: must fail closed ---
+
+    @Test
+    public void testNullAuthenticatedOrganizationIsRejected() {
+
+        assertRejected(null);
+    }
+
+    @Test
+    public void testEmptyAuthenticatedOrganizationIsRejected() {
+
+        // An empty organization must not be passed through: it removes the ORGANIZATION
+        // predicate in the list query while retaining it in the by-id query.
+        assertRejected("");
+    }
+
+    private void assertRejected(String authenticatedOrganization) {
+
+        try {
+            LlmProvidersApiServiceImpl.getOrganizationXWSO2Tenant(ALL, authenticatedOrganization);
+            fail("Expected APIManagementException when the authenticated organization is unavailable");
+        } catch (APIManagementException expected) {
+            // expected
+        }
+    }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/test/java/org/wso2/carbon/apimgt/internal/service/impl/NotifyApiServiceImplTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/test/java/org/wso2/carbon/apimgt/internal/service/impl/NotifyApiServiceImplTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.apimgt.internal.service.impl;
+
+import org.junit.Test;
+import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests which callers may dispatch notification events.
+ *
+ * Notification events are published on behalf of the whole deployment and the organization they
+ * apply to is taken from the event payload, so only the super tenant may dispatch them.
+ */
+public class NotifyApiServiceImplTest {
+
+    private static final String TENANT_DOMAIN = "event-sender.example";
+
+    @Test
+    public void testSuperTenantIsAllowedToDispatch() {
+
+        assertTrue(NotifyApiServiceImpl.isNotificationDispatchAllowed(
+                MultitenantConstants.SUPER_TENANT_DOMAIN_NAME));
+    }
+
+    @Test
+    public void testSuperTenantMatchIsCaseInsensitive() {
+
+        assertTrue(NotifyApiServiceImpl.isNotificationDispatchAllowed(
+                MultitenantConstants.SUPER_TENANT_DOMAIN_NAME.toUpperCase()));
+    }
+
+    @Test
+    public void testTenantIsNotAllowedToDispatch() {
+
+        assertFalse(NotifyApiServiceImpl.isNotificationDispatchAllowed(TENANT_DOMAIN));
+    }
+
+    @Test
+    public void testNullOrganizationIsNotAllowedToDispatch() {
+
+        assertFalse(NotifyApiServiceImpl.isNotificationDispatchAllowed(null));
+    }
+
+    @Test
+    public void testEmptyOrganizationIsNotAllowedToDispatch() {
+
+        assertFalse(NotifyApiServiceImpl.isNotificationDispatchAllowed(""));
+    }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/test/java/org/wso2/carbon/apimgt/internal/service/impl/RevokedjwtApiServiceImplTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/test/java/org/wso2/carbon/apimgt/internal/service/impl/RevokedjwtApiServiceImplTest.java
@@ -74,6 +74,30 @@ public class RevokedjwtApiServiceImplTest {
     }
 
     @Test
+    public void testFilterRevokedJWTEventsForSuperTenantRegardlessOfDomainCase() {
+
+        RevokedEventsDTO result = RevokedjwtApiServiceImpl.filterRevokedJWTEvents(
+                createRevokedJWTEventData(), MultitenantConstants.SUPER_TENANT_DOMAIN_NAME.toUpperCase(),
+                MultitenantConstants.SUPER_TENANT_ID);
+
+        assertEquals(3, result.getRevokedJWTList().size());
+        assertEquals(2, result.getRevokedJWTConsumerKeyList().size());
+        assertEquals(2, result.getRevokedJWTSubjectEntityList().size());
+    }
+
+    @Test
+    public void testFilterRevokedJWTEventsForTenantRegardlessOfOrganizationCase() {
+
+        RevokedEventsDTO result = RevokedjwtApiServiceImpl.filterRevokedJWTEvents(
+                createRevokedJWTEventData(), TENANT_DOMAIN.toUpperCase(), TENANT_ID);
+
+        assertEquals(1, result.getRevokedJWTConsumerKeyList().size());
+        assertEquals("own-consumer-key", result.getRevokedJWTConsumerKeyList().get(0).getConsumerKey());
+        assertEquals(1, result.getRevokedJWTSubjectEntityList().size());
+        assertEquals("own-subject", result.getRevokedJWTSubjectEntityList().get(0).getEntityId());
+    }
+
+    @Test
     public void testFilterRevokedJWTEventsFailsClosedForInvalidTenantContext() {
 
         assertEmpty(RevokedjwtApiServiceImpl.filterRevokedJWTEvents(

--- a/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/test/java/org/wso2/carbon/apimgt/internal/service/impl/RevokedjwtApiServiceImplTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/test/java/org/wso2/carbon/apimgt/internal/service/impl/RevokedjwtApiServiceImplTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.apimgt.internal.service.impl;
+
+import org.junit.Test;
+import org.wso2.carbon.apimgt.internal.service.dto.RevokedEventsDTO;
+import org.wso2.carbon.apimgt.internal.service.dto.RevokedJWTConsumerKeyDTO;
+import org.wso2.carbon.apimgt.internal.service.dto.RevokedJWTSubjectEntityDTO;
+import org.wso2.carbon.apimgt.internal.service.model.RevokedJWTEventData;
+import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class RevokedjwtApiServiceImplTest {
+
+    private static final String TENANT_DOMAIN = "tenant-a.com";
+    private static final String FOREIGN_TENANT_DOMAIN = "tenant-b.com";
+    private static final int TENANT_ID = 1;
+    private static final int FOREIGN_TENANT_ID = 2;
+
+    @Test
+    public void testFilterRevokedJWTEventsForTenant() {
+
+        RevokedEventsDTO result = RevokedjwtApiServiceImpl.filterRevokedJWTEvents(
+                createRevokedJWTEventData(), TENANT_DOMAIN, TENANT_ID);
+
+        assertEquals(1, result.getRevokedJWTList().size());
+        assertEquals("own-signature", result.getRevokedJWTList().get(0).getJwtSignature());
+        assertEquals(1, result.getRevokedJWTConsumerKeyList().size());
+        assertEquals("own-consumer-key", result.getRevokedJWTConsumerKeyList().get(0).getConsumerKey());
+        assertEquals(1, result.getRevokedJWTSubjectEntityList().size());
+        assertEquals("own-subject", result.getRevokedJWTSubjectEntityList().get(0).getEntityId());
+    }
+
+    @Test
+    public void testFilterRevokedJWTEventsForSuperTenant() {
+
+        RevokedEventsDTO result = RevokedjwtApiServiceImpl.filterRevokedJWTEvents(
+                createRevokedJWTEventData(), MultitenantConstants.SUPER_TENANT_DOMAIN_NAME,
+                MultitenantConstants.SUPER_TENANT_ID);
+
+        assertEquals(3, result.getRevokedJWTList().size());
+        assertEquals(2, result.getRevokedJWTConsumerKeyList().size());
+        assertEquals(2, result.getRevokedJWTSubjectEntityList().size());
+    }
+
+    @Test
+    public void testFilterRevokedJWTEventsFailsClosedForInconsistentSuperTenantContext() {
+
+        RevokedEventsDTO domainMismatchResult = RevokedjwtApiServiceImpl.filterRevokedJWTEvents(
+                createRevokedJWTEventData(), MultitenantConstants.SUPER_TENANT_DOMAIN_NAME, TENANT_ID);
+        RevokedEventsDTO idMismatchResult = RevokedjwtApiServiceImpl.filterRevokedJWTEvents(
+                createRevokedJWTEventData(), TENANT_DOMAIN, MultitenantConstants.SUPER_TENANT_ID);
+
+        assertEmpty(domainMismatchResult);
+        assertEmpty(idMismatchResult);
+    }
+
+    @Test
+    public void testFilterRevokedJWTEventsFailsClosedForInvalidTenantContext() {
+
+        assertEmpty(RevokedjwtApiServiceImpl.filterRevokedJWTEvents(
+                createRevokedJWTEventData(), null, TENANT_ID));
+        assertEmpty(RevokedjwtApiServiceImpl.filterRevokedJWTEvents(
+                createRevokedJWTEventData(), "", TENANT_ID));
+        assertEmpty(RevokedjwtApiServiceImpl.filterRevokedJWTEvents(
+                createRevokedJWTEventData(), TENANT_DOMAIN, -2));
+    }
+
+    private static RevokedJWTEventData createRevokedJWTEventData() {
+
+        RevokedJWTEventData data = new RevokedJWTEventData();
+        data.getRevokedJWTList().add(new RevokedJWTEventData.RevokedJWTData(
+                "own-signature", 1000L, TENANT_ID));
+        data.getRevokedJWTList().add(new RevokedJWTEventData.RevokedJWTData(
+                "foreign-signature", 2000L, FOREIGN_TENANT_ID));
+        data.getRevokedJWTList().add(new RevokedJWTEventData.RevokedJWTData(
+                "legacy-signature", 3000L, MultitenantConstants.INVALID_TENANT_ID));
+
+        data.getRevokedJWTConsumerKeyList().add(new RevokedJWTConsumerKeyDTO()
+                .consumerKey("own-consumer-key").revocationTime(1000L).organization(TENANT_DOMAIN));
+        data.getRevokedJWTConsumerKeyList().add(new RevokedJWTConsumerKeyDTO()
+                .consumerKey("foreign-consumer-key").revocationTime(2000L).organization(FOREIGN_TENANT_DOMAIN));
+
+        data.getRevokedJWTSubjectEntityList().add(new RevokedJWTSubjectEntityDTO()
+                .entityId("own-subject").entityType("USER").revocationTime(1000L).organization(TENANT_DOMAIN));
+        data.getRevokedJWTSubjectEntityList().add(new RevokedJWTSubjectEntityDTO()
+                .entityId("foreign-subject").entityType("USER").revocationTime(2000L)
+                .organization(FOREIGN_TENANT_DOMAIN));
+        return data;
+    }
+
+    private static void assertEmpty(RevokedEventsDTO result) {
+
+        assertTrue(result.getRevokedJWTList().isEmpty());
+        assertTrue(result.getRevokedJWTConsumerKeyList().isEmpty());
+        assertTrue(result.getRevokedJWTSubjectEntityList().isEmpty());
+    }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/test/java/org/wso2/carbon/apimgt/internal/service/impl/SubscriptionsApiServiceImplTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/test/java/org/wso2/carbon/apimgt/internal/service/impl/SubscriptionsApiServiceImplTest.java
@@ -21,11 +21,15 @@ package org.wso2.carbon.apimgt.internal.service.impl;
 import org.junit.Test;
 import org.wso2.carbon.apimgt.api.model.subscription.Subscription;
 import org.wso2.carbon.apimgt.impl.dao.SubscriptionValidationDAO;
+import org.wso2.carbon.apimgt.internal.service.dto.SubscriptionListDTO;
 import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
+
+import javax.ws.rs.core.Response;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 
 public class SubscriptionsApiServiceImplTest {
 
@@ -166,6 +170,30 @@ public class SubscriptionsApiServiceImplTest {
     public void testValidateOrganizationUsesAuthenticatedTenantWhenRequestedOrganizationIsMissing() {
 
         assertEquals(TENANT_ORGANIZATION, validateAs(TENANT_ORGANIZATION, null));
+    }
+
+    @Test
+    public void testValidateOrganizationRecognizesSuperTenantRegardlessOfCase() {
+
+        // Every other super-tenant check in this class is case-insensitive; this one must match.
+        assertEquals(OTHER_ORGANIZATION, validateAs(
+                MultitenantConstants.SUPER_TENANT_DOMAIN_NAME.toUpperCase(), OTHER_ORGANIZATION));
+    }
+
+    @Test
+    public void testMissingAuthenticatedOrganizationReturnsEmptyListInsteadOfUnscopedQuery() throws Exception {
+
+        // A caller whose own tenant cannot be resolved must not fall through to the unscoped
+        // getAllSubscriptions() branches further down subscriptionsGet(). A thread that never
+        // started a tenant flow has no tenant domain set, reproducing that unresolved state
+        // directly, since RestApiCommonUtil.getLoggedInUserTenantDomain() is a plain
+        // CarbonContext read.
+        System.setProperty("carbon.home", SubscriptionsApiServiceImplTest.class.getResource("/").getFile());
+        Response response = new SubscriptionsApiServiceImpl().subscriptionsGet(
+                null, null, null, null, null, null);
+
+        assertEquals(200, response.getStatus());
+        assertTrue(((SubscriptionListDTO) response.getEntity()).getList().isEmpty());
     }
 
     private String validateAs(String authenticatedOrganization, String requestedOrganization) {

--- a/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/test/java/org/wso2/carbon/apimgt/internal/service/impl/SubscriptionsApiServiceImplTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/test/java/org/wso2/carbon/apimgt/internal/service/impl/SubscriptionsApiServiceImplTest.java
@@ -137,6 +137,42 @@ public class SubscriptionsApiServiceImplTest {
         assertEquals(1, dao.uuidCalls);
     }
 
+    @Test
+    public void testValidateOrganizationUsesAuthenticatedTenantForDifferentOrganization() {
+
+        assertEquals(TENANT_ORGANIZATION, validateAs(TENANT_ORGANIZATION, OTHER_ORGANIZATION));
+    }
+
+    @Test
+    public void testValidateOrganizationUsesAuthenticatedTenantForAllOrganizations() {
+
+        assertEquals(TENANT_ORGANIZATION, validateAs(TENANT_ORGANIZATION, "ALL"));
+    }
+
+    @Test
+    public void testValidateOrganizationPreservesRequestedOrganizationForSuperTenant() {
+
+        assertEquals(OTHER_ORGANIZATION, validateAs(
+                MultitenantConstants.SUPER_TENANT_DOMAIN_NAME, OTHER_ORGANIZATION));
+    }
+
+    @Test
+    public void testValidateOrganizationPreservesMatchingOrganization() {
+
+        assertEquals(TENANT_ORGANIZATION, validateAs(TENANT_ORGANIZATION, TENANT_ORGANIZATION));
+    }
+
+    @Test
+    public void testValidateOrganizationUsesAuthenticatedTenantWhenRequestedOrganizationIsMissing() {
+
+        assertEquals(TENANT_ORGANIZATION, validateAs(TENANT_ORGANIZATION, null));
+    }
+
+    private String validateAs(String authenticatedOrganization, String requestedOrganization) {
+
+        return SubscriptionsApiServiceImpl.validateOrganization(requestedOrganization, authenticatedOrganization);
+    }
+
     private Subscription createSubscription(String applicationOrganization, String apiOrganization) {
 
         Subscription subscription = new Subscription();

--- a/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/test/java/org/wso2/carbon/apimgt/internal/service/impl/SubscriptionsApiServiceImplTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/test/java/org/wso2/carbon/apimgt/internal/service/impl/SubscriptionsApiServiceImplTest.java
@@ -188,12 +188,21 @@ public class SubscriptionsApiServiceImplTest {
         // started a tenant flow has no tenant domain set, reproducing that unresolved state
         // directly, since RestApiCommonUtil.getLoggedInUserTenantDomain() is a plain
         // CarbonContext read.
+        String previousCarbonHome = System.getProperty("carbon.home");
         System.setProperty("carbon.home", SubscriptionsApiServiceImplTest.class.getResource("/").getFile());
-        Response response = new SubscriptionsApiServiceImpl().subscriptionsGet(
-                null, null, null, null, null, null);
+        try {
+            Response response = new SubscriptionsApiServiceImpl().subscriptionsGet(
+                    null, null, null, null, null, null);
 
-        assertEquals(200, response.getStatus());
-        assertTrue(((SubscriptionListDTO) response.getEntity()).getList().isEmpty());
+            assertEquals(200, response.getStatus());
+            assertTrue(((SubscriptionListDTO) response.getEntity()).getList().isEmpty());
+        } finally {
+            if (previousCarbonHome != null) {
+                System.setProperty("carbon.home", previousCarbonHome);
+            } else {
+                System.clearProperty("carbon.home");
+            }
+        }
     }
 
     private String validateAs(String authenticatedOrganization, String requestedOrganization) {

--- a/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/test/java/org/wso2/carbon/apimgt/internal/service/impl/SubscriptionsApiServiceImplTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/test/java/org/wso2/carbon/apimgt/internal/service/impl/SubscriptionsApiServiceImplTest.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.apimgt.internal.service.impl;
+
+import org.junit.Test;
+import org.wso2.carbon.apimgt.api.model.subscription.Subscription;
+import org.wso2.carbon.apimgt.impl.dao.SubscriptionValidationDAO;
+import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+
+public class SubscriptionsApiServiceImplTest {
+
+    private static final int API_ID = 11;
+    private static final int APPLICATION_ID = 22;
+    private static final String API_UUID = "api-uuid";
+    private static final String APPLICATION_UUID = "application-uuid";
+    private static final String TENANT_ORGANIZATION = "tenant.example";
+    private static final String OTHER_ORGANIZATION = "other.example";
+
+    @Test
+    public void testUuidLookupReturnsSubscriptionFromMatchingApplicationOrganization() {
+
+        RecordingSubscriptionValidationDAO dao = new RecordingSubscriptionValidationDAO();
+        Subscription subscription = createSubscription(TENANT_ORGANIZATION, OTHER_ORGANIZATION);
+        dao.uuidResult = subscription;
+
+        assertSame(subscription, SubscriptionsApiServiceImpl.getSubscription(
+                dao, API_UUID, APPLICATION_UUID, TENANT_ORGANIZATION.toUpperCase()));
+        assertEquals(1, dao.uuidCalls);
+        assertEquals(API_UUID, dao.apiUUID);
+        assertEquals(APPLICATION_UUID, dao.applicationUUID);
+    }
+
+    @Test
+    public void testUuidLookupReturnsNullForDifferentApplicationOrganization() {
+
+        RecordingSubscriptionValidationDAO dao = new RecordingSubscriptionValidationDAO();
+        dao.uuidResult = createSubscription(OTHER_ORGANIZATION, TENANT_ORGANIZATION);
+
+        assertNull(SubscriptionsApiServiceImpl.getSubscription(
+                dao, API_UUID, APPLICATION_UUID, TENANT_ORGANIZATION));
+        assertEquals(1, dao.uuidCalls);
+    }
+
+    @Test
+    public void testNumericLookupUsesApplicationOrganization() {
+
+        RecordingSubscriptionValidationDAO dao = new RecordingSubscriptionValidationDAO();
+        Subscription subscription = createSubscription(TENANT_ORGANIZATION, OTHER_ORGANIZATION);
+        dao.numericResult = subscription;
+
+        assertSame(subscription, SubscriptionsApiServiceImpl.getSubscription(
+                dao, API_ID, APPLICATION_ID, TENANT_ORGANIZATION));
+        assertEquals(1, dao.numericCalls);
+        assertEquals(API_ID, dao.apiId);
+        assertEquals(APPLICATION_ID, dao.applicationId);
+    }
+
+    @Test
+    public void testNumericLookupReturnsNullForDifferentApplicationOrganization() {
+
+        RecordingSubscriptionValidationDAO dao = new RecordingSubscriptionValidationDAO();
+        dao.numericResult = createSubscription(OTHER_ORGANIZATION, TENANT_ORGANIZATION);
+
+        assertNull(SubscriptionsApiServiceImpl.getSubscription(
+                dao, API_ID, APPLICATION_ID, TENANT_ORGANIZATION));
+        assertEquals(1, dao.numericCalls);
+    }
+
+    @Test
+    public void testSuperTenantCanUseBothLookupFormsAcrossOrganizations() {
+
+        RecordingSubscriptionValidationDAO dao = new RecordingSubscriptionValidationDAO();
+        Subscription subscription = createSubscription(OTHER_ORGANIZATION, OTHER_ORGANIZATION);
+        dao.uuidResult = subscription;
+        dao.numericResult = subscription;
+
+        assertSame(subscription, SubscriptionsApiServiceImpl.getSubscription(
+                dao, API_UUID, APPLICATION_UUID, MultitenantConstants.SUPER_TENANT_DOMAIN_NAME));
+        assertSame(subscription, SubscriptionsApiServiceImpl.getSubscription(
+                dao, API_ID, APPLICATION_ID, MultitenantConstants.SUPER_TENANT_DOMAIN_NAME));
+        assertEquals(1, dao.uuidCalls);
+        assertEquals(1, dao.numericCalls);
+    }
+
+    @Test
+    public void testMissingSubscriptionReturnsNullForBothLookupForms() {
+
+        RecordingSubscriptionValidationDAO dao = new RecordingSubscriptionValidationDAO();
+
+        assertNull(SubscriptionsApiServiceImpl.getSubscription(
+                dao, API_UUID, APPLICATION_UUID, TENANT_ORGANIZATION));
+        assertNull(SubscriptionsApiServiceImpl.getSubscription(
+                dao, API_ID, APPLICATION_ID, TENANT_ORGANIZATION));
+        assertEquals(1, dao.uuidCalls);
+        assertEquals(1, dao.numericCalls);
+    }
+
+    @Test
+    public void testMissingAuthenticatedOrganizationDoesNotQuerySubscriptions() {
+
+        RecordingSubscriptionValidationDAO dao = new RecordingSubscriptionValidationDAO();
+
+        assertNull(SubscriptionsApiServiceImpl.getSubscription(dao, API_UUID, APPLICATION_UUID, null));
+        assertNull(SubscriptionsApiServiceImpl.getSubscription(dao, API_ID, APPLICATION_ID, ""));
+        assertEquals(0, dao.uuidCalls);
+        assertEquals(0, dao.numericCalls);
+    }
+
+    @Test
+    public void testMissingApplicationOrganizationReturnsNull() {
+
+        RecordingSubscriptionValidationDAO dao = new RecordingSubscriptionValidationDAO();
+        dao.uuidResult = createSubscription(null, TENANT_ORGANIZATION);
+
+        assertNull(SubscriptionsApiServiceImpl.getSubscription(
+                dao, API_UUID, APPLICATION_UUID, TENANT_ORGANIZATION));
+        assertEquals(1, dao.uuidCalls);
+    }
+
+    private Subscription createSubscription(String applicationOrganization, String apiOrganization) {
+
+        Subscription subscription = new Subscription();
+        subscription.setAppOrganization(applicationOrganization);
+        subscription.setApiOrganization(apiOrganization);
+        return subscription;
+    }
+
+    private static class RecordingSubscriptionValidationDAO extends SubscriptionValidationDAO {
+
+        private int uuidCalls;
+        private int numericCalls;
+        private String apiUUID;
+        private String applicationUUID;
+        private int apiId;
+        private int applicationId;
+        private Subscription uuidResult;
+        private Subscription numericResult;
+
+        @Override
+        public Subscription getSubscription(String requestedApiUUID, String requestedApplicationUUID) {
+
+            uuidCalls++;
+            apiUUID = requestedApiUUID;
+            applicationUUID = requestedApplicationUUID;
+            return uuidResult;
+        }
+
+        @Override
+        public Subscription getSubscription(int requestedApiId, int requestedApplicationId) {
+
+            numericCalls++;
+            apiId = requestedApiId;
+            applicationId = requestedApplicationId;
+            return numericResult;
+        }
+    }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/test/java/org/wso2/carbon/apimgt/internal/service/utils/BlockConditionDBUtilTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/test/java/org/wso2/carbon/apimgt/internal/service/utils/BlockConditionDBUtilTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.apimgt.internal.service.utils;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.wso2.carbon.apimgt.internal.service.model.RevokedJWTEventData;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.util.Calendar;
+
+import static org.junit.Assert.assertEquals;
+
+public class BlockConditionDBUtilTest {
+
+    @Test
+    public void testGetRevokedJWTEventsWithOwnership() throws Exception {
+
+        Connection connection = Mockito.mock(Connection.class);
+        PreparedStatement jwtStatement = Mockito.mock(PreparedStatement.class);
+        ResultSet jwtResultSet = Mockito.mock(ResultSet.class);
+        PreparedStatement consumerKeyStatement = Mockito.mock(PreparedStatement.class);
+        ResultSet consumerKeyResultSet = Mockito.mock(ResultSet.class);
+        PreparedStatement subjectEntityStatement = Mockito.mock(PreparedStatement.class);
+        ResultSet subjectEntityResultSet = Mockito.mock(ResultSet.class);
+
+        Mockito.when(connection.prepareStatement(Mockito.contains("AM_REVOKED_JWT"))).thenReturn(jwtStatement);
+        Mockito.when(connection.prepareStatement(Mockito.contains("AM_APP_REVOKED_EVENT")))
+                .thenReturn(consumerKeyStatement);
+        Mockito.when(connection.prepareStatement(Mockito.contains("AM_SUBJECT_ENTITY_REVOKED_EVENT")))
+                .thenReturn(subjectEntityStatement);
+        Mockito.when(jwtStatement.executeQuery()).thenReturn(jwtResultSet);
+        Mockito.when(consumerKeyStatement.executeQuery()).thenReturn(consumerKeyResultSet);
+        Mockito.when(subjectEntityStatement.executeQuery()).thenReturn(subjectEntityResultSet);
+
+        Mockito.when(jwtResultSet.next()).thenReturn(true, false);
+        Mockito.when(jwtResultSet.getString("SIGNATURE")).thenReturn("signature");
+        Mockito.when(jwtResultSet.getLong("EXPIRY_TIMESTAMP")).thenReturn(1000L);
+        Mockito.when(jwtResultSet.getInt("TENANT_ID")).thenReturn(10);
+
+        Mockito.when(consumerKeyResultSet.next()).thenReturn(true, false);
+        Mockito.when(consumerKeyResultSet.getString("CONSUMER_KEY")).thenReturn("consumer-key");
+        Mockito.when(consumerKeyResultSet.getTimestamp(Mockito.eq("TIME_REVOKED"), Mockito.any(Calendar.class)))
+                .thenReturn(new Timestamp(2000L));
+        Mockito.when(consumerKeyResultSet.getString("ORGANIZATION")).thenReturn("tenant-a.com");
+
+        Mockito.when(subjectEntityResultSet.next()).thenReturn(true, false);
+        Mockito.when(subjectEntityResultSet.getString("ENTITY_ID")).thenReturn("subject");
+        Mockito.when(subjectEntityResultSet.getString("ENTITY_TYPE")).thenReturn("USER");
+        Mockito.when(subjectEntityResultSet.getTimestamp(Mockito.eq("TIME_REVOKED"), Mockito.any(Calendar.class)))
+                .thenReturn(new Timestamp(3000L));
+        Mockito.when(subjectEntityResultSet.getString("ORGANIZATION")).thenReturn("tenant-a.com");
+
+        RevokedJWTEventData result = BlockConditionDBUtil.getRevokedJWTEventsWithOwnership(connection);
+
+        assertEquals(1, result.getRevokedJWTList().size());
+        assertEquals("signature", result.getRevokedJWTList().get(0).getJwtSignature());
+        assertEquals(Long.valueOf(1000L), result.getRevokedJWTList().get(0).getExpiryTime());
+        assertEquals(10, result.getRevokedJWTList().get(0).getTenantId());
+        assertEquals(1, result.getRevokedJWTConsumerKeyList().size());
+        assertEquals("consumer-key", result.getRevokedJWTConsumerKeyList().get(0).getConsumerKey());
+        assertEquals(Long.valueOf(2000L), result.getRevokedJWTConsumerKeyList().get(0).getRevocationTime());
+        assertEquals("tenant-a.com", result.getRevokedJWTConsumerKeyList().get(0).getOrganization());
+        assertEquals(1, result.getRevokedJWTSubjectEntityList().size());
+        assertEquals("subject", result.getRevokedJWTSubjectEntityList().get(0).getEntityId());
+        assertEquals("USER", result.getRevokedJWTSubjectEntityList().get(0).getEntityType());
+        assertEquals(Long.valueOf(3000L), result.getRevokedJWTSubjectEntityList().get(0).getRevocationTime());
+        assertEquals("tenant-a.com", result.getRevokedJWTSubjectEntityList().get(0).getOrganization());
+    }
+
+    @Test(expected = SQLException.class)
+    public void testGetRevokedJWTEventsWithOwnershipPropagatesRetrievalFailure() throws Exception {
+
+        Connection connection = Mockito.mock(Connection.class);
+        PreparedStatement jwtStatement = Mockito.mock(PreparedStatement.class);
+        ResultSet jwtResultSet = Mockito.mock(ResultSet.class);
+
+        Mockito.when(connection.prepareStatement(Mockito.contains("AM_REVOKED_JWT"))).thenReturn(jwtStatement);
+        Mockito.when(jwtStatement.executeQuery()).thenReturn(jwtResultSet);
+        Mockito.when(jwtResultSet.next()).thenReturn(false);
+        Mockito.when(connection.prepareStatement(Mockito.contains("AM_APP_REVOKED_EVENT")))
+                .thenThrow(new SQLException("synthetic failure"));
+
+        BlockConditionDBUtil.getRevokedJWTEventsWithOwnership(connection);
+    }
+}


### PR DESCRIPTION
## Summary
Refactors organization handling across a set of internal data REST API (`/internal/data/v1/*`) endpoints for consistency: application lookup, subscription lookup and listing, revoked-JWT event listing, LLM provider lookup, and notification event dispatch.

## Test plan
- Unit test coverage added/updated for each endpoint.
- Verified manually against a running instance.

## Compatibility
No REST API contract change — response shapes are unchanged.
