### PR TITLE
[deprecated] Add deprecated cross organization subscription visibility to the Dev Portal

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -1208,6 +1208,8 @@ public final class APIConstants {
     public static final String ENABLE_ANONYMOUS_MODE = "EnableAnonymous";
     public static final String API_DEVPORTAL_ENABLE_CROSS_TENANT_SUBSCRIPTION = API_STORE +
             "EnableCrossTenantSubscription";
+    public static final String API_DEVPORTAL_ENABLE_DEPRECATED_CROSS_TENANT_SUBSCRIPTION_VISIBILITY = API_STORE +
+            "EnableDeprecatedCrossTenantSubscriptionVisibility";
     public static final String DEVPORTAL_MODE = "Mode";
     public static final String API_DEVPORTAL_DEFAULT_RESERVED_USERNAME = API_STORE +
             "DefaultReservedUsername";

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/ApiMgtDAO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/ApiMgtDAO.java
@@ -1452,10 +1452,18 @@ public class ApiMgtDAO {
                                                         String organization) throws SQLException {
 
         int subscriptionCount = 0;
-        String sqlQuery = SQLConstants.GET_SUBSCRIPTION_COUNT_BY_APP_ID_SQL;
+        // DEPRECATED: when cross organization subscription visibility is enabled, count the application's
+        // subscriptions to APIs owned by other organizations as well, so the count is consistent with the listing
+        // returned by getPaginatedSubscribedAPIsByApplication (pre 4.1.0 behaviour). Off by default.
+        boolean crossOrganizationVisibility = APIUtil.isDeprecatedCrossTenantSubscriptionVisibilityEnabled();
+        String sqlQuery = crossOrganizationVisibility
+                ? SQLConstants.GET_SUBSCRIPTION_COUNT_BY_APP_ID_ALL_ORGANIZATIONS_SQL
+                : SQLConstants.GET_SUBSCRIPTION_COUNT_BY_APP_ID_SQL;
         try (PreparedStatement ps = connection.prepareStatement(sqlQuery)) {
             ps.setInt(1, application.getId());
-            ps.setString(2, organization);
+            if (!crossOrganizationVisibility) {
+                ps.setString(2, organization);
+            }
             try (ResultSet result = ps.executeQuery()) {
                 while (result.next()) {
                     subscriptionCount = result.getInt("SUB_COUNT");
@@ -23043,11 +23051,20 @@ public class ApiMgtDAO {
                 
         Set<SubscribedAPI> subscribedAPIs = new LinkedHashSet<>();
 
+        // DEPRECATED: when cross organization subscription visibility is enabled, use the unfiltered query so the
+        // application's subscriptions to APIs owned by other organizations are listed as well (pre 4.1.0
+        // behaviour). Off by default, in which case the listing stays scoped to the requesting organization.
+        boolean crossOrganizationVisibility = APIUtil.isDeprecatedCrossTenantSubscriptionVisibilityEnabled();
+        String sqlQuery = crossOrganizationVisibility
+                ? SQLConstants.GET_PAGINATED_SUBSCRIBED_APIS_BY_APP_ID_ALL_ORGANIZATIONS_SQL
+                : SQLConstants.GET_PAGINATED_SUBSCRIBED_APIS_BY_APP_ID_SQL;
+
         try (Connection connection = APIMgtDBUtil.getConnection();
-             PreparedStatement ps =
-                     connection.prepareStatement(SQLConstants.GET_PAGINATED_SUBSCRIBED_APIS_BY_APP_ID_SQL)) {
+             PreparedStatement ps = connection.prepareStatement(sqlQuery)) {
             ps.setInt(1, application.getId());
-            ps.setString(2, organization);
+            if (!crossOrganizationVisibility) {
+                ps.setString(2, organization);
+            }
             try (ResultSet result = ps.executeQuery()) {
                 int index = 0;
                 while (result.next()) {

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/constants/SQLConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/constants/SQLConstants.java
@@ -475,6 +475,23 @@ public class SQLConstants {
                     "   AND APP.APPLICATION_ID = ?" +
                     "   AND API.ORGANIZATION = ?";
 
+    /**
+     * DEPRECATED cross organization subscription visibility variant of
+     * {@link #GET_SUBSCRIPTION_COUNT_BY_APP_ID_SQL}. Identical apart from the omitted {@code API.ORGANIZATION = ?}
+     * filter, so the application's subscription count also covers subscriptions to APIs owned by other
+     * organizations (pre 4.1.0 behaviour). Used only when
+     * {@code APIStore.EnableDeprecatedCrossTenantSubscriptionVisibility} is enabled.
+     */
+    public static final String GET_SUBSCRIPTION_COUNT_BY_APP_ID_ALL_ORGANIZATIONS_SQL =
+            " SELECT COUNT(*) AS SUB_COUNT " +
+                    " FROM " +
+                    "   AM_SUBSCRIPTION SUBS, AM_APPLICATION APP,AM_API API " +
+                    " WHERE SUBS.SUBS_CREATE_STATE ='" + APIConstants.SubscriptionCreatedStatus.SUBSCRIBE + "'" +
+                    "   AND SUBS.APPLICATION_ID = APP.APPLICATION_ID" +
+                    "   AND API.API_ID = SUBS.API_ID" +
+                    "   AND API.SUB_VALIDATION = 'ENABLED'" +
+                    "   AND APP.APPLICATION_ID = ?";
+
     public static final String GET_SUBSCRIPTION_COUNT_CASE_INSENSITIVE_SQL =
             " SELECT COUNT(*) AS SUB_COUNT " +
             " FROM " +
@@ -551,6 +568,39 @@ public class SQLConstants {
                     "   AND API.API_ID=SUBS.API_ID " +
                     "   AND APP.APPLICATION_ID = ? " +
                     "   AND API.ORGANIZATION = ?"+
+                    "   AND SUBS.SUBS_CREATE_STATE = '" + APIConstants.SubscriptionCreatedStatus.SUBSCRIBE + "'" +
+                    " ORDER BY API_NAME ASC";
+
+    /**
+     * DEPRECATED cross organization subscription visibility variant of
+     * {@link #GET_PAGINATED_SUBSCRIBED_APIS_BY_APP_ID_SQL}. Identical apart from the omitted
+     * {@code API.ORGANIZATION = ?} filter, so an application's subscriptions to APIs owned by any organization are
+     * returned (pre 4.1.0 behaviour). Used only when
+     * {@code APIStore.EnableDeprecatedCrossTenantSubscriptionVisibility} is enabled.
+     */
+    public static final String GET_PAGINATED_SUBSCRIBED_APIS_BY_APP_ID_ALL_ORGANIZATIONS_SQL =
+            " SELECT " +
+                    "   SUBS.SUBSCRIPTION_ID, " +
+                    "   API.API_PROVIDER AS API_PROVIDER, " +
+                    "   API.API_UUID AS API_UUID, " +
+                    "   API.API_NAME AS API_NAME, " +
+                    "   API.API_TYPE AS TYPE, " +
+                    "   API.API_VERSION AS API_VERSION, " +
+                    "   SUBS.TIER_ID AS TIER_ID, " +
+                    "   SUBS.TIER_ID_PENDING AS TIER_ID_PENDING, " +
+                    "   APP.APPLICATION_ID AS APP_ID, " +
+                    "   SUBS.SUB_STATUS AS SUB_STATUS, " +
+                    "   SUBS.UUID AS SUB_UUID, " +
+                    "   SUBS.SUBS_CREATE_STATE AS SUBS_CREATE_STATE, " +
+                    "   APP.NAME AS APP_NAME " +
+                    " FROM " +
+                    "   AM_APPLICATION APP, " +
+                    "   AM_SUBSCRIPTION SUBS, " +
+                    "   AM_API API " +
+                    " WHERE " +
+                    "   APP.APPLICATION_ID=SUBS.APPLICATION_ID " +
+                    "   AND API.API_ID=SUBS.API_ID " +
+                    "   AND APP.APPLICATION_ID = ? " +
                     "   AND SUBS.SUBS_CREATE_STATE = '" + APIConstants.SubscriptionCreatedStatus.SUBSCRIBE + "'" +
                     " ORDER BY API_NAME ASC";
 

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
@@ -10692,6 +10692,36 @@ public final class APIUtil {
         return false;
     }
 
+    /**
+     * DEPRECATED. Whether an application's subscriptions to APIs owned by other organizations should be listed and
+     * counted in the Dev Portal, restoring the pre 4.1.0 behaviour where the listing was scoped to the subscriber's
+     * tenant rather than to the organization the request is made in.
+     * <p>
+     * Controlled by the {@code APIStore.EnableDeprecatedCrossTenantSubscriptionVisibility} configuration and disabled
+     * by default. Provided only for deployments migrating a Dev Portal customisation that relied on the old
+     * behaviour; it is not recommended for new deployments and organization scoped listing remains the default.
+     *
+     * @return true if deprecated cross organization subscription visibility is enabled
+     */
+    public static boolean isDeprecatedCrossTenantSubscriptionVisibilityEnabled() {
+
+        APIManagerConfigurationService apiManagerConfigurationService =
+                ServiceReferenceHolder.getInstance().getAPIManagerConfigurationService();
+        if (apiManagerConfigurationService == null) {
+            return false;
+        }
+        APIManagerConfiguration apiManagerConfiguration = apiManagerConfigurationService.getAPIManagerConfiguration();
+        if (apiManagerConfiguration == null) {
+            return false;
+        }
+        String property = apiManagerConfiguration.getFirstProperty(
+                APIConstants.API_DEVPORTAL_ENABLE_DEPRECATED_CROSS_TENANT_SUBSCRIPTION_VISIBILITY);
+        if (StringUtils.isNotEmpty(property)) {
+            return Boolean.parseBoolean(property);
+        }
+        return false;
+    }
+
     public static boolean isApplicationScopesEnabledForResidentKM() {
 
         APIManagerConfiguration apiManagerConfiguration =

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.common/src/main/resources/devportal-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.common/src/main/resources/devportal-api.yaml
@@ -6338,6 +6338,13 @@ components:
           type: string
           description: The unique identifier of the API.
           example: 2962f3bb-8330-438e-baee-0ee1d6434ba4
+        apiProviderTenantDomain:
+          type: string
+          description: |
+            Tenant domain of the API or API Product owner. DEPRECATED. Present only when cross tenant subscription
+            visibility is enabled via the APIStore.EnableDeprecatedCrossTenantSubscriptionVisibility configuration,
+            and omitted from the response otherwise.
+          example: carbon.super
         apiInfo:
           $ref: '#/components/schemas/APIInfo'
         applicationInfo:
@@ -7560,6 +7567,14 @@ components:
             - MCP_ONLY
             - API_ONLY
           default: HYBRID
+        crossTenantSubscriptionEnabled:
+          type: boolean
+          description: |
+            DEPRECATED. Indicates that an application's subscriptions to APIs owned by other tenants are listed in
+            the Dev Portal. Present and true only when the
+            APIStore.EnableDeprecatedCrossTenantSubscriptionVisibility configuration is enabled, and omitted from the
+            response otherwise.
+          example: true
     ApplicationAttribute:
       title: Application attributes
       type: object

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.common/src/main/resources/devportal-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.common/src/main/resources/devportal-api.yaml
@@ -6341,9 +6341,12 @@ components:
         apiProviderTenantDomain:
           type: string
           description: |
-            Tenant domain of the API or API Product owner. DEPRECATED. Present only when cross tenant subscription
-            visibility is enabled via the APIStore.EnableDeprecatedCrossTenantSubscriptionVisibility configuration,
-            and omitted from the response otherwise.
+            Tenant domain that owns the API or API Product this subscription points to. DEPRECATED. Present only
+            when cross tenant subscription visibility is enabled via the
+            APIStore.EnableDeprecatedCrossTenantSubscriptionVisibility configuration, and omitted from the response
+            otherwise.
+          deprecated: true
+          readOnly: true
           example: carbon.super
         apiInfo:
           $ref: '#/components/schemas/APIInfo'
@@ -7570,10 +7573,12 @@ components:
         crossTenantSubscriptionEnabled:
           type: boolean
           description: |
-            DEPRECATED. Indicates that an application's subscriptions to APIs owned by other tenants are listed in
-            the Dev Portal. Present and true only when the
-            APIStore.EnableDeprecatedCrossTenantSubscriptionVisibility configuration is enabled, and omitted from the
-            response otherwise.
+            DEPRECATED. Indicates that an application's subscriptions to APIs and API Products owned by other
+            organizations are listed and counted in the Dev Portal, instead of the listing being scoped to the
+            organization the request is made in. Present and true only when the
+            APIStore.EnableDeprecatedCrossTenantSubscriptionVisibility configuration is enabled, and omitted from
+            the response otherwise.
+          deprecated: true
           example: true
     ApplicationAttribute:
       title: Application attributes

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/v1/dto/SettingsDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/v1/dto/SettingsDTO.java
@@ -1,5 +1,6 @@
 package org.wso2.carbon.apimgt.rest.api.store.v1.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
@@ -45,6 +46,7 @@ public class SettingsDTO   {
     private Boolean aiAuthTokenProvided = false;
     private Boolean marketplaceAssistantEnabled = true;
     private Boolean orgWideAppUpdateEnabled = false;
+    private Boolean crossTenantSubscriptionEnabled = null;
 
     @XmlType(name="DevportalModeEnum")
     @XmlEnum(String.class)
@@ -480,6 +482,26 @@ return null;
     this.devportalMode = devportalMode;
   }
 
+  /**
+   * DEPRECATED. Whether an application's subscriptions to APIs owned by other organizations are listed in the
+   * Dev Portal. Set only when the behaviour is enabled; omitted from the response otherwise.
+   **/
+  public SettingsDTO crossTenantSubscriptionEnabled(Boolean crossTenantSubscriptionEnabled) {
+    this.crossTenantSubscriptionEnabled = crossTenantSubscriptionEnabled;
+    return this;
+  }
+
+
+  @ApiModelProperty(example = "false", value = "Is Cross Tenant Subscription visibility enabled ")
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  @JsonProperty("crossTenantSubscriptionEnabled")
+  public Boolean isCrossTenantSubscriptionEnabled() {
+    return crossTenantSubscriptionEnabled;
+  }
+  public void setCrossTenantSubscriptionEnabled(Boolean crossTenantSubscriptionEnabled) {
+    this.crossTenantSubscriptionEnabled = crossTenantSubscriptionEnabled;
+  }
+
 
   @Override
   public boolean equals(java.lang.Object o) {
@@ -512,12 +534,13 @@ return null;
         Objects.equals(aiAuthTokenProvided, settings.aiAuthTokenProvided) &&
         Objects.equals(marketplaceAssistantEnabled, settings.marketplaceAssistantEnabled) &&
         Objects.equals(orgWideAppUpdateEnabled, settings.orgWideAppUpdateEnabled) &&
-        Objects.equals(devportalMode, settings.devportalMode);
+        Objects.equals(devportalMode, settings.devportalMode) &&
+        Objects.equals(crossTenantSubscriptionEnabled, settings.crossTenantSubscriptionEnabled);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(grantTypes, scopes, applicationSharingEnabled, isLegacyApiKeysEnabled, mapExistingAuthApps, apiGatewayEndpoint, monetizationEnabled, recommendationEnabled, isUnlimitedTierPaid, identityProvider, isAnonymousModeEnabled, isPasswordChangeEnabled, isJWTEnabledForLoginTokens, orgAccessControlEnabled, userStorePasswordPattern, passwordPolicyPattern, passwordPolicyMinLength, passwordPolicyMaxLength, apiChatEnabled, aiAuthTokenProvided, marketplaceAssistantEnabled, orgWideAppUpdateEnabled, devportalMode);
+    return Objects.hash(grantTypes, scopes, applicationSharingEnabled, isLegacyApiKeysEnabled, mapExistingAuthApps, apiGatewayEndpoint, monetizationEnabled, recommendationEnabled, isUnlimitedTierPaid, identityProvider, isAnonymousModeEnabled, isPasswordChangeEnabled, isJWTEnabledForLoginTokens, orgAccessControlEnabled, userStorePasswordPattern, passwordPolicyPattern, passwordPolicyMinLength, passwordPolicyMaxLength, apiChatEnabled, aiAuthTokenProvided, marketplaceAssistantEnabled, orgWideAppUpdateEnabled, devportalMode, crossTenantSubscriptionEnabled);
   }
 
   @Override
@@ -548,6 +571,7 @@ return null;
     sb.append("    marketplaceAssistantEnabled: ").append(toIndentedString(marketplaceAssistantEnabled)).append("\n");
     sb.append("    orgWideAppUpdateEnabled: ").append(toIndentedString(orgWideAppUpdateEnabled)).append("\n");
     sb.append("    devportalMode: ").append(toIndentedString(devportalMode)).append("\n");
+    sb.append("    crossTenantSubscriptionEnabled: ").append(toIndentedString(crossTenantSubscriptionEnabled)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/v1/dto/SettingsDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/v1/dto/SettingsDTO.java
@@ -492,7 +492,7 @@ return null;
   }
 
 
-  @ApiModelProperty(example = "true", value = "DEPRECATED. Indicates that an application's subscriptions to APIs owned by other tenants are listed in the Dev Portal. Present and true only when the APIStore.EnableDeprecatedCrossTenantSubscriptionVisibility configuration is enabled, and omitted from the response otherwise. ")
+  @ApiModelProperty(example = "true", value = "DEPRECATED. Indicates that an application's subscriptions to APIs and API Products owned by other organizations are listed and counted in the Dev Portal, instead of the listing being scoped to the organization the request is made in. Present and true only when the APIStore.EnableDeprecatedCrossTenantSubscriptionVisibility configuration is enabled, and omitted from the response otherwise. ")
   @JsonInclude(JsonInclude.Include.NON_NULL)
   @JsonProperty("crossTenantSubscriptionEnabled")
   public Boolean isCrossTenantSubscriptionEnabled() {

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/v1/dto/SettingsDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/v1/dto/SettingsDTO.java
@@ -492,7 +492,7 @@ return null;
   }
 
 
-  @ApiModelProperty(example = "false", value = "Is Cross Tenant Subscription visibility enabled ")
+  @ApiModelProperty(example = "true", value = "DEPRECATED. Indicates that an application's subscriptions to APIs owned by other tenants are listed in the Dev Portal. Present and true only when the APIStore.EnableDeprecatedCrossTenantSubscriptionVisibility configuration is enabled, and omitted from the response otherwise. ")
   @JsonInclude(JsonInclude.Include.NON_NULL)
   @JsonProperty("crossTenantSubscriptionEnabled")
   public Boolean isCrossTenantSubscriptionEnabled() {

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/v1/dto/SubscriptionDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/v1/dto/SubscriptionDTO.java
@@ -1,5 +1,6 @@
 package org.wso2.carbon.apimgt.rest.api.store.v1.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
@@ -25,6 +26,7 @@ public class SubscriptionDTO   {
     private String subscriptionId = null;
     private String applicationId = null;
     private String apiId = null;
+    private String apiProviderTenantDomain = null;
     private APIInfoDTO apiInfo = null;
     private ApplicationInfoDTO applicationInfo = null;
     private String throttlingPolicy = null;
@@ -121,6 +123,26 @@ return null;
   }
   public void setApiId(String apiId) {
     this.apiId = apiId;
+  }
+
+  /**
+   * Tenant domain of the API or API Product owner. DEPRECATED, populated only when cross organization subscription
+   * visibility is enabled; omitted from the response otherwise.
+   **/
+  public SubscriptionDTO apiProviderTenantDomain(String apiProviderTenantDomain) {
+    this.apiProviderTenantDomain = apiProviderTenantDomain;
+    return this;
+  }
+
+
+  @ApiModelProperty(example = "carbon.super", value = "Tenant domain of the API or API Product owner. ")
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  @JsonProperty("apiProviderTenantDomain")
+  public String getApiProviderTenantDomain() {
+    return apiProviderTenantDomain;
+  }
+  public void setApiProviderTenantDomain(String apiProviderTenantDomain) {
+    this.apiProviderTenantDomain = apiProviderTenantDomain;
   }
 
   /**
@@ -242,6 +264,7 @@ return null;
     return Objects.equals(subscriptionId, subscription.subscriptionId) &&
         Objects.equals(applicationId, subscription.applicationId) &&
         Objects.equals(apiId, subscription.apiId) &&
+        Objects.equals(apiProviderTenantDomain, subscription.apiProviderTenantDomain) &&
         Objects.equals(apiInfo, subscription.apiInfo) &&
         Objects.equals(applicationInfo, subscription.applicationInfo) &&
         Objects.equals(throttlingPolicy, subscription.throttlingPolicy) &&
@@ -252,7 +275,7 @@ return null;
 
   @Override
   public int hashCode() {
-    return Objects.hash(subscriptionId, applicationId, apiId, apiInfo, applicationInfo, throttlingPolicy, requestedThrottlingPolicy, status, redirectionParams);
+    return Objects.hash(subscriptionId, applicationId, apiId, apiProviderTenantDomain, apiInfo, applicationInfo, throttlingPolicy, requestedThrottlingPolicy, status, redirectionParams);
   }
 
   @Override
@@ -263,6 +286,7 @@ return null;
     sb.append("    subscriptionId: ").append(toIndentedString(subscriptionId)).append("\n");
     sb.append("    applicationId: ").append(toIndentedString(applicationId)).append("\n");
     sb.append("    apiId: ").append(toIndentedString(apiId)).append("\n");
+    sb.append("    apiProviderTenantDomain: ").append(toIndentedString(apiProviderTenantDomain)).append("\n");
     sb.append("    apiInfo: ").append(toIndentedString(apiInfo)).append("\n");
     sb.append("    applicationInfo: ").append(toIndentedString(applicationInfo)).append("\n");
     sb.append("    throttlingPolicy: ").append(toIndentedString(throttlingPolicy)).append("\n");

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/v1/dto/SubscriptionDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/v1/dto/SubscriptionDTO.java
@@ -135,7 +135,7 @@ return null;
   }
 
 
-  @ApiModelProperty(example = "carbon.super", value = "Tenant domain of the API or API Product owner. ")
+  @ApiModelProperty(example = "carbon.super", value = "Tenant domain of the API or API Product owner. DEPRECATED. Present only when cross tenant subscription visibility is enabled via the APIStore.EnableDeprecatedCrossTenantSubscriptionVisibility configuration, and omitted from the response otherwise. ")
   @JsonInclude(JsonInclude.Include.NON_NULL)
   @JsonProperty("apiProviderTenantDomain")
   public String getApiProviderTenantDomain() {

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/v1/dto/SubscriptionDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/v1/dto/SubscriptionDTO.java
@@ -135,7 +135,7 @@ return null;
   }
 
 
-  @ApiModelProperty(example = "carbon.super", value = "Tenant domain of the API or API Product owner. DEPRECATED. Present only when cross tenant subscription visibility is enabled via the APIStore.EnableDeprecatedCrossTenantSubscriptionVisibility configuration, and omitted from the response otherwise. ")
+  @ApiModelProperty(example = "carbon.super", value = "Tenant domain that owns the API or API Product this subscription points to. DEPRECATED. Present only when cross tenant subscription visibility is enabled via the APIStore.EnableDeprecatedCrossTenantSubscriptionVisibility configuration, and omitted from the response otherwise. ")
   @JsonInclude(JsonInclude.Include.NON_NULL)
   @JsonProperty("apiProviderTenantDomain")
   public String getApiProviderTenantDomain() {

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/mappings/SettingsMappingUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/mappings/SettingsMappingUtil.java
@@ -65,6 +65,12 @@ public class SettingsMappingUtil {
         settingsDTO.setMapExistingAuthApps(APIUtil.isMapExistingAuthAppsEnabled());
         settingsDTO.setMonetizationEnabled(moneatizationEnabled);
         settingsDTO.setOrgWideAppUpdateEnabled(APIUtil.isOrgWideAppUpdateEnabled());
+        // DEPRECATED: the Dev Portal renders the provider organization column in the application subscriptions view
+        // only when this is present and true. Left unset when the behaviour is disabled so that the settings
+        // response is unchanged for every deployment that does not opt in.
+        if (APIUtil.isDeprecatedCrossTenantSubscriptionVisibilityEnabled()) {
+            settingsDTO.setCrossTenantSubscriptionEnabled(true);
+        }
         SettingsIdentityProviderDTO identityProviderDTO = new SettingsIdentityProviderDTO();
         identityProviderDTO.setExternal(APIUtil.getIdentityProviderConfig() != null);
         settingsDTO.setIdentityProvider(identityProviderDTO);

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/mappings/SubscriptionMappingUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/mappings/SubscriptionMappingUtil.java
@@ -29,6 +29,7 @@ import org.wso2.carbon.apimgt.api.model.Application;
 import org.wso2.carbon.apimgt.api.model.Identifier;
 import org.wso2.carbon.apimgt.api.model.SubscribedAPI;
 import org.wso2.carbon.apimgt.api.model.Tier;
+import org.wso2.carbon.apimgt.impl.dao.ApiMgtDAO;
 import org.wso2.carbon.apimgt.impl.utils.APIUtil;
 import org.wso2.carbon.apimgt.rest.api.common.RestApiCommonUtil;
 import org.wso2.carbon.apimgt.rest.api.common.RestApiConstants;
@@ -37,6 +38,7 @@ import org.wso2.carbon.apimgt.rest.api.store.v1.dto.ApplicationInfoDTO;
 import org.wso2.carbon.apimgt.rest.api.store.v1.dto.PaginationDTO;
 import org.wso2.carbon.apimgt.rest.api.store.v1.dto.SubscriptionDTO;
 import org.wso2.carbon.apimgt.rest.api.store.v1.dto.SubscriptionListDTO;
+import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -64,6 +66,7 @@ public class SubscriptionMappingUtil {
         APIConsumer apiConsumer = RestApiCommonUtil.getLoggedInUserConsumer();
         SubscriptionDTO subscriptionDTO = new SubscriptionDTO();
         subscriptionDTO.setSubscriptionId(subscription.getUUID());
+        setApiProviderTenantDomain(subscriptionDTO, subscription);
         APIInfoDTO apiInfo;
         Identifier apiId = subscription.getIdentifier();
         ApiTypeWrapper apiTypeWrapper;
@@ -89,6 +92,7 @@ public class SubscriptionMappingUtil {
             apiInfo = new APIInfoDTO();
             apiInfo.setName(apiId.getName());
             apiInfo.setVersion(apiId.getVersion());
+            setApiTypeForUnresolvedApi(apiInfo, apiId);
             subscriptionDTO.setApiInfo(apiInfo);
         }
         Application application = subscription.getApplication();
@@ -108,6 +112,7 @@ public class SubscriptionMappingUtil {
 
         SubscriptionDTO subscriptionDTO = new SubscriptionDTO();
         subscriptionDTO.setSubscriptionId(subscription.getUUID());
+        setApiProviderTenantDomain(subscriptionDTO, subscription);
         APIConsumer apiConsumer = RestApiCommonUtil.getLoggedInUserConsumer();
         Set<String> deniedTiers = apiConsumer.getDeniedTiers(organization);
         Map<String,Tier> tierMap = APIUtil.getTiers(organization);
@@ -134,6 +139,51 @@ public class SubscriptionMappingUtil {
         subscriptionDTO.setApplicationInfo(applicationInfoDTO);
 
         return subscriptionDTO;
+    }
+
+    /**
+     * DEPRECATED. Sets the API type on the partially populated API information of a subscription whose API could not
+     * be resolved in the requesting organization, but only when cross organization subscription visibility is
+     * enabled. The type is read from the stored API record, which is not organization scoped, so that the Dev Portal
+     * can still tell an MCP Server subscription apart from an API subscription and list it under the correct
+     * section. Failures are logged and ignored: the row is still worth listing without its type.
+     *
+     * @param apiInfo partially populated API information
+     * @param apiId   identifier of the API the subscription points to
+     */
+    private static void setApiTypeForUnresolvedApi(APIInfoDTO apiInfo, Identifier apiId) {
+
+        if (!APIUtil.isDeprecatedCrossTenantSubscriptionVisibilityEnabled() || apiId.getUUID() == null) {
+            return;
+        }
+        try {
+            apiInfo.setType(ApiMgtDAO.getInstance().getAPITypeFromUUID(apiId.getUUID()));
+        } catch (APIManagementException e) {
+            log.warn("Failed to resolve the API type of " + apiId.getUUID() + " for a cross organization "
+                    + "subscription. The subscription is listed without its type.", e);
+        }
+    }
+
+    /**
+     * DEPRECATED. Sets the tenant domain of the API or API Product owner on the subscription DTO, but only when cross
+     * organization subscription visibility is enabled. When the behaviour is disabled the field is left null and is
+     * therefore omitted from the response, keeping the subscription response identical to a deployment without this
+     * change.
+     *
+     * @param subscriptionDTO subscription DTO being populated
+     * @param subscription    the subscription the DTO is built from
+     */
+    private static void setApiProviderTenantDomain(SubscriptionDTO subscriptionDTO, SubscribedAPI subscription) {
+
+        if (!APIUtil.isDeprecatedCrossTenantSubscriptionVisibilityEnabled()) {
+            return;
+        }
+        Identifier identifier = subscription.getIdentifier();
+        if (identifier == null || identifier.getProviderName() == null) {
+            return;
+        }
+        subscriptionDTO.setApiProviderTenantDomain(
+                MultitenantUtils.getTenantDomain(APIUtil.replaceEmailDomainBack(identifier.getProviderName())));
     }
 
     /**

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/resources/devportal-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/resources/devportal-api.yaml
@@ -6338,6 +6338,13 @@ components:
           type: string
           description: The unique identifier of the API.
           example: 2962f3bb-8330-438e-baee-0ee1d6434ba4
+        apiProviderTenantDomain:
+          type: string
+          description: |
+            Tenant domain of the API or API Product owner. DEPRECATED. Present only when cross tenant subscription
+            visibility is enabled via the APIStore.EnableDeprecatedCrossTenantSubscriptionVisibility configuration,
+            and omitted from the response otherwise.
+          example: carbon.super
         apiInfo:
           $ref: '#/components/schemas/APIInfo'
         applicationInfo:
@@ -7560,6 +7567,14 @@ components:
             - MCP_ONLY
             - API_ONLY
           default: HYBRID
+        crossTenantSubscriptionEnabled:
+          type: boolean
+          description: |
+            DEPRECATED. Indicates that an application's subscriptions to APIs owned by other tenants are listed in
+            the Dev Portal. Present and true only when the
+            APIStore.EnableDeprecatedCrossTenantSubscriptionVisibility configuration is enabled, and omitted from the
+            response otherwise.
+          example: true
     ApplicationAttribute:
       title: Application attributes
       type: object

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/resources/devportal-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/resources/devportal-api.yaml
@@ -6341,9 +6341,12 @@ components:
         apiProviderTenantDomain:
           type: string
           description: |
-            Tenant domain of the API or API Product owner. DEPRECATED. Present only when cross tenant subscription
-            visibility is enabled via the APIStore.EnableDeprecatedCrossTenantSubscriptionVisibility configuration,
-            and omitted from the response otherwise.
+            Tenant domain that owns the API or API Product this subscription points to. DEPRECATED. Present only
+            when cross tenant subscription visibility is enabled via the
+            APIStore.EnableDeprecatedCrossTenantSubscriptionVisibility configuration, and omitted from the response
+            otherwise.
+          deprecated: true
+          readOnly: true
           example: carbon.super
         apiInfo:
           $ref: '#/components/schemas/APIInfo'
@@ -7570,10 +7573,12 @@ components:
         crossTenantSubscriptionEnabled:
           type: boolean
           description: |
-            DEPRECATED. Indicates that an application's subscriptions to APIs owned by other tenants are listed in
-            the Dev Portal. Present and true only when the
-            APIStore.EnableDeprecatedCrossTenantSubscriptionVisibility configuration is enabled, and omitted from the
-            response otherwise.
+            DEPRECATED. Indicates that an application's subscriptions to APIs and API Products owned by other
+            organizations are listed and counted in the Dev Portal, instead of the listing being scoped to the
+            organization the request is made in. Present and true only when the
+            APIStore.EnableDeprecatedCrossTenantSubscriptionVisibility configuration is enabled, and omitted from
+            the response otherwise.
+          deprecated: true
           example: true
     ApplicationAttribute:
       title: Application attributes

--- a/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/templates/repository/conf/api-manager.xml.j2
+++ b/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/templates/repository/conf/api-manager.xml.j2
@@ -676,6 +676,14 @@
         <!--This parameter specifies whether Anonymous Mode is enabled. By default it is true.-->
         <EnableAnonymousMode>{{apim.devportal.enable_anonymous_mode}}</EnableAnonymousMode>
         <EnableCrossTenantSubscription>{{apim.devportal.enable_cross_tenant_subscriptions}}</EnableCrossTenantSubscription>
+        {% if apim.devportal.enable_deprecated_cross_tenant_subscription_visibility is defined %}
+        <!--DEPRECATED: When enabled, an application's subscriptions to APIs owned by other organizations are listed
+            and counted in the Dev Portal Applications > Subscriptions view, restoring the pre 4.1.0 behaviour.
+            Organization scoped listing is the default and the recommended behaviour. This is provided only for
+            deployments migrating a Dev Portal customisation that relied on the old behaviour and should not be
+            enabled for new deployments.-->
+        <EnableDeprecatedCrossTenantSubscriptionVisibility>{{apim.devportal.enable_deprecated_cross_tenant_subscription_visibility}}</EnableDeprecatedCrossTenantSubscriptionVisibility>
+        {% endif %}
         <DefaultReservedUsername>{{apim.devportal.default_reserved_username}}</DefaultReservedUsername>
         {% if apim.devportal.create_default_application is defined %}
         <CreateDefaultApplication>{{apim.devportal.create_default_application}}</CreateDefaultApplication>


### PR DESCRIPTION
> **Not intended for merge as-is.** Opened on the public repository so that automated review runs
> over the change. The shipping fix is on the 4.6.0 support line
> (wso2-support/carbon-apimgt#8575); this is the same change ported onto `master`.

### Purpose

Since 4.1.0 an application's subscription listing is scoped to the organization the request is made
in, so an application does not see or count its subscriptions to APIs owned by other organizations.
This adds an opt-in configuration that restores the earlier behaviour for a deployment migrating a
Dev Portal customisation that relied on it. Organization scoped listing remains the default and the
recommended behaviour, which is why the configuration is named and documented as deprecated.

```toml
[apim.devportal]
enable_deprecated_cross_tenant_subscription_visibility = true
```

### Changes

- `APIStore.EnableDeprecatedCrossTenantSubscriptionVisibility`, disabled by default and guarded in
  the config template, so a deployment that does not set it renders an unchanged `api-manager.xml`.
- Separate `*_ALL_ORGANIZATIONS_SQL` variants without the organization filter. The existing queries
  are untouched; the DAO selects between them on the configuration.
- Two optional response fields, `SubscriptionDTO.apiProviderTenantDomain` and
  `SettingsDTO.crossTenantSubscriptionEnabled`. Both are annotated `@JsonInclude(NON_NULL)` and
  populated only when the configuration is enabled, so they are omitted rather than serialised as
  `null`. This matters because the REST API uses a plain `JacksonJsonProvider` with Jackson's
  default `ALWAYS` inclusion.

### Verification

Verified on the 4.6.0 line at its current staging update level. With the configuration off,
`settings`, `subscriptions`, `applications/{id}`, the application list and the admin application
list are byte-identical to an unpatched build on the same pack and database. With it on, cross
organization subscriptions are listed and counted, each carrying the owning organization; covered
for APIs, API Products and same organization subscriptions.

On this branch the change is ported and compiles; it has not been run against a `master` build.

Related: https://github.com/wso2-enterprise/wso2-apim-internal/issues/18922
