### PR TITLE
Enhancement on path related issues

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/utils/CommonUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/utils/CommonUtil.java
@@ -99,7 +99,11 @@ public class CommonUtil {
         String currentDirectory = System.getProperty(APIConstants.JAVA_IO_TMPDIR);
         String createdDirectories;
         if (identifier != null) {
-            createdDirectories = File.separator + identifier.toString() + File.separator;
+            // append a random component so the export staging dir name is not
+            // deterministic (defeats predictable-name symlink-redirect / race).
+            createdDirectories = File.separator + identifier.toString() + "-"
+                    + RandomStringUtils.randomAlphanumeric(ImportExportConstants.TEMP_FILENAME_LENGTH)
+                    + File.separator;
         } else {
             createdDirectories =
                     File.separator + RandomStringUtils.randomAlphanumeric(ImportExportConstants.TEMP_FILENAME_LENGTH)

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/impl/TenantThemeApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/impl/TenantThemeApiServiceImpl.java
@@ -98,14 +98,16 @@ public class TenantThemeApiServiceImpl implements TenantThemeApiService {
         InputStream tenantTheme = apiAdmin.getTenantTheme(tenantId);
         String tempPath =
                 System.getProperty(RestApiConstants.JAVA_IO_TMPDIR) + File.separator + TENANT_THEMES_EXPORT_DIR_PREFIX;
-        String tempFile = tenantDomain + APIConstants.ZIP_FILE_EXTENSION;
-        File tenantThemeArchive = new File(tempPath, tempFile);
-
         try {
+            // random (non-predictable) temp file name + auto-cleanup (CWE-377/459).
+            new File(tempPath).mkdirs();
+            File tenantThemeArchive = File.createTempFile(tenantDomain + "-", APIConstants.ZIP_FILE_EXTENSION,
+                    new File(tempPath));
+            tenantThemeArchive.deleteOnExit();
             FileUtils.copyInputStreamToFile(tenantTheme, tenantThemeArchive);
             return Response.ok(tenantThemeArchive, MediaType.APPLICATION_OCTET_STREAM)
-                    .header(RestApiConstants.HEADER_CONTENT_DISPOSITION, "attachment; filename=\""
-                            + tenantThemeArchive.getName() + "\"").build();
+                    .header(RestApiConstants.HEADER_COdNTENT_DISPOSITION, "attachment; filename=\""
+                            + tenantDomain + APIConstants.ZIP_FILE_EXTENSION + "\"").build();
         } catch (IOException e) {
             throw new APIManagementException(e.getMessage(), e,
                     ExceptionCodes.from(ExceptionCodes.TENANT_THEME_EXPORT_FAILED, tenantDomain, e.getMessage()));

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/impl/ThrottlingApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/impl/ThrottlingApiServiceImpl.java
@@ -1227,32 +1227,42 @@ public class ThrottlingApiServiceImpl implements ThrottlingApiService {
             throws ParseException, APIImportExportException, IOException {
 
         File importFolder = CommonUtil.createTempDirectory(null);
-        String uploadFileName = fileDetail == null ? null : fileDetail.getDataHandler().getName();
-        if (StringUtils.isEmpty(uploadFileName)) {
-            throw new APIImportExportException("Invalid file name. File name cannot be null or empty.");
+
+        try {  // E16-068: delete the import staging dir on every exit path (CWE-459 temp-leak)
+            String uploadFileName = fileDetail == null ? null : fileDetail.getDataHandler().getName();
+            if (StringUtils.isEmpty(uploadFileName)) {
+                throw new APIImportExportException("Invalid file name. File name cannot be null or empty.");
+            }
+
+            String uploadFileName = fileDetail == null ? null : fileDetail.getDataHandler().getName();
+            if (StringUtils.isEmpty(uploadFileName)) {
+                throw new APIImportExportException("Invalid file name. File name cannot be null or empty.");
+            }
+            // Validate file extension to prevent uploading unauthorized file types
+            String lowerCaseFileName = uploadFileName.toLowerCase();
+            boolean isYamlFile =
+                    lowerCaseFileName.endsWith(ImportExportConstants.YAML_EXTENSION) || lowerCaseFileName.endsWith(
+                            ImportExportConstants.YML_EXTENSION);
+            boolean isJsonFile = lowerCaseFileName.endsWith(ImportExportConstants.JSON_EXTENSION);
+            if (!isYamlFile && !isJsonFile) {
+                throw new APIImportExportException("Invalid file type. Only YAML and JSON files are allowed.");
+            }
+            String fileType = isYamlFile ?
+                    ImportExportConstants.EXPORT_POLICY_TYPE_YAML :
+                    ImportExportConstants.EXPORT_POLICY_TYPE_JSON;
+            // Validating the canonical path
+            String absolutePath = importFolder.getAbsolutePath() + File.separator + uploadFileName;
+            File targetFile = new File(absolutePath);
+            String canonicalPath = targetFile.getCanonicalPath();
+            String canonicalImportPath = importFolder.getCanonicalPath();
+            if (!canonicalPath.startsWith(canonicalImportPath + File.separator)) {
+                throw new APIImportExportException("Invalid file name.");
+            }
+            FileUtils.copyInputStreamToFile(uploadedInputStream, targetFile);
+            return preprocessImportedArtifact(absolutePath, fileType);
+        } finally {
+            FileUtils.deleteQuietly(importFolder);
         }
-        // Validate file extension to prevent uploading unauthorized file types
-        String lowerCaseFileName = uploadFileName.toLowerCase();
-        boolean isYamlFile =
-                lowerCaseFileName.endsWith(ImportExportConstants.YAML_EXTENSION) || lowerCaseFileName.endsWith(
-                        ImportExportConstants.YML_EXTENSION);
-        boolean isJsonFile = lowerCaseFileName.endsWith(ImportExportConstants.JSON_EXTENSION);
-        if (!isYamlFile && !isJsonFile) {
-            throw new APIImportExportException("Invalid file type. Only YAML and JSON files are allowed.");
-        }
-        String fileType = isYamlFile ?
-                ImportExportConstants.EXPORT_POLICY_TYPE_YAML :
-                ImportExportConstants.EXPORT_POLICY_TYPE_JSON;
-        // Validating the canonical path
-        String absolutePath = importFolder.getAbsolutePath() + File.separator + uploadFileName;
-        File targetFile = new File(absolutePath);
-        String canonicalPath = targetFile.getCanonicalPath();
-        String canonicalImportPath = importFolder.getCanonicalPath();
-        if (!canonicalPath.startsWith(canonicalImportPath + File.separator)) {
-            throw new APIImportExportException("Invalid file name.");
-        }
-        FileUtils.copyInputStreamToFile(uploadedInputStream, targetFile);
-        return preprocessImportedArtifact(absolutePath, fileType);
     }
 
     /**

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/APIControllerUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/APIControllerUtil.java
@@ -1068,6 +1068,10 @@ public class APIControllerUtil {
             cert.setAlias(alias);
             cert.setTierName(certObject.get(ImportExportConstants.CERTIFICATE_TIER_NAME_PROPERTY).getAsString());
             String certName = certObject.get(ImportExportConstants.CERTIFICATE_PATH_PROPERTY).getAsString();
+            if (certName != null && (certName.contains("/") || certName.contains("\\") || certName.contains(".."))) {
+                // cert path must be a bare filename inside the archive cert dir
+                throw new APIManagementException("Invalid certificate path (must be a bare filename): " + certName);
+            }
             cert.setCertificate(certName);
 
             String clientCertificatesDirectory;

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ExportUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ExportUtils.java
@@ -1075,12 +1075,17 @@ public class ExportUtils {
         Gson gson = new GsonBuilder().setPrettyPrinting().create();
         JsonArray certificatesList = new JsonArray();
         certificateMetadataDTOS.forEach(metadataDTO -> {
-            try (ByteArrayInputStream certificate = certificateManager.getCertificateContent(tenantId,
-                    metadataDTO.getAlias())) {
+            try (ByteArrayInputStream certificate = certificateManager.getCertificateContent(tenantId, metaDataAlias)) {
                 byte[] certificateContent = IOUtils.toByteArray(certificate);
                 String certificateContentEncoded = APIConstants.BEGIN_CERTIFICATE_STRING.concat(System.lineSeparator())
                         .concat(new String(Base64.encodeBase64(certificateContent))).concat(System.lineSeparator())
                         .concat(APIConstants.END_CERTIFICATE_STRING);
+                String metaDataAlias = metadataDTO.getAlias();
+                if (metaDataAlias == null || metaDataAlias.contains("/") || metaDataAlias.contains("\\")
+                        || metaDataAlias.contains("..")) {
+                    // reject path-traversal in certificate alias
+                    throw new IllegalArgumentException("Invalid certificate alias (path traversal): " + metaDataAlias);
+                }
                 CommonUtil.writeFile(certDirectoryPath + File.separator + metadataDTO.getAlias() + ".crt",
                         certificateContentEncoded);
                 // Add the file name to the Certificate Metadata

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ImportUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ImportUtils.java
@@ -2938,6 +2938,16 @@ public class ImportUtils {
                 log.error("Failed to find the thumbnail file. ", e);
             }
         }
+        // restrict imported thumbnail MIME to raster images / json (prevent stored-XSS
+        // via caller-named files like icon.html that guessContentTypeFromName maps to text/html).
+        String thumbnailMimeType = (mimeType == null) ? "" : mimeType.toLowerCase().trim();
+        java.util.Set<String> thumbnailAllowedList = new java.util.HashSet<String>(java.util.Arrays.asList(
+                "image/png", "image/jpeg", "image/jpg", "image/gif", "image/bmp", "image/webp",
+                APIConstants.APPLICATION_JSON_MEDIA_TYPE));
+        if (!thumbnailAllowedList.contains(thumbnailMimeType)) {
+            log.warn("Skipping imported thumbnail with disallowed content type: " + mimeType);
+            return;
+        }
         try (FileInputStream inputStream = new FileInputStream(imageFile.getAbsolutePath())) {
             String apiOrApiProductId = (!apiTypeWrapper.isAPIProduct()) ?
                     apiTypeWrapper.getApi().getUuid() :

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.service.catalog/src/main/java/org/wso2/carbon/apimgt/rest/api/service/catalog/impl/ServicesApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.service.catalog/src/main/java/org/wso2/carbon/apimgt/rest/api/service/catalog/impl/ServicesApiServiceImpl.java
@@ -258,87 +258,93 @@ public class ServicesApiServiceImpl implements ServicesApiService {
         List<ServiceEntry> servicesWithInvalidDefinition = new ArrayList<>();
 
         // unzip the uploaded zip
-        try {
-            FileBasedServicesImportExportManager importExportManager =
-                    new FileBasedServicesImportExportManager(tempDirPath);
-            importExportManager.importService(fileInputStream);
-        } catch (APIMgtResourceAlreadyExistsException e) {
-            RestApiUtil.handleResourceAlreadyExistsError("Error while importing Service", e, log);
-        }
+        try {  // ensure the per-request temp dir is always cleaned up
+            // unzip the uploaded zip
+            try {
+                FileBasedServicesImportExportManager importExportManager =
+                        new FileBasedServicesImportExportManager(tempDirPath);
+                importExportManager.importService(fileInputStream);
+            } catch (APIMgtResourceAlreadyExistsException e) {
+                RestApiUtil.handleResourceAlreadyExistsError("Error while importing Service", e, log);
+            }
 
-        newResourcesHash = Md5HashGenerator.generateHash(tempDirPath, serviceCatalog.hashingAlgorithm());
-        serviceEntries = ServiceEntryMappingUtil.fromDirToServiceEntryMap(tempDirPath);
-        Map<String, Boolean> validationResults = new HashMap<>();
-        if (overwrite && StringUtils.isNotEmpty(verifier)) {
-            validationResults = validateVerifier(verifier, tenantId);
-        }
-        try {
-            for (Map.Entry<String, ServiceEntry> entry : serviceEntries.entrySet()) {
-                String key = entry.getKey();
-                serviceEntries.get(key).setMd5(newResourcesHash.get(key));
-                ServiceEntry service = serviceEntries.get(key);
-                byte[] definitionFileByteArray = getDefinitionFromInput(service.getEndpointDef());
-                if (validateAndRetrieveServiceDefinition(definitionFileByteArray, service.getDefUrl(),
-                        service.getDefinitionType()).isValid() ||
-                        (ServiceEntry.DefinitionType.WSDL1.equals(service.getDefinitionType())
-                                && APIMWSDLReader.validateWSDLFile(definitionFileByteArray).isValid())) {
-                    service.setEndpointDef(new ByteArrayInputStream(definitionFileByteArray));
-                } else {
-                    servicesWithInvalidDefinition.add(service);
-                }
-                if (overwrite) {
-                    if (StringUtils.isNotEmpty(verifier) && validationResults
-                            .containsKey(service.getServiceKey()) && !validationResults.get(service.getServiceKey())) {
-                        serviceListToIgnore.add(service);
+            newResourcesHash = Md5HashGenerator.generateHash(tempDirPath, serviceCatalog.hashingAlgorithm());
+            serviceEntries = ServiceEntryMappingUtil.fromDirToServiceEntryMap(tempDirPath);
+            Map<String, Boolean> validationResults = new HashMap<>();
+            if (overwrite && StringUtils.isNotEmpty(verifier)) {
+                validationResults = validateVerifier(verifier, tenantId);
+            }
+            try {
+                for (Map.Entry<String, ServiceEntry> entry : serviceEntries.entrySet()) {
+                    String key = entry.getKey();
+                    serviceEntries.get(key).setMd5(newResourcesHash.get(key));
+                    ServiceEntry service = serviceEntries.get(key);
+                    byte[] definitionFileByteArray = getDefinitionFromInput(service.getEndpointDef());
+                    if (validateAndRetrieveServiceDefinition(definitionFileByteArray, service.getDefUrl(),
+                            service.getDefinitionType()).isValid() ||
+                            (ServiceEntry.DefinitionType.WSDL1.equals(service.getDefinitionType())
+                                    && APIMWSDLReader.validateWSDLFile(definitionFileByteArray).isValid())) {
+                        service.setEndpointDef(new ByteArrayInputStream(definitionFileByteArray));
+                    } else {
+                        servicesWithInvalidDefinition.add(service);
+                    }
+                    if (overwrite) {
+                        if (StringUtils.isNotEmpty(verifier) && validationResults
+                                .containsKey(service.getServiceKey()) && !validationResults.get(service.getServiceKey())) {
+                            serviceListToIgnore.add(service);
+                        } else {
+                            serviceListToImport.add(service);
+                        }
                     } else {
                         serviceListToImport.add(service);
                     }
-                } else {
-                    serviceListToImport.add(service);
                 }
+            } catch (IOException e) {
+                RestApiUtil.handleInternalServerError("Error when reading the service definition content", log);
             }
-        } catch (IOException e) {
-            RestApiUtil.handleInternalServerError("Error when reading the service definition content", log);
-        }
-        if (servicesWithInvalidDefinition.size() > 0) {
-            serviceList = ServiceEntryMappingUtil.fromServiceListToDTOList(servicesWithInvalidDefinition);
-            String errorMsg = "The Service import has been failed as invalid service definition provided";
-            return Response.status(Response.Status.BAD_REQUEST).entity(getErrorDTO(RestApiConstants
-            .STATUS_BAD_REQUEST_MESSAGE_DEFAULT, 400L, errorMsg, new JSONArray(serviceList).toString())).build();
-        }
-        if (serviceListToIgnore.size() > 0) {
-            serviceList = ServiceEntryMappingUtil.fromServiceListToDTOList(serviceListToIgnore);
-            String errorMsg = "The Service import has been failed since to verifier validation fails";
+            if (servicesWithInvalidDefinition.size() > 0) {
+                serviceList = ServiceEntryMappingUtil.fromServiceListToDTOList(servicesWithInvalidDefinition);
+                String errorMsg = "The Service import has been failed as invalid service definition provided";
+                return Response.status(Response.Status.BAD_REQUEST).entity(getErrorDTO(RestApiConstants
+                        .STATUS_BAD_REQUEST_MESSAGE_DEFAULT, 400L, errorMsg, new JSONArray(serviceList).toString())).build();
+            }
+            if (serviceListToIgnore.size() > 0) {
+                serviceList = ServiceEntryMappingUtil.fromServiceListToDTOList(serviceListToIgnore);
+                String errorMsg = "The Service import has been failed since to verifier validation fails";
 
-            return Response.status(Response.Status.BAD_REQUEST).entity(getErrorDTO(RestApiConstants
-            .STATUS_BAD_REQUEST_MESSAGE_DEFAULT, 400L, errorMsg, new JSONArray(serviceList).toString())).build();
-        } else {
-            List<ServiceEntry> importedServiceList = new ArrayList<>();
-            List<ServiceEntry> retrievedServiceList = new ArrayList<>();
-            try {
-                if (serviceListToImport.size() > 0) {
-                    importedServiceList = serviceCatalog.importServices(serviceListToImport, tenantId, userName,
-                            overwrite);
+                return Response.status(Response.Status.BAD_REQUEST).entity(getErrorDTO(RestApiConstants
+                        .STATUS_BAD_REQUEST_MESSAGE_DEFAULT, 400L, errorMsg, new JSONArray(serviceList).toString())).build();
+            } else {
+                List<ServiceEntry> importedServiceList = new ArrayList<>();
+                List<ServiceEntry> retrievedServiceList = new ArrayList<>();
+                try {
+                    if (serviceListToImport.size() > 0) {
+                        importedServiceList = serviceCatalog.importServices(serviceListToImport, tenantId, userName,
+                                overwrite);
+                    }
+                } catch (APIManagementException e) {
+                    if (ExceptionCodes.SERVICE_IMPORT_FAILED_WITHOUT_OVERWRITE.getErrorCode() == e.getErrorHandler()
+                            .getErrorCode()) {
+                        RestApiUtil.handleBadRequest("Cannot update existing services when overwrite is false", log);
+                    } else {
+                        RestApiUtil.handleInternalServerError("Error when importing services to service catalog",
+                                e, log);
+                    }
                 }
-            } catch (APIManagementException e) {
-                if (ExceptionCodes.SERVICE_IMPORT_FAILED_WITHOUT_OVERWRITE.getErrorCode() == e.getErrorHandler()
-                        .getErrorCode()) {
-                    RestApiUtil.handleBadRequest("Cannot update existing services when overwrite is false", log);
-                } else {
-                    RestApiUtil.handleInternalServerError("Error when importing services to service catalog",
-                            e, log);
+                if (importedServiceList == null) {
+                    RestApiUtil.handleBadRequest("Cannot update the name or version or key or definition type of an " +
+                            "existing service", log);
                 }
+                for (ServiceEntry service : importedServiceList) {
+                    retrievedServiceList.add(serviceCatalog.getServiceByKey(service.getServiceKey(), tenantId));
+                }
+                serviceList = ServiceEntryMappingUtil.fromServiceListToDTOList(retrievedServiceList);
+                return Response.ok().entity(ServiceEntryMappingUtil
+                        .fromServiceInfoDTOToServiceInfoListDTO(serviceList)).build();
             }
-            if (importedServiceList == null) {
-                RestApiUtil.handleBadRequest("Cannot update the name or version or key or definition type of an " +
-                        "existing service", log);
-            }
-            for (ServiceEntry service : importedServiceList) {
-                retrievedServiceList.add(serviceCatalog.getServiceByKey(service.getServiceKey(), tenantId));
-            }
-            serviceList = ServiceEntryMappingUtil.fromServiceListToDTOList(retrievedServiceList);
-            return Response.ok().entity(ServiceEntryMappingUtil
-                    .fromServiceInfoDTOToServiceInfoListDTO(serviceList)).build();
+        } finally {
+            // delete the per-request staging dir on every exit path (CWE-459 temp-leak)
+            org.apache.commons.io.FileUtils.deleteQuietly(new java.io.File(tempDirPath));
         }
     }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.service.catalog/src/main/java/org/wso2/carbon/apimgt/rest/api/service/catalog/utils/FileBasedServicesImportExportManager.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.service.catalog/src/main/java/org/wso2/carbon/apimgt/rest/api/service/catalog/utils/FileBasedServicesImportExportManager.java
@@ -161,6 +161,13 @@ public class FileBasedServicesImportExportManager {
      */
     private void writeArchiveFile(File directoryToZip, List<File> fileList, String archiveLocation,
                                   String archiveName) throws IOException {
+
+        // canonicalize + containment-check the archive write path (archiveName caller-controlled, CWE-22)
+        File baseFile = new File(archiveLocation).getCanonicalFile();
+        File targetFile = new File(baseFile, archiveName + APIConstants.ZIP_FILE_EXTENSION).getCanonicalFile();
+        if (!targetFile.toPath().startsWith(baseFile.toPath())) {
+            throw new IOException("Archive name resolves outside the target directory: " + archiveName);
+        }
         try (FileOutputStream fileOutputStream = new FileOutputStream(archiveLocation + File.separator +
                 archiveName
                 + APIConstants.ZIP_FILE_EXTENSION);

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/impl/ApisApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/impl/ApisApiServiceImpl.java
@@ -18,6 +18,7 @@
 
 package org.wso2.carbon.apimgt.rest.api.store.v1.impl;
 
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -69,6 +70,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -1092,7 +1094,14 @@ public class ApisApiServiceImpl implements ApisApiService {
                         swaggerDefinition);
                 //Create the sdk response.
                 File sdkFile = new File(sdkArtifacts.get("zipFilePath"));
-                return Response.ok(sdkFile, MediaType.APPLICATION_OCTET_STREAM_TYPE).header("Content-Disposition",
+                // read the SDK into memory and delete the temp staging dir before returning so
+                // it does not leak on the success path. Returned content is unchanged.
+                byte[] sdkBytes = Files.readAllBytes(sdkFile.toPath());
+                // deleteDirectory (not the shipped cleanTempDirectory, which only empties
+                // contents and leaves the dir shell) so no <UUID>/ directory leaks.
+                FileUtils.deleteDirectory(new java.io.File(sdkArtifacts.get("tempDirectoryPath")));
+
+                return Response.ok(sdkBytes, MediaType.APPLICATION_OCTET_STREAM_TYPE).header("Content-Disposition",
                         "attachment; filename=\"" + sdkArtifacts.get("zipFileName") + "\"" ).build();
             } catch (APIClientGenerationException e) {
                 String message = "Error generating client sdk for api: " + api.getName() + " for language: " + language;


### PR DESCRIPTION
This PR is fixing below issues

* Blocking path-traversal in certificate alias

* Canonicalize + containment-check the archive write path

* validate bare-filename cert path on API import

* Fixing Temp-file hygiene

* Restricting imported thumbnail MIME to raster images

* Adding random suffix on temp file creation