### PR TITLE
Test IP condition generation at unsigned address boundaries

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/test/java/org/wso2/carbon/apimgt/api/model/policy/IPConditionTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/test/java/org/wso2/carbon/apimgt/api/model/policy/IPConditionTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.apimgt.api.model.policy;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Tests the address representation and inclusive bounds in generated IP policy conditions.
+ */
+public class IPConditionTest {
+
+    @Test
+    public void testSpecificIPv6AddressUsesUnsignedValue() {
+
+        IPCondition condition = new IPCondition(PolicyConstants.IP_SPECIFIC_TYPE);
+        condition.setSpecificIP("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff");
+
+        Assert.assertEquals("(throttler:bigIntcmp(map:get(propertiesMap,'ipv6'), "
+                + "'340282366920938463463374607431768211455')==0)", condition.getCondition());
+    }
+
+    @Test
+    public void testEquivalentIPv6RepresentationsGenerateSameCondition() {
+
+        IPCondition condition = new IPCondition(PolicyConstants.IP_SPECIFIC_TYPE);
+        condition.setSpecificIP("::1");
+        String expected = "(throttler:bigIntcmp(map:get(propertiesMap,'ipv6'), '1')==0)";
+        Assert.assertEquals(expected, condition.getCondition());
+
+        condition.setSpecificIP("0000:0000:0000:0000:0000:0000:0000:0001");
+        Assert.assertEquals(expected, condition.getCondition());
+    }
+
+    @Test
+    public void testInvertedSpecificIPv6Condition() {
+
+        IPCondition condition = new IPCondition(PolicyConstants.IP_SPECIFIC_TYPE);
+        condition.setSpecificIP("::1");
+        condition.setInvertCondition(true);
+
+        Assert.assertEquals("NOT(throttler:bigIntcmp(map:get(propertiesMap,'ipv6'), '1')==0)",
+                condition.getCondition());
+    }
+
+    @Test
+    public void testIPv6RangeIncludesBothBounds() {
+
+        IPCondition condition = new IPCondition(PolicyConstants.IP_RANGE_TYPE);
+        condition.setStartingIP("::");
+        condition.setEndingIP("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff");
+
+        Assert.assertEquals("(throttler:bigIntcmp(map:get(propertiesMap,'ipv6'), '0')>=0 AND "
+                + "throttler:bigIntcmp(map:get(propertiesMap,'ipv6'), "
+                + "'340282366920938463463374607431768211455')<=0)", condition.getCondition());
+    }
+
+    @Test
+    public void testInvertedIPv6RangeNegatesWholeCondition() {
+
+        IPCondition condition = new IPCondition(PolicyConstants.IP_RANGE_TYPE);
+        condition.setStartingIP("::1");
+        condition.setEndingIP("::2");
+        condition.setInvertCondition(true);
+
+        Assert.assertEquals("NOT(throttler:bigIntcmp(map:get(propertiesMap,'ipv6'), '1')>=0 AND "
+                + "throttler:bigIntcmp(map:get(propertiesMap,'ipv6'), '2')<=0)", condition.getCondition());
+    }
+
+    @Test
+    public void testIPv4RangeRetainsUnsignedLongBounds() {
+
+        IPCondition condition = new IPCondition(PolicyConstants.IP_RANGE_TYPE);
+        condition.setStartingIP("128.0.0.0");
+        condition.setEndingIP("255.255.255.255");
+
+        Assert.assertEquals("(2147483648l<=cast(map:get(propertiesMap,'ip'),'Long') AND "
+                + "4294967295l>=cast(map:get(propertiesMap,'ip'),'Long'))", condition.getCondition());
+    }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/test/java/org/wso2/carbon/apimgt/api/model/policy/IPConditionTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/test/java/org/wso2/carbon/apimgt/api/model/policy/IPConditionTest.java
@@ -26,6 +26,9 @@ import org.junit.Test;
  */
 public class IPConditionTest {
 
+    /**
+     * An address with its high bit set must not become a negative Siddhi comparison operand.
+     */
     @Test
     public void testSpecificIPv6AddressUsesUnsignedValue() {
 
@@ -36,6 +39,9 @@ public class IPConditionTest {
                 + "'340282366920938463463374607431768211455')==0)", condition.getCondition());
     }
 
+    /**
+     * Compressed and expanded literals for the same address must produce identical policy expressions.
+     */
     @Test
     public void testEquivalentIPv6RepresentationsGenerateSameCondition() {
 
@@ -48,6 +54,9 @@ public class IPConditionTest {
         Assert.assertEquals(expected, condition.getCondition());
     }
 
+    /**
+     * Excluding a specific IPv6 address must negate its equality predicate.
+     */
     @Test
     public void testInvertedSpecificIPv6Condition() {
 
@@ -59,6 +68,9 @@ public class IPConditionTest {
                 condition.getCondition());
     }
 
+    /**
+     * Both ends of the full unsigned IPv6 range must remain inclusive.
+     */
     @Test
     public void testIPv6RangeIncludesBothBounds() {
 
@@ -71,6 +83,9 @@ public class IPConditionTest {
                 + "'340282366920938463463374607431768211455')<=0)", condition.getCondition());
     }
 
+    /**
+     * Range exclusion must negate the conjunction, not just one boundary comparison.
+     */
     @Test
     public void testInvertedIPv6RangeNegatesWholeCondition() {
 
@@ -83,6 +98,9 @@ public class IPConditionTest {
                 + "throttler:bigIntcmp(map:get(propertiesMap,'ipv6'), '2')<=0)", condition.getCondition());
     }
 
+    /**
+     * IPv4 bounds above Integer.MAX_VALUE must retain the long literals used by Siddhi.
+     */
     @Test
     public void testIPv4RangeRetainsUnsignedLongBounds() {
 


### PR DESCRIPTION
## Purpose

Add direct coverage for `IPCondition.getCondition()` in the API module. Existing gateway tests exercise condition evaluation, and DAO tests construct IP conditions, but neither directly checks the IPv6 Siddhi expression generated by this class.

The tests cover the maximum unsigned IPv6 address, equivalent compressed/expanded literals, inclusive IPv6 range bounds, inversion of specific/range conditions, and IPv4 values above the signed 32-bit range. Incorrect signed conversion or reversed/exclusive comparisons can change which addresses a throttling policy matches.

## Validation

- Compiled the unmodified upstream `IPCondition`, `Condition`, and `PolicyConstants` sources together with the new test, using JDK 22 with `--release 21` and the repository's JUnit 4.13.1 version.
- Ran `org.junit.runner.JUnitCore org.wso2.carbon.apimgt.api.model.policy.IPConditionTest`: **6 tests passed**.
- Temporary source mutation checks confirmed failures for signed `BigInteger` conversion, exclusive lower bounds, exclusive upper bounds, and removed inversion. No mutated production sources are included in this PR.
- `git diff --check` passed.

This was a focused compilation/JUnit run, not the full Maven reactor or Siddhi execution suite. No production code or dependencies change.
