### PR TITLE
Remove unused 'Meta' section from tenant-conf.json and its schema

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/resources/tenant/tenant-conf.json
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/resources/tenant/tenant-conf.json
@@ -435,11 +435,6 @@
       }
     ]
   },
-  "Meta" : {
-    "Migration": {
-      "3.0.0": true
-    }
-  },
   "NotificationsEnabled":"false",
   "Notifications":[{
     "Type":"new_api_version",

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/resources/tenant/tenant-config-schema.json
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/resources/tenant/tenant-config-schema.json
@@ -11,7 +11,6 @@
     "IsUnlimitedTierPaid",
     "ExtensionHandlerPosition",
     "RESTAPIScopes",
-    "Meta",
     "NotificationsEnabled",
     "Notifications",
     "DefaultRoles"
@@ -455,54 +454,6 @@
               }
             ]
           }
-        }
-      },
-      "additionalProperties": true
-    },
-    "Meta": {
-      "$id": "#/properties/Meta",
-      "type": "object",
-      "title": "The Meta schema",
-      "description": "An explanation about the purpose of this instance.",
-      "default": {},
-      "examples": [
-        {
-          "Migration": {
-            "3.0.0": true
-          }
-        }
-      ],
-      "required": [
-        "Migration"
-      ],
-      "properties": {
-        "Migration": {
-          "$id": "#/properties/Meta/properties/Migration",
-          "type": "object",
-          "title": "The Migration schema",
-          "description": "An explanation about the purpose of this instance.",
-          "default": {},
-          "examples": [
-            {
-              "3.0.0": true
-            }
-          ],
-          "required": [
-            "3.0.0"
-          ],
-          "properties": {
-            "3.0.0": {
-              "$id": "#/properties/Meta/properties/Migration/properties/3.0.0",
-              "type": "boolean",
-              "title": "The 3.0.0 schema",
-              "description": "An explanation about the purpose of this instance.",
-              "default": false,
-              "examples": [
-                true
-              ]
-            }
-          },
-          "additionalProperties": true
         }
       },
       "additionalProperties": true


### PR DESCRIPTION
## Purpose

Fixes wso2/api-manager#5180.

`Meta` is in the `required` array of `tenant-config-schema.json`, which `APIAdminImpl.updateTenantConfig` validates every Admin Portal tenant-config save against. The migration client stopped writing that section (wso2-enterprise/apim-migration-resources#210), so tenants migrated from a pre-3.1.0 source have no `Meta` block and every Advanced Configurations save fails with:

```
400 Invalid tenant-config found with error #: required key [Meta] not found
```

`Meta` was added here in 15b63c5557f (Sep 2021) and never removed. wso2-support/carbon-apimgt#5162 removed it from the 4.1.0 support branch only, so every release cut from master since has inherited it, and it has now been patched separately for 4.2.0 through 4.7.0. Without this change the next release from master ships it again.

## Fix

- Removed `Meta` from `required` and its property definition in `tenant-config-schema.json`
- Removed the `Meta` block from the default `tenant-conf.json`

Nothing reads this section, so it is resource-only with no compile impact. It also drops `Meta` from the **default** `tenant-conf.json`, so new tenants no longer get one; existing configs that still carry the block continue to validate via the schema root's `additionalProperties: true`.

## Testing

Verified at runtime on a `wso2am-4.7.0` pack by deploying only these two files into the shipped bundle, so the test isolates this change.
