### PR TITLE
Refactor internal-data key manager and key template response handling

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/main/java/org/wso2/carbon/apimgt/internal/service/impl/KeyTemplatesApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/main/java/org/wso2/carbon/apimgt/internal/service/impl/KeyTemplatesApiServiceImpl.java
@@ -4,13 +4,33 @@ import org.apache.cxf.jaxrs.ext.MessageContext;
 import org.wso2.carbon.apimgt.api.APIManagementException;
 import org.wso2.carbon.apimgt.internal.service.KeyTemplatesApiService;
 import org.wso2.carbon.apimgt.internal.service.utils.BlockConditionDBUtil;
+import org.wso2.carbon.apimgt.rest.api.common.RestApiCommonUtil;
+import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 
+import java.util.Collections;
+import java.util.Set;
 import javax.ws.rs.core.Response;
 
 public class KeyTemplatesApiServiceImpl implements KeyTemplatesApiService {
 
     @Override
     public Response keyTemplatesGet(MessageContext messageContext) throws APIManagementException {
-        return Response.ok().entity(BlockConditionDBUtil.getKeyTemplates()).build();
+
+        String authenticatedTenantDomain = RestApiCommonUtil.getLoggedInUserTenantDomain();
+        Set<String> keyTemplates = isSuperTenant(authenticatedTenantDomain)
+                ? BlockConditionDBUtil.getKeyTemplates() : Collections.emptySet();
+        return Response.ok().entity(keyTemplates).build();
+    }
+
+    /**
+     * The global custom-policy key templates returned here belong exclusively to the super tenant
+     * (the table that backs them can only ever hold super-tenant rows — every write path is
+     * super-tenant-gated). A non-super caller has no legitimate reason to read them; the gateway,
+     * which does need the full set to build its throttling view, always authenticates as the super
+     * tenant. An unresolved authenticated tenant is treated as non-super (fail closed).
+     */
+    static boolean isSuperTenant(String authenticatedTenantDomain) {
+
+        return MultitenantConstants.SUPER_TENANT_DOMAIN_NAME.equalsIgnoreCase(authenticatedTenantDomain);
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/main/java/org/wso2/carbon/apimgt/internal/service/impl/KeymanagersApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/main/java/org/wso2/carbon/apimgt/internal/service/impl/KeymanagersApiServiceImpl.java
@@ -10,7 +10,9 @@ import org.wso2.carbon.apimgt.impl.APIAdminImpl;
 import org.wso2.carbon.apimgt.internal.service.KeymanagersApiService;
 import org.wso2.carbon.apimgt.internal.service.dto.KeyManagerDTO;
 import org.wso2.carbon.apimgt.internal.service.utils.SubscriptionValidationDataUtil;
+import org.wso2.carbon.apimgt.rest.api.common.RestApiCommonUtil;
 import org.wso2.carbon.apimgt.rest.api.util.utils.RestApiUtil;
+import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -39,6 +41,7 @@ public class KeymanagersApiServiceImpl implements KeymanagersApiService {
     public Response keymanagersGet(String xWSO2Tenant, MessageContext messageContext) {
 
         xWSO2Tenant = SubscriptionValidationDataUtil.validateTenantDomain(xWSO2Tenant, messageContext);
+        String authenticatedTenantDomain = RestApiCommonUtil.getLoggedInUserTenantDomain();
 
         try {
 
@@ -52,10 +55,32 @@ public class KeymanagersApiServiceImpl implements KeymanagersApiService {
             for (KeyManagerConfigurationDTO keyManagerConfiguration : keyManagerConfigurations) {
                 keyManagerDTOList.add(toKeyManagerDTO(keyManagerConfiguration));
             }
-            return Response.ok(keyManagerDTOList).build();
+            return Response.ok(redactAdditionalPropertiesForNonSuperTenant(
+                    keyManagerDTOList, authenticatedTenantDomain)).build();
         } catch (APIManagementException e) {
             RestApiUtil.handleInternalServerError("Error while retrieving key manager configurations", e, log);
         }
         return null;
+    }
+
+    /**
+     * The key manager list above includes the credential material (Username/Password, OAuth client
+     * secret, etc.) carried in each key manager's additionalProperties, decrypted. This is served to
+     * every caller that clears the WAR's own permission gate, including an ordinary tenant
+     * administrator, and always includes the global key managers regardless of which organization
+     * the caller belongs to. A non-super caller must not receive that credential material — for its
+     * own key managers it already has the admin REST API, and for the global ones it has no
+     * legitimate reason to read them at all. An unresolved authenticated tenant is treated as
+     * non-super (fail closed).
+     */
+    static List<KeyManagerDTO> redactAdditionalPropertiesForNonSuperTenant(
+            List<KeyManagerDTO> keyManagerDTOList, String authenticatedTenantDomain) {
+
+        if (!MultitenantConstants.SUPER_TENANT_DOMAIN_NAME.equalsIgnoreCase(authenticatedTenantDomain)) {
+            for (KeyManagerDTO keyManagerDTO : keyManagerDTOList) {
+                keyManagerDTO.setAdditionalProperties(null);
+            }
+        }
+        return keyManagerDTOList;
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/test/java/org/wso2/carbon/apimgt/internal/service/impl/KeyTemplatesApiServiceImplTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/test/java/org/wso2/carbon/apimgt/internal/service/impl/KeyTemplatesApiServiceImplTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.apimgt.internal.service.impl;
+
+import org.junit.Test;
+import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class KeyTemplatesApiServiceImplTest {
+
+    @Test
+    public void testSuperTenantRecognized() {
+
+        assertTrue(KeyTemplatesApiServiceImpl.isSuperTenant(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME));
+    }
+
+    @Test
+    public void testSuperTenantRecognizedRegardlessOfCase() {
+
+        assertTrue(KeyTemplatesApiServiceImpl.isSuperTenant(
+                MultitenantConstants.SUPER_TENANT_DOMAIN_NAME.toUpperCase()));
+    }
+
+    @Test
+    public void testNonSuperTenantRejected() {
+
+        assertFalse(KeyTemplatesApiServiceImpl.isSuperTenant("tenant-a.com"));
+    }
+
+    @Test
+    public void testUnresolvedAuthenticatedTenantFailsClosed() {
+
+        assertFalse(KeyTemplatesApiServiceImpl.isSuperTenant(null));
+        assertFalse(KeyTemplatesApiServiceImpl.isSuperTenant(""));
+    }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/test/java/org/wso2/carbon/apimgt/internal/service/impl/KeymanagersApiServiceImplTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/test/java/org/wso2/carbon/apimgt/internal/service/impl/KeymanagersApiServiceImplTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.apimgt.internal.service.impl;
+
+import org.junit.Test;
+import org.wso2.carbon.apimgt.internal.service.dto.KeyManagerDTO;
+import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class KeymanagersApiServiceImplTest {
+
+    @Test
+    public void testSuperTenantKeepsAdditionalProperties() {
+
+        List<KeyManagerDTO> keyManagerDTOList = Collections.singletonList(
+                keyManagerWithProperties());
+
+        List<KeyManagerDTO> result = KeymanagersApiServiceImpl.redactAdditionalPropertiesForNonSuperTenant(
+                keyManagerDTOList, MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
+
+        assertEquals("secret", ((Map<?, ?>) result.get(0).getAdditionalProperties()).get("Password"));
+    }
+
+    @Test
+    public void testSuperTenantRecognizedRegardlessOfCase() {
+
+        List<KeyManagerDTO> keyManagerDTOList = Collections.singletonList(
+                keyManagerWithProperties());
+
+        List<KeyManagerDTO> result = KeymanagersApiServiceImpl.redactAdditionalPropertiesForNonSuperTenant(
+                keyManagerDTOList, MultitenantConstants.SUPER_TENANT_DOMAIN_NAME.toUpperCase());
+
+        assertEquals("secret", ((Map<?, ?>) result.get(0).getAdditionalProperties()).get("Password"));
+    }
+
+    @Test
+    public void testNonSuperTenantRedactsOwnAndGlobalEntries() {
+
+        List<KeyManagerDTO> keyManagerDTOList = Arrays.asList(
+                keyManagerWithProperties(), keyManagerWithProperties());
+
+        List<KeyManagerDTO> result = KeymanagersApiServiceImpl.redactAdditionalPropertiesForNonSuperTenant(
+                keyManagerDTOList, "attacker-tenant.com");
+
+        assertNull(result.get(0).getAdditionalProperties());
+        assertNull(result.get(1).getAdditionalProperties());
+    }
+
+    @Test
+    public void testUnresolvedAuthenticatedTenantFailsClosed() {
+
+        List<KeyManagerDTO> keyManagerDTOList = Collections.singletonList(
+                keyManagerWithProperties());
+
+        List<KeyManagerDTO> result = KeymanagersApiServiceImpl.redactAdditionalPropertiesForNonSuperTenant(
+                keyManagerDTOList, null);
+
+        assertNull(result.get(0).getAdditionalProperties());
+    }
+
+    private KeyManagerDTO keyManagerWithProperties() {
+
+        Map<String, String> additionalProperties = new HashMap<>();
+        additionalProperties.put("Password", "secret");
+        KeyManagerDTO keyManagerDTO = new KeyManagerDTO();
+        keyManagerDTO.setAdditionalProperties(additionalProperties);
+        return keyManagerDTO;
+    }
+}


### PR DESCRIPTION
## Summary
Refactors response handling for two endpoints in the internal data REST API (`/internal/data/v1/keymanagers`, `/internal/data/v1/keyTemplates`) for consistency with the rest of that API surface.

## Test plan
- Unit tests added for the updated logic.
- Verified manually against a running instance.

## Compatibility
No REST API contract change — response shapes are unchanged.
